### PR TITLE
fix(ci): use --depth 2 in cargo hack

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ permissions:
 # main branch ensures that the PR only gets built once.
 on:
   push:
-    branches: [main]
+    branches: [ main ]
   pull_request:
 # If new code is pushed to a PR branch, then cancel in progress workflows for
 # that PR. Ensures that we don't waste CI time, and returns results quicker.
@@ -50,7 +50,7 @@ jobs:
       matrix:
         # Get early warning of new lints which are regularly introduced in beta
         # channels.
-        toolchain: [stable, beta]
+        toolchain: [ stable, beta ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -98,7 +98,7 @@ jobs:
       # Intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
       # `--feature-powerset` runs for every combination of features.
       - name: cargo hack
-        run: cargo hack --feature-powerset check --release
+        run: cargo hack --feature-powerset check --depth 2 --release
   typos:
     runs-on: ubuntu-latest
     name: ubuntu / stable / typos


### PR DESCRIPTION
Since running `cargo-hack` has an `O(2^n)` complexity where `n` is the number of features, we update it to use `--depth 2`, which makes the complexity `O(n^2)` and makes it feasible again for now.

