### PR TITLE
fix(test_utils): recover from lock poisoning in tests

### DIFF
--- a/contracts/src/test_utils.rs
+++ b/contracts/src/test_utils.rs
@@ -14,7 +14,7 @@ pub(crate) static STORAGE_MUTEX: Mutex<()> = Mutex::new(());
 
 /// Acquires access to storage.
 pub(crate) fn acquire_storage() -> MutexGuard<'static, ()> {
-    STORAGE_MUTEX.lock().unwrap()
+    STORAGE_MUTEX.lock().unwrap_or_else(|e| e.into_inner())
 }
 
 /// Decorates a closure by running it with exclusive access to storage.


### PR DESCRIPTION
Small fix so that when a test thread panics (which happens when an `assert_eq` evaluates to `false`), we recover from it and all other tests continue running. Otherwise, the lock gets poisoned, we `unwrap` and all the other tests fail.
