### PR TITLE
chore: tweak PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,21 @@
-<!-- Thank you for your interest in contributing to OpenZeppelin! -->
+<!-- 
+Thank you for your interest in contributing to OpenZeppelin! 
 
-<!-- Consider opening an issue for discussion prior to submitting a PR. -->
-<!-- New features will be merged faster if they were first discussed and designed with the team. -->
+Consider opening an issue for discussion prior to submitting a PR. New features will be merged faster if they were first discussed and designed with the team. 
 
-Fixes #??? <!-- Fill in with issue number -->
+Describe the changes introduced in this pull request. Include any context necessary for understanding the PR's purpose.
+-->
 
-<!-- Describe the changes introduced in this pull request. -->
-<!-- Include any context necessary for understanding the PR's purpose. -->
+<!-- Fill in with issue number -->
+Resolves #???
 
 #### PR Checklist
 
-<!-- Before merging the pull request all of the following must be completed. -->
-<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
-<!-- Some of the items may not apply. -->
+<!--
+Before merging the pull request all of the following must be completed.
+Feel free to submit a PR or Draft PR even if some items are pending.
+Some of the items may not apply.
+-->
 
 - [ ] Tests
 - [ ] Documentation


### PR DESCRIPTION
Our PR template is a bit jarring due to having so many `<!-- -->` symbols, so I reduced it a bit. I think it's more readable now.

![Screenshot 2024-05-14 at 15 47 50](https://github.com/OpenZeppelin/rust-contracts-stylus/assets/22298999/7836ad7c-925e-4848-9968-11f3568485ac)
---

![Screenshot 2024-05-14 at 15 48 17](https://github.com/OpenZeppelin/rust-contracts-stylus/assets/22298999/1f92a52e-e245-4363-88c8-777afefab32a)