### PR TITLE
fix(ci): cache rust dependencies per pr

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,7 +29,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            target/
+            ./target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
           
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -29,9 +29,8 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-            ./target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-          
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-${{ github.event.number }}
 
       - name: cache cargo-stylus
         uses: actions/cache@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-${{ github.event.number }}
           restore-keys: |
-            {{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
 
       - name: cache cargo-stylus
         uses: actions/cache@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,6 +31,7 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+          
 
       - name: cache cargo-stylus
         uses: actions/cache@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,6 +31,8 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-${{ github.event.number }}
+          restore-keys: |
+            {{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
 
       - name: cache cargo-stylus
         uses: actions/cache@v4


### PR DESCRIPTION
E2e pipeline forcing recompilation and deps download when we open a new pr despite caching step.
Cache hit still occurs and stale cache retrieved. Since cache hit happened new (valid) cache won't be saved. So it doesn't help after consecutive pushes. 
Just cache reset forces cargo cache to be persisted and it works faster after.

This pr basically adds caching for `e2e` test per scope of pull request (pr id).
And if it wasn't found (like pr just opened) should try retrieve a cache with the same hash of `Cargo.lock` file and persist new cache per pr id.
Will see how it will work.