### PR TITLE
fix: update koba's git url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2394,7 +2394,7 @@ checksum = "57d8d8ce877200136358e0bbff3a77965875db3af755a11e1fa6b1b3e2df13ea"
 [[package]]
 name = "koba"
 version = "0.1.0"
-source = "git+https://github.com/alexfertel/koba#65e33d5ddabf6d3bd2e47028379d42cb4e7f78d1"
+source = "git+https://github.com/OpenZeppelin/koba#65e33d5ddabf6d3bd2e47028379d42cb4e7f78d1"
 dependencies = [
  "alloy 0.1.0 (git+https://github.com/alloy-rs/alloy?rev=c6c91cc)",
  "brotli2",

--- a/lib/e2e/Cargo.toml
+++ b/lib/e2e/Cargo.toml
@@ -13,7 +13,7 @@ tokio = { version = "1.12.0", features = ["full", "process"] }
 eyre = "0.6.8"
 regex = "1.10.4"
 once_cell = "1.19.0"
-koba = { git = "https://github.com/alexfertel/koba" }
+koba = { git = "https://github.com/OpenZeppelin/koba" }
 alloy = { git = "https://github.com/alloy-rs/alloy", rev = "2bff1dd", features = [
   "contract",
   "network",


### PR DESCRIPTION
Change necessary because the repository's ownership changed.