### PR TITLE
feat: custom derive macro for Default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,8 +2562,13 @@ dependencies = [
 name = "motsu-proc"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives 0.3.3",
+ "alloy-sol-types 0.3.1",
+ "motsu",
  "proc-macro2",
  "quote",
+ "stylus-proc",
+ "stylus-sdk",
  "syn 2.0.66",
 ]
 

--- a/contracts/src/access/control.rs
+++ b/contracts/src/access/control.rs
@@ -112,7 +112,7 @@ sol_storage! {
     }
 
     /// State of an `AccessControl` contract.
-    #[cfg_attr(test, derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
     pub struct AccessControl {
         /// Role identifier -> Role information.
         mapping(bytes32 => RoleData) _roles;

--- a/contracts/src/access/control.rs
+++ b/contracts/src/access/control.rs
@@ -112,6 +112,7 @@ sol_storage! {
     }
 
     /// State of an `AccessControl` contract.
+    #[cfg_attr(test, derive(motsu::StylusDefault))]
     pub struct AccessControl {
         /// Role identifier -> Role information.
         mapping(bytes32 => RoleData) _roles;
@@ -390,12 +391,6 @@ mod tests {
     };
 
     use super::{AccessControl, Error};
-
-    impl Default for AccessControl {
-        fn default() -> Self {
-            AccessControl { _roles: unsafe { StorageMap::new(U256::ZERO, 0) } }
-        }
-    }
 
     /// Shorthand for declaring variables converted from a hex literla to a
     /// fixed 32-byte slice;

--- a/contracts/src/access/control.rs
+++ b/contracts/src/access/control.rs
@@ -112,7 +112,7 @@ sol_storage! {
     }
 
     /// State of an `AccessControl` contract.
-    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::DefaultStorageLayout))]
     pub struct AccessControl {
         /// Role identifier -> Role information.
         mapping(bytes32 => RoleData) _roles;

--- a/contracts/src/access/ownable.rs
+++ b/contracts/src/access/ownable.rs
@@ -48,6 +48,7 @@ pub enum Error {
 
 sol_storage! {
     /// State of an `Ownable` contract.
+    #[cfg_attr(test, derive(motsu::StylusDefault))]
     pub struct Ownable {
         /// The current owner of this contract.
         address _owner;
@@ -148,13 +149,6 @@ mod tests {
     };
 
     use super::{Error, Ownable};
-
-    impl Default for Ownable {
-        fn default() -> Self {
-            let root = U256::ZERO;
-            Ownable { _owner: unsafe { StorageAddress::new(root, 0) } }
-        }
-    }
 
     const ALICE: Address = address!("A11CEacF9aa32246d767FCCD72e02d6bCbcC375d");
 

--- a/contracts/src/access/ownable.rs
+++ b/contracts/src/access/ownable.rs
@@ -48,7 +48,7 @@ pub enum Error {
 
 sol_storage! {
     /// State of an `Ownable` contract.
-    #[cfg_attr(test, derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
     pub struct Ownable {
         /// The current owner of this contract.
         address _owner;

--- a/contracts/src/access/ownable.rs
+++ b/contracts/src/access/ownable.rs
@@ -48,7 +48,7 @@ pub enum Error {
 
 sol_storage! {
     /// State of an `Ownable` contract.
-    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::DefaultStorageLayout))]
     pub struct Ownable {
         /// The current owner of this contract.
         address _owner;

--- a/contracts/src/token/erc20/extensions/capped.rs
+++ b/contracts/src/token/erc20/extensions/capped.rs
@@ -37,7 +37,7 @@ pub enum Error {
 sol_storage! {
     /// State of a Capped Contract.
     #[allow(clippy::pub_underscore_fields)]
-    #[cfg_attr(test, derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
     pub struct Capped {
         /// A cap to the supply of tokens.
         uint256 _cap;

--- a/contracts/src/token/erc20/extensions/capped.rs
+++ b/contracts/src/token/erc20/extensions/capped.rs
@@ -37,6 +37,7 @@ pub enum Error {
 sol_storage! {
     /// State of a Capped Contract.
     #[allow(clippy::pub_underscore_fields)]
+    #[cfg_attr(test, derive(motsu::StylusDefault))]
     pub struct Capped {
         /// A cap to the supply of tokens.
         uint256 _cap;
@@ -57,13 +58,6 @@ mod tests {
     use stylus_sdk::storage::{StorageType, StorageU256};
 
     use super::Capped;
-
-    impl Default for Capped {
-        fn default() -> Self {
-            let root = U256::ZERO;
-            Capped { _cap: unsafe { StorageU256::new(root, 0) } }
-        }
-    }
 
     #[motsu::test]
     fn cap_works(contract: Capped) {

--- a/contracts/src/token/erc20/extensions/capped.rs
+++ b/contracts/src/token/erc20/extensions/capped.rs
@@ -37,7 +37,7 @@ pub enum Error {
 sol_storage! {
     /// State of a Capped Contract.
     #[allow(clippy::pub_underscore_fields)]
-    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::DefaultStorageLayout))]
     pub struct Capped {
         /// A cap to the supply of tokens.
         uint256 _cap;

--- a/contracts/src/token/erc20/mod.rs
+++ b/contracts/src/token/erc20/mod.rs
@@ -93,7 +93,7 @@ pub enum Error {
 
 sol_storage! {
     /// State of an `Erc20` token.
-    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::DefaultStorageLayout))]
     pub struct Erc20 {
         /// Maps users to balances.
         mapping(address => uint256) _balances;

--- a/contracts/src/token/erc20/mod.rs
+++ b/contracts/src/token/erc20/mod.rs
@@ -93,7 +93,7 @@ pub enum Error {
 
 sol_storage! {
     /// State of an `Erc20` token.
-    #[cfg_attr(test, derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
     pub struct Erc20 {
         /// Maps users to balances.
         mapping(address => uint256) _balances;

--- a/contracts/src/token/erc20/mod.rs
+++ b/contracts/src/token/erc20/mod.rs
@@ -93,6 +93,7 @@ pub enum Error {
 
 sol_storage! {
     /// State of an `Erc20` token.
+    #[cfg_attr(test, derive(motsu::StylusDefault))]
     pub struct Erc20 {
         /// Maps users to balances.
         mapping(address => uint256) _balances;
@@ -504,21 +505,6 @@ mod tests {
     };
 
     use super::{Erc20, Error, IErc20};
-
-    impl Default for Erc20 {
-        fn default() -> Self {
-            let root = U256::ZERO;
-            Erc20 {
-                _balances: unsafe { StorageMap::new(root, 0) },
-                _allowances: unsafe {
-                    StorageMap::new(root + U256::from(32), 0)
-                },
-                _total_supply: unsafe {
-                    StorageU256::new(root + U256::from(64), 0)
-                },
-            }
-        }
-    }
 
     #[motsu::test]
     fn reads_balance(contract: Erc20) {

--- a/contracts/src/token/erc721/extensions/enumerable.rs
+++ b/contracts/src/token/erc721/extensions/enumerable.rs
@@ -45,7 +45,7 @@ pub enum Error {
 
 sol_storage! {
     /// State of an Enumerable extension.
-    #[cfg_attr(test, derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
     pub struct Erc721Enumerable {
         /// Maps owners to a mapping of indices to tokens ids.
         mapping(address => mapping(uint256 => uint256)) _owned_tokens;

--- a/contracts/src/token/erc721/extensions/enumerable.rs
+++ b/contracts/src/token/erc721/extensions/enumerable.rs
@@ -45,6 +45,7 @@ pub enum Error {
 
 sol_storage! {
     /// State of an Enumerable extension.
+    #[cfg_attr(test, derive(motsu::StylusDefault))]
     pub struct Erc721Enumerable {
         /// Maps owners to a mapping of indices to tokens ids.
         mapping(address => mapping(uint256 => uint256)) _owned_tokens;
@@ -318,25 +319,6 @@ mod tests {
     use crate::token::erc721::{tests::random_token_id, Erc721, IErc721};
 
     const BOB: Address = address!("F4EaCDAbEf3c8f1EdE91b6f2A6840bc2E4DD3526");
-
-    impl Default for Erc721Enumerable {
-        fn default() -> Self {
-            let root = U256::ZERO;
-
-            Erc721Enumerable {
-                _owned_tokens: unsafe { StorageMap::new(root, 0) },
-                _owned_tokens_index: unsafe {
-                    StorageMap::new(root + U256::from(32), 0)
-                },
-                _all_tokens: unsafe {
-                    StorageVec::new(root + U256::from(64), 0)
-                },
-                _all_tokens_index: unsafe {
-                    StorageMap::new(root + U256::from(96), 0)
-                },
-            }
-        }
-    }
 
     #[motsu::test]
     fn total_supply_no_tokens(contract: Erc721Enumerable) {

--- a/contracts/src/token/erc721/extensions/enumerable.rs
+++ b/contracts/src/token/erc721/extensions/enumerable.rs
@@ -45,7 +45,7 @@ pub enum Error {
 
 sol_storage! {
     /// State of an Enumerable extension.
-    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::DefaultStorageLayout))]
     pub struct Erc721Enumerable {
         /// Maps owners to a mapping of indices to tokens ids.
         mapping(address => mapping(uint256 => uint256)) _owned_tokens;

--- a/contracts/src/token/erc721/extensions/uri_storage.rs
+++ b/contracts/src/token/erc721/extensions/uri_storage.rs
@@ -25,7 +25,7 @@ sol! {
 
 sol_storage! {
     /// Uri Storage.
-    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::DefaultStorageLayout))]
     pub struct Erc721UriStorage {
         /// Optional mapping for token URIs.
         mapping(uint256 => string) _token_uris;

--- a/contracts/src/token/erc721/extensions/uri_storage.rs
+++ b/contracts/src/token/erc721/extensions/uri_storage.rs
@@ -25,7 +25,7 @@ sol! {
 
 sol_storage! {
     /// Uri Storage.
-    #[cfg_attr(test, derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
     pub struct Erc721UriStorage {
         /// Optional mapping for token URIs.
         mapping(uint256 => string) _token_uris;

--- a/contracts/src/token/erc721/extensions/uri_storage.rs
+++ b/contracts/src/token/erc721/extensions/uri_storage.rs
@@ -25,6 +25,7 @@ sol! {
 
 sol_storage! {
     /// Uri Storage.
+    #[cfg_attr(test, derive(motsu::StylusDefault))]
     pub struct Erc721UriStorage {
         /// Optional mapping for token URIs.
         mapping(uint256 => string) _token_uris;
@@ -68,16 +69,6 @@ mod tests {
     use stylus_sdk::{prelude::StorageType, storage::StorageMap};
 
     use super::Erc721UriStorage;
-
-    impl Default for Erc721UriStorage {
-        fn default() -> Self {
-            let root = U256::ZERO;
-
-            Erc721UriStorage {
-                _token_uris: unsafe { StorageMap::new(root, 0) },
-            }
-        }
-    }
 
     fn random_token_id() -> U256 {
         let num: u32 = rand::random();

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -169,6 +169,7 @@ sol_interface! {
 
 sol_storage! {
     /// State of an [`Erc721`] token.
+    #[cfg_attr(test, derive(motsu::StylusDefault))]
     pub struct Erc721 {
         /// Maps tokens to owners.
         mapping(uint256 => address) _owners;
@@ -1120,23 +1121,6 @@ mod tests {
     };
 
     const BOB: Address = address!("F4EaCDAbEf3c8f1EdE91b6f2A6840bc2E4DD3526");
-
-    impl Default for Erc721 {
-        fn default() -> Self {
-            let root = U256::ZERO;
-
-            Erc721 {
-                _owners: unsafe { StorageMap::new(root, 0) },
-                _balances: unsafe { StorageMap::new(root + U256::from(32), 0) },
-                _token_approvals: unsafe {
-                    StorageMap::new(root + U256::from(64), 0)
-                },
-                _operator_approvals: unsafe {
-                    StorageMap::new(root + U256::from(96), 0)
-                },
-            }
-        }
-    }
 
     pub(crate) fn random_token_id() -> U256 {
         let num: u32 = rand::random();

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -169,7 +169,7 @@ sol_interface! {
 
 sol_storage! {
     /// State of an [`Erc721`] token.
-    #[cfg_attr(test, derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
     pub struct Erc721 {
         /// Maps tokens to owners.
         mapping(uint256 => address) _owners;

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -169,7 +169,7 @@ sol_interface! {
 
 sol_storage! {
     /// State of an [`Erc721`] token.
-    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::DefaultStorageLayout))]
     pub struct Erc721 {
         /// Maps tokens to owners.
         mapping(uint256 => address) _owners;

--- a/contracts/src/utils/pausable.rs
+++ b/contracts/src/utils/pausable.rs
@@ -51,7 +51,7 @@ pub enum Error {
 
 sol_storage! {
     /// State of a Pausable Contract.
-    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::DefaultStorageLayout))]
     pub struct Pausable {
         /// Indicates whether the contract is `Paused`.
         bool _paused;

--- a/contracts/src/utils/pausable.rs
+++ b/contracts/src/utils/pausable.rs
@@ -52,6 +52,7 @@ pub enum Error {
 sol_storage! {
     /// State of a Pausable Contract.
     #[allow(missing_docs)]
+    #[cfg_attr(test, derive(motsu::StylusDefault))]
     pub struct Pausable {
         /// Indicates whether the contract is `Paused`.
         bool _paused;
@@ -146,13 +147,6 @@ mod tests {
     use stylus_sdk::storage::{StorageBool, StorageType};
 
     use crate::utils::pausable::{Error, Pausable};
-
-    impl Default for Pausable {
-        fn default() -> Self {
-            let root = U256::ZERO;
-            Pausable { _paused: unsafe { StorageBool::new(root, 0) } }
-        }
-    }
 
     #[motsu::test]
     fn paused_works(contract: Pausable) {

--- a/contracts/src/utils/pausable.rs
+++ b/contracts/src/utils/pausable.rs
@@ -51,8 +51,7 @@ pub enum Error {
 
 sol_storage! {
     /// State of a Pausable Contract.
-    #[allow(missing_docs)]
-    #[cfg_attr(test, derive(motsu::StylusDefault))]
+    #[cfg_attr(all(test, feature = "std"), derive(motsu::StylusDefault))]
     pub struct Pausable {
         /// Indicates whether the contract is `Paused`.
         bool _paused;
@@ -143,9 +142,6 @@ impl Pausable {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use alloy_primitives::U256;
-    use stylus_sdk::storage::{StorageBool, StorageType};
-
     use crate::utils::pausable::{Error, Pausable};
 
     #[motsu::test]

--- a/lib/motsu-proc/Cargo.toml
+++ b/lib/motsu-proc/Cargo.toml
@@ -12,5 +12,12 @@ proc-macro2 = "1.0.79"
 quote = "1.0.35"
 syn = { version = "2.0.58", features = ["full"] }
 
+[dev-dependencies]
+motsu = { path = "../motsu" }
+alloy-primitives.workspace = true
+alloy-sol-types.workspace = true
+stylus-sdk.workspace = true
+stylus-proc.workspace = true
+
 [lib]
 proc-macro = true

--- a/lib/motsu-proc/src/default_storage_layout.rs
+++ b/lib/motsu-proc/src/default_storage_layout.rs
@@ -1,4 +1,4 @@
-//! Defines the `#[derive(motsu::StylusDefault)]` procedural macro.
+//! Defines the `#[derive(motsu::DefaultStorageLayout)]` procedural macro.
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{Data, DeriveInput, PathArguments, Type};
@@ -7,7 +7,7 @@ pub fn impl_stylus_default(ast: &DeriveInput) -> TokenStream {
     let name = &ast.ident;
 
     let Data::Struct(ref data_struct) = ast.data else {
-        error!(ast, "StylusDefault can only be derived for structs");
+        error!(ast, "DefaultStorageLayout can only be derived for structs");
     };
 
     let fields = match &data_struct.fields {

--- a/lib/motsu-proc/src/default_storage_layout.rs
+++ b/lib/motsu-proc/src/default_storage_layout.rs
@@ -1,9 +1,9 @@
 //! Defines the `#[derive(motsu::DefaultStorageLayout)]` procedural macro.
 use proc_macro::TokenStream;
-use quote::{quote, ToTokens};
+use quote::quote;
 use syn::{Data, DeriveInput, PathArguments, Type};
 
-pub fn impl_stylus_default(ast: &DeriveInput) -> TokenStream {
+pub fn impl_default_storage_layout(ast: &DeriveInput) -> TokenStream {
     let name = &ast.ident;
 
     let Data::Struct(ref data_struct) = ast.data else {
@@ -55,12 +55,12 @@ pub fn impl_stylus_default(ast: &DeriveInput) -> TokenStream {
 
         let field_init = quote! {
             {
-                let instance = unsafe { #type_ident::new(alloy_primitives::U256::from(next_slot), offset) };
-                offset += #type_ident::SLOT_BYTES as u8;
-                if offset >= 32 {
+                if offset + #type_ident::SLOT_BYTES as u8 > 32 {
                     next_slot += 32;
                     offset = 0;
                 }
+                let instance = unsafe { #type_ident::new(alloy_primitives::U256::from(next_slot), offset) };
+                offset += #type_ident::SLOT_BYTES as u8;
                 instance
             }
         };

--- a/lib/motsu-proc/src/default_storage_layout.rs
+++ b/lib/motsu-proc/src/default_storage_layout.rs
@@ -3,6 +3,8 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Data, DeriveInput};
 
+const STORAGE_WORD_BYTES: u8 = 32;
+
 pub fn impl_default_storage_layout(ast: &DeriveInput) -> TokenStream {
     let name = &ast.ident;
 
@@ -24,8 +26,8 @@ pub fn impl_default_storage_layout(ast: &DeriveInput) -> TokenStream {
         let ty = quote! { <#field_type as stylus_sdk::storage::StorageType> };
         let field_init = quote! {
             {
-                if offset + #ty::SLOT_BYTES as u8 > 32 {
-                    next_slot += 32;
+                if offset + #ty::SLOT_BYTES as u8 > #STORAGE_WORD_BYTES {
+                    next_slot += 1;
                     offset = 0;
                 }
                 let instance = unsafe { #ty::new(alloy_primitives::U256::from(next_slot), offset) };

--- a/lib/motsu-proc/src/default_storage_layout.rs
+++ b/lib/motsu-proc/src/default_storage_layout.rs
@@ -1,7 +1,7 @@
 //! Defines the `#[derive(motsu::DefaultStorageLayout)]` procedural macro.
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput, PathArguments, Type};
+use syn::{Data, DeriveInput};
 
 pub fn impl_default_storage_layout(ast: &DeriveInput) -> TokenStream {
     let name = &ast.ident;

--- a/lib/motsu-proc/src/lib.rs
+++ b/lib/motsu-proc/src/lib.rs
@@ -1,6 +1,8 @@
 //! Procedural macro definitions used in `motsu`.
 use proc_macro::TokenStream;
+use syn::{parse_macro_input, DeriveInput};
 
+mod stylus_default;
 mod test;
 
 /// Defines a unit test that provides access to Stylus' execution context.
@@ -41,4 +43,10 @@ mod test;
 #[proc_macro_attribute]
 pub fn test(attr: TokenStream, input: TokenStream) -> TokenStream {
     test::test(attr, input)
+}
+
+#[proc_macro_derive(StylusDefault)]
+pub fn derive_stylus_default(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    stylus_default::impl_stylus_default(&input)
 }

--- a/lib/motsu-proc/src/lib.rs
+++ b/lib/motsu-proc/src/lib.rs
@@ -67,8 +67,8 @@ pub fn test(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # Usage
 ///
-/// To use this macro, simply add `#[derive(motsu::DefaultStorageLayout)]` to your
-/// `sol_storage!` struct. Make sure all the fields in your struct are
+/// To use this macro, simply add `#[derive(motsu::DefaultStorageLayout)]` to
+/// your `sol_storage!` struct. Make sure all the fields in your struct are
 /// compatible with Stylus' storage, that means they implement the `StorageType`
 /// trait.
 ///

--- a/lib/motsu-proc/src/lib.rs
+++ b/lib/motsu-proc/src/lib.rs
@@ -102,5 +102,5 @@ pub fn test(attr: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_derive(DefaultStorageLayout)]
 pub fn derive_stylus_default(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    default_storage_layout::impl_stylus_default(&input)
+    default_storage_layout::impl_default_storage_layout(&input)
 }

--- a/lib/motsu-proc/src/lib.rs
+++ b/lib/motsu-proc/src/lib.rs
@@ -45,6 +45,45 @@ pub fn test(attr: TokenStream, input: TokenStream) -> TokenStream {
     test::test(attr, input)
 }
 
+/// Automatically implements the `Default` trait for a struct that uses `sol_storage!`.
+///
+/// This macro initializes the struct fields based on how they are laid out in the EVM state trie.
+/// It is intended to be a helper for tests to avoid having to implement `Default` for each contract.
+///
+/// # Usage
+///
+/// To use this macro, simply add `#[cfg_attr(test, derive(motsu::StylusDefault))]`
+/// to your `sol_storage!` struct.  
+/// Make sure all the fields in your struct are compatible with Stylus' storage,
+/// that means they implement the StorageType trait.
+///
+/// # Examples
+///
+/// ```rust,ignore
+///
+/// sol_storage! {
+///    #[cfg_attr(test, derive(motsu::StylusDefault))]
+///    pub struct Erc20 {
+///        /// Maps users to balances.
+///        mapping(address => uint256) _balances;
+///        /// Maps users to a mapping of each spender's allowance.
+///        mapping(address => mapping(address => uint256)) _allowances;
+///        /// The total supply of the token.
+///        uint256 _total_supply;
+/// }
+/// ```
+///
+/// ## Notice
+///
+/// For now this macro only works with structs that use the
+/// `sol_storage!` macro that allows you to use the solidity syntax.
+/// If you want to write your contracts using `#[solidity_storage]`
+/// and the Rust syntax, you will have to implement `Default` youself.
+///
+/// ## See Also
+///
+/// - [Layout of State Variables in Storage](https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html)
+
 #[proc_macro_derive(StylusDefault)]
 pub fn derive_stylus_default(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/lib/motsu-proc/src/lib.rs
+++ b/lib/motsu-proc/src/lib.rs
@@ -15,7 +15,7 @@ macro_rules! error {
     }};
 }
 
-mod stylus_default;
+mod default_storage_layout;
 mod test;
 
 /// Defines a unit test that provides access to Stylus' execution context.
@@ -67,7 +67,7 @@ pub fn test(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # Usage
 ///
-/// To use this macro, simply add `#[derive(motsu::StylusDefault)]` to your
+/// To use this macro, simply add `#[derive(motsu::DefaultStorageLayout)]` to your
 /// `sol_storage!` struct. Make sure all the fields in your struct are
 /// compatible with Stylus' storage, that means they implement the `StorageType`
 /// trait.
@@ -76,7 +76,7 @@ pub fn test(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// ```rust,ignore
 /// sol_storage! {
-///    #[derive(motsu::StylusDefault)]
+///    #[derive(motsu::DefaultStorageLayout)]
 ///    pub struct Erc20 {
 ///        /// Maps users to balances.
 ///        mapping(address => uint256) _balances;
@@ -99,8 +99,8 @@ pub fn test(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// - [Layout of State Variables in Storage](https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html)
 
-#[proc_macro_derive(StylusDefault)]
+#[proc_macro_derive(DefaultStorageLayout)]
 pub fn derive_stylus_default(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    stylus_default::impl_stylus_default(&input)
+    default_storage_layout::impl_stylus_default(&input)
 }

--- a/lib/motsu-proc/src/stylus_default.rs
+++ b/lib/motsu-proc/src/stylus_default.rs
@@ -1,0 +1,64 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, Type};
+
+pub fn impl_stylus_default(ast: &DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+    let gen = match &ast.data {
+        syn::Data::Struct(data) => {
+            let fields = match &data.fields {
+                syn::Fields::Named(fields) => &fields.named,
+                syn::Fields::Unnamed(fields) => &fields.unnamed,
+                syn::Fields::Unit => return TokenStream::new(),
+            };
+
+            let mut field_initializations = Vec::new();
+
+            for field in fields {
+                let field_name = &field.ident;
+                let field_type = &field.ty;
+                let type_path = match field_type {
+                    Type::Path(type_path) => type_path,
+                    _ => panic!("Unsupported field type: {:?}. Only path types are supported.", field_type),
+                };
+                let type_ident =
+                    &type_path.path.segments.first().unwrap().ident;
+
+                let field_init = quote! {
+                    {
+                        let instance = unsafe { #type_ident::new(U256::from(next_slot), offset) };
+                        offset += #type_ident::SLOT_BYTES as u8;
+                        if offset >= 32 {
+                            next_slot += 32;
+                            offset = 0;
+                        }
+                        instance
+                    }
+                };
+
+                field_initializations.push(quote! {
+                    #field_name: #field_init
+                });
+            }
+
+            let combined_initializations = quote! {
+                #(#field_initializations),*
+            };
+
+            quote! {
+                impl Default for #name {
+                    fn default() -> Self {
+                        let mut next_slot: i32 = 0;
+                        let mut offset: u8 = 0;
+                        #name {
+                            #combined_initializations
+                        }
+                    }
+                }
+            }
+        }
+        _ => panic!("StylusDefault can only be derived for structs."),
+    };
+    gen.into()
+}

--- a/lib/motsu-proc/src/stylus_default.rs
+++ b/lib/motsu-proc/src/stylus_default.rs
@@ -18,15 +18,9 @@ pub fn impl_stylus_default(ast: &DeriveInput) -> TokenStream {
             for field in fields {
                 let field_name = &field.ident;
                 let field_type = &field.ty;
-                let type_path: &syn::TypePath = match field_type {
+                let type_path = match field_type {
                     Type::Path(type_path) => type_path,
-                    _ => {
-                        let field_type_str =
-                            field_type.to_token_stream().to_string();
-                        return TokenStream::from(quote! {
-                            compile_error!(concat!("Unsupported field type: ", #field_type_str, ". Only path types are supported."));
-                        });
-                    }
+                    _ => panic!("Unsupported field type: {:?}. Only path types are supported.", field_type),
                 };
 
                 // Types when using `sol_storage!` look like this: `stylus_sdk::storage::type<generic arguments>`
@@ -36,10 +30,7 @@ pub fn impl_stylus_default(ast: &DeriveInput) -> TokenStream {
                 let main_type = if segments.len() >= 3 {
                     &segments[2].ident
                 } else {
-                    let type_path_str = type_path.to_token_stream().to_string();
-                    return TokenStream::from(quote! {
-                        compile_error!(concat!("Unexpected type path: ", #type_path_str));
-                    });
+                    panic!("Unexpected type path: {:?}", type_path);
                 };
 
                 // If the type has generic arguments form the token stream that
@@ -93,11 +84,7 @@ pub fn impl_stylus_default(ast: &DeriveInput) -> TokenStream {
                 }
             }
         }
-        _ => {
-            return TokenStream::from(quote! {
-                compile_error!("StylusDefault can only be derived for structs.");
-            })
-        }
+        _ => panic!("StylusDefault can only be derived for structs."),
     };
     gen.into()
 }

--- a/lib/motsu-proc/src/stylus_default.rs
+++ b/lib/motsu-proc/src/stylus_default.rs
@@ -1,90 +1,95 @@
-extern crate proc_macro;
+//! Defines the `#[derive(motsu::StylusDefault)]` procedural macro.
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
-use syn::{DeriveInput, PathArguments, Type};
+use syn::{Data, DeriveInput, PathArguments, Type};
 
 pub fn impl_stylus_default(ast: &DeriveInput) -> TokenStream {
     let name = &ast.ident;
-    let gen = match &ast.data {
-        syn::Data::Struct(data) => {
-            let fields = match &data.fields {
-                syn::Fields::Named(fields) => &fields.named,
-                syn::Fields::Unnamed(fields) => &fields.unnamed,
-                syn::Fields::Unit => return TokenStream::new(),
-            };
 
-            let mut field_initializations = Vec::new();
+    let Data::Struct(ref data_struct) = ast.data else {
+        error!(ast, "StylusDefault can only be derived for structs");
+    };
 
-            for field in fields {
-                let field_name = &field.ident;
-                let field_type = &field.ty;
-                let type_path = match field_type {
-                    Type::Path(type_path) => type_path,
-                    _ => panic!("Unsupported field type: {:?}. Only path types are supported.", field_type),
-                };
+    let fields = match &data_struct.fields {
+        syn::Fields::Named(fields) => &fields.named,
+        syn::Fields::Unnamed(fields) => &fields.unnamed,
+        syn::Fields::Unit => return TokenStream::new(),
+    };
 
-                // Types when using `sol_storage!` look like this: `stylus_sdk::storage::type<generic arguments>`
-                // (e.g. uint256 is stylus_sdk::storage::StorageUint<256,4>).
-                // So we must first get the third argument, which is the main type.
-                let segments = &type_path.path.segments;
-                let main_type = if segments.len() >= 3 {
-                    &segments[2].ident
-                } else {
-                    panic!("Unexpected type path: {:?}", type_path);
-                };
+    let mut field_initializations = Vec::new();
 
-                // If the type has generic arguments form the token stream that
-                // we latter append to access `new` and `SLOT_BYTES`
-                let generic_args = match &segments[2].arguments {
-                    PathArguments::AngleBracketed(args) => {
-                        let args_tokens = args.to_token_stream();
-                        quote! { ::#args_tokens }
-                    }
-                    _ => quote! {},
-                };
+    for field in fields {
+        let field_name = &field.ident;
+        let field_ty = &field.ty;
 
-                // Reconstruct the type with the correct formatting
-                let type_ident =
-                    quote! { stylus_sdk::storage:: #main_type #generic_args };
+        let Type::Path(type_path) = field_ty else {
+            error!(
+                field_ty,
+                "unsupported field type. Only path types are supported"
+            );
+        };
 
-                let field_init = quote! {
-                    {
-                        // Usually we would include an import of `alloy_primitives::U256`, but this causes conflicts
-                        // if it is already imported in the file that is using this macro. Instead we use the full
-                        // here to avoid this issue.
-                        let instance = unsafe { #type_ident::new(alloy_primitives::U256::from(next_slot), offset) };
-                        offset += #type_ident::SLOT_BYTES as u8;
-                        if offset >= 32 {
-                            next_slot += 32;
-                            offset = 0;
-                        }
-                        instance
-                    }
-                };
+        // Types when using `sol_storage!` look like this:
+        // `stylus_sdk::storage::type<generic arguments>`
+        // (e.g. uint256 is stylus_sdk::storage::StorageUint<256,4>).
+        // So we must first get the third argument, which is the main
+        // type.
+        let segments = &type_path.path.segments;
+        let main_type = if segments.len() >= 3 {
+            &segments[2].ident
+        } else {
+            error!(type_path, "unexpected type path");
+        };
 
-                field_initializations.push(quote! {
-                    #field_name: #field_init
-                });
+        // If the type has generic arguments form the token stream that
+        // we latter append to access `new` and `SLOT_BYTES`
+        let generic_args = match &segments[2].arguments {
+            PathArguments::AngleBracketed(args) => {
+                let args_tokens = args.to_token_stream();
+                quote! { ::#args_tokens }
             }
+            _ => quote! {},
+        };
 
-            let combined_initializations = quote! {
-                #(#field_initializations),*
-            };
+        // Reconstruct the type with the correct formatting
+        let type_ident =
+            quote! { stylus_sdk::storage:: #main_type #generic_args };
 
-            quote! {
-                use stylus_sdk::prelude::StorageType;
-                impl Default for #name {
-                    fn default() -> Self {
-                        let mut next_slot: i32 = 0;
-                        let mut offset: u8 = 0;
-                        #name {
-                            #combined_initializations
-                        }
-                    }
+        let field_init = quote! {
+            {
+                // Usually we would include an import of `alloy_primitives::U256`, but this causes conflicts
+                // if it is already imported in the file that is using this macro. Instead we use the full
+                // here to avoid this issue.
+                let instance = unsafe { #type_ident::new(alloy_primitives::U256::from(next_slot), offset) };
+                offset += #type_ident::SLOT_BYTES as u8;
+                if offset >= 32 {
+                    next_slot += 32;
+                    offset = 0;
+                }
+                instance
+            }
+        };
+
+        field_initializations.push(quote! {
+            #field_name: #field_init
+        });
+    }
+
+    let combined_initializations = quote! {
+        #(#field_initializations),*
+    };
+
+    quote! {
+        use stylus_sdk::prelude::StorageType;
+        impl Default for #name {
+            fn default() -> Self {
+                let mut next_slot: i32 = 0;
+                let mut offset: u8 = 0;
+                #name {
+                    #combined_initializations
                 }
             }
         }
-        _ => panic!("StylusDefault can only be derived for structs."),
-    };
-    gen.into()
+    }
+    .into()
 }

--- a/lib/motsu-proc/src/test.rs
+++ b/lib/motsu-proc/src/test.rs
@@ -3,17 +3,6 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, FnArg};
 
-/// Shorthand to print nice errors.
-macro_rules! error {
-    ($tokens:expr, $($msg:expr),+ $(,)?) => {{
-        let error = syn::Error::new(syn::spanned::Spanned::span(&$tokens), format!($($msg),+));
-        return error.to_compile_error().into();
-    }};
-    (@ $tokens:expr, $($msg:expr),+ $(,)?) => {{
-        return Err(syn::Error::new(syn::spanned::Spanned::span(&$tokens), format!($($msg),+)))
-    }};
-}
-
 /// Defines a unit test that provides access to Stylus' execution context.
 ///
 /// For more information see [`crate::test`].

--- a/lib/motsu-proc/tests/default.rs
+++ b/lib/motsu-proc/tests/default.rs
@@ -2,7 +2,7 @@ use alloy_primitives::U256;
 use stylus_sdk::stylus_proc::sol_storage;
 
 sol_storage! {
-    #[derive(motsu_proc::StylusDefault)]
+    #[derive(motsu_proc::DefaultStorageLayout)]
     pub struct Erc20 {
         /// Maps users to balances.
         mapping(address => uint256) _balances;

--- a/lib/motsu-proc/tests/default.rs
+++ b/lib/motsu-proc/tests/default.rs
@@ -1,94 +1,130 @@
-mod erc20 {
-    use alloy_primitives::U256;
-    use stylus_sdk::stylus_proc::sol_storage;
-    sol_storage! {
-        #[derive(motsu_proc::DefaultStorageLayout)]
-        pub struct Erc20 {
-            mapping(address => uint256) _balances;
-            mapping(address => mapping(address => uint256)) _allowances;
-            uint256 _total_supply;
-        }
-    }
+use alloy_primitives::{address, Address, U128, U16, U256, U32, U64, U8};
+use stylus_sdk::stylus_proc::sol_storage;
 
-    #[motsu::test]
-    fn erc20_initiates_correctly(contract: Erc20) {
-        assert_eq!(contract._total_supply.get(), U256::from(0));
+sol_storage! {
+    #[derive(motsu_proc::DefaultStorageLayout)]
+    pub struct Erc20 {
+        mapping(address => uint256) _balances;
+        mapping(address => mapping(address => uint256)) _allowances;
+        uint256 _total_supply;
     }
 }
 
-mod uint {
-    use alloy_primitives::{U128, U16, U256, U32, U64, U8};
-    use stylus_sdk::stylus_proc::sol_storage;
+#[motsu::test]
+fn mapping_initializes_and_updates(contract: Erc20) {
+    let key = address!("a935CEC3c5Ef99D7F1016674DEFd455Ef06776C5");
+    let value = U256::from(100);
+    contract._balances.insert(key, value);
+    let balance = contract._balances.get(key);
+    assert_eq!(balance, value);
+}
 
-    sol_storage! {
-        #[derive(motsu_proc::DefaultStorageLayout)]
-        pub struct UintContract {
-            uint256 a;
-            uint128 b;
-            uint64 c;
-            uint32 d;
-            uint16 e;
-            uint8 f;
-            uint8 g;
-        }
-    }
-
-    #[motsu::test]
-    fn uint_initiates_correctly(contract: UintContract) {
-        assert_eq!(contract.a.get(), U256::from(0));
-        assert_eq!(contract.b.get(), U128::from(0));
-        assert_eq!(contract.c.get(), U64::from(0));
-        assert_eq!(contract.d.get(), U32::from(0));
-        assert_eq!(contract.e.get(), U16::from(0));
-        assert_eq!(contract.f.get(), U8::from(0));
-        assert_eq!(contract.g.get(), U8::from(0));
-    }
-
-    #[motsu::test]
-    fn uint_updates_correctly(contract: UintContract) {
-        contract.a.set(U256::from(1));
-        contract.b.set(U128::from(2));
-        contract.c.set(U64::from(3));
-        contract.d.set(U32::from(4));
-        contract.e.set(U16::from(5));
-        contract.f.set(U8::from(6));
-        contract.g.set(U8::from(7));
-
-        assert_eq!(contract.a.get(), U256::from(1));
-        assert_eq!(contract.b.get(), U128::from(2));
-        assert_eq!(contract.c.get(), U64::from(3));
-        assert_eq!(contract.d.get(), U32::from(4));
-        assert_eq!(contract.e.get(), U16::from(5));
-        assert_eq!(contract.f.get(), U8::from(6));
-        assert_eq!(contract.g.get(), U8::from(7));
+sol_storage! {
+    #[derive(motsu_proc::DefaultStorageLayout)]
+    pub struct UintSorted {
+        uint256 a;
+        uint128 b;
+        uint64 c;
+        uint32 d;
+        uint16 e;
+        uint8 f;
+        uint8 g;
     }
 }
 
-mod address {
-    use alloy_primitives::{address, Address};
-    use stylus_sdk::stylus_proc::sol_storage;
+#[motsu::test]
+fn uint_sorted_initializes(contract: UintSorted) {
+    assert_eq!(contract.a.get(), U256::ZERO);
+    assert_eq!(contract.b.get(), U128::ZERO);
+    assert_eq!(contract.c.get(), U64::ZERO);
+    assert_eq!(contract.d.get(), U32::ZERO);
+    assert_eq!(contract.e.get(), U16::ZERO);
+    assert_eq!(contract.f.get(), U8::ZERO);
+    assert_eq!(contract.g.get(), U8::ZERO);
+}
 
-    sol_storage! {
-        #[derive(motsu_proc::DefaultStorageLayout)]
-        pub struct AddressContract {
-            address lender;
-            address borrower;
-        }
-    }
+#[motsu::test]
+fn uint_sorted_updates(contract: UintSorted) {
+    contract.a.set(U256::from(1));
+    contract.b.set(U128::from(2));
+    contract.c.set(U64::from(3));
+    contract.d.set(U32::from(4));
+    contract.e.set(U16::from(5));
+    contract.f.set(U8::from(6));
+    contract.g.set(U8::from(7));
 
-    #[motsu::test]
-    fn address_initiates_correctly(contract: AddressContract) {
-        assert_eq!(contract.lender.get(), Address::ZERO);
-        assert_eq!(contract.borrower.get(), Address::ZERO);
-    }
+    assert_eq!(contract.a.get(), U256::from(1));
+    assert_eq!(contract.b.get(), U128::from(2));
+    assert_eq!(contract.c.get(), U64::from(3));
+    assert_eq!(contract.d.get(), U32::from(4));
+    assert_eq!(contract.e.get(), U16::from(5));
+    assert_eq!(contract.f.get(), U8::from(6));
+    assert_eq!(contract.g.get(), U8::from(7));
+}
 
-    #[motsu::test]
-    fn address_updates_correctly(contract: AddressContract) {
-        let lender = address!("a935CEC3c5Ef99D7F1016674DEFd455Ef06776C5");
-        let borrower = address!("DeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF");
-        contract.lender.set(lender);
-        contract.borrower.set(borrower);
-        assert_eq!(contract.lender.get(), lender);
-        assert_eq!(contract.borrower.get(), borrower);
+sol_storage! {
+    #[derive(motsu_proc::DefaultStorageLayout)]
+    pub struct UintUnsorted {
+        uint256 a;
+        uint16 b;
+        uint64 c;
+        uint8 d;
+        uint32 e;
+        uint128 f;
+        uint8 g;
     }
+}
+
+#[motsu::test]
+fn uint_unsorted_initializes(contract: UintUnsorted) {
+    assert_eq!(contract.a.get(), U256::ZERO);
+    assert_eq!(contract.b.get(), U16::ZERO);
+    assert_eq!(contract.c.get(), U64::ZERO);
+    assert_eq!(contract.d.get(), U8::ZERO);
+    assert_eq!(contract.e.get(), U32::ZERO);
+    assert_eq!(contract.f.get(), U128::ZERO);
+    assert_eq!(contract.g.get(), U8::ZERO);
+}
+
+#[motsu::test]
+fn uint_unsorted_updates(contract: UintUnsorted) {
+    contract.a.set(U256::from(1));
+    contract.b.set(U16::from(5));
+    contract.c.set(U64::from(3));
+    contract.d.set(U8::from(6));
+    contract.e.set(U32::from(4));
+    contract.f.set(U128::from(2));
+    contract.g.set(U8::from(7));
+
+    assert_eq!(contract.a.get(), U256::from(1));
+    assert_eq!(contract.b.get(), U16::from(5));
+    assert_eq!(contract.c.get(), U64::from(3));
+    assert_eq!(contract.d.get(), U8::from(6));
+    assert_eq!(contract.e.get(), U32::from(4));
+    assert_eq!(contract.f.get(), U128::from(2));
+    assert_eq!(contract.g.get(), U8::from(7));
+}
+
+sol_storage! {
+    #[derive(motsu_proc::DefaultStorageLayout)]
+    pub struct AddressContract {
+        address lender;
+        address borrower;
+    }
+}
+
+#[motsu::test]
+fn address_initializes(contract: AddressContract) {
+    assert_eq!(contract.lender.get(), Address::ZERO);
+    assert_eq!(contract.borrower.get(), Address::ZERO);
+}
+
+#[motsu::test]
+fn address_updates(contract: AddressContract) {
+    let lender = address!("a935CEC3c5Ef99D7F1016674DEFd455Ef06776C5");
+    let borrower = address!("DeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF");
+    contract.lender.set(lender);
+    contract.borrower.set(borrower);
+    assert_eq!(contract.lender.get(), lender);
+    assert_eq!(contract.borrower.get(), borrower);
 }

--- a/lib/motsu-proc/tests/default.rs
+++ b/lib/motsu-proc/tests/default.rs
@@ -1,0 +1,20 @@
+use alloy_primitives::U256;
+use stylus_sdk::stylus_proc::sol_storage;
+
+sol_storage! {
+    #[derive(motsu_proc::StylusDefault)]
+    pub struct Erc20 {
+        /// Maps users to balances.
+        mapping(address => uint256) _balances;
+        /// Maps users to a mapping of each spender's allowance.
+        mapping(address => mapping(address => uint256)) _allowances;
+        /// The total supply of the token.
+        uint256 _total_supply;
+    }
+}
+
+#[motsu::test]
+fn instantiates() {
+    let contract = Erc20::default();
+    assert_eq!(contract._total_supply.get(), U256::from(0));
+}

--- a/lib/motsu-proc/tests/default.rs
+++ b/lib/motsu-proc/tests/default.rs
@@ -1,20 +1,94 @@
-use alloy_primitives::U256;
-use stylus_sdk::stylus_proc::sol_storage;
+mod erc20 {
+    use alloy_primitives::U256;
+    use stylus_sdk::stylus_proc::sol_storage;
+    sol_storage! {
+        #[derive(motsu_proc::DefaultStorageLayout)]
+        pub struct Erc20 {
+            mapping(address => uint256) _balances;
+            mapping(address => mapping(address => uint256)) _allowances;
+            uint256 _total_supply;
+        }
+    }
 
-sol_storage! {
-    #[derive(motsu_proc::DefaultStorageLayout)]
-    pub struct Erc20 {
-        /// Maps users to balances.
-        mapping(address => uint256) _balances;
-        /// Maps users to a mapping of each spender's allowance.
-        mapping(address => mapping(address => uint256)) _allowances;
-        /// The total supply of the token.
-        uint256 _total_supply;
+    #[motsu::test]
+    fn erc20_initiates_correctly(contract: Erc20) {
+        assert_eq!(contract._total_supply.get(), U256::from(0));
     }
 }
 
-#[motsu::test]
-fn instantiates() {
-    let contract = Erc20::default();
-    assert_eq!(contract._total_supply.get(), U256::from(0));
+mod uint {
+    use alloy_primitives::{U128, U16, U256, U32, U64, U8};
+    use stylus_sdk::stylus_proc::sol_storage;
+
+    sol_storage! {
+        #[derive(motsu_proc::DefaultStorageLayout)]
+        pub struct UintContract {
+            uint256 a;
+            uint128 b;
+            uint64 c;
+            uint32 d;
+            uint16 e;
+            uint8 f;
+            uint8 g;
+        }
+    }
+
+    #[motsu::test]
+    fn uint_initiates_correctly(contract: UintContract) {
+        assert_eq!(contract.a.get(), U256::from(0));
+        assert_eq!(contract.b.get(), U128::from(0));
+        assert_eq!(contract.c.get(), U64::from(0));
+        assert_eq!(contract.d.get(), U32::from(0));
+        assert_eq!(contract.e.get(), U16::from(0));
+        assert_eq!(contract.f.get(), U8::from(0));
+        assert_eq!(contract.g.get(), U8::from(0));
+    }
+
+    #[motsu::test]
+    fn uint_updates_correctly(contract: UintContract) {
+        contract.a.set(U256::from(1));
+        contract.b.set(U128::from(2));
+        contract.c.set(U64::from(3));
+        contract.d.set(U32::from(4));
+        contract.e.set(U16::from(5));
+        contract.f.set(U8::from(6));
+        contract.g.set(U8::from(7));
+
+        assert_eq!(contract.a.get(), U256::from(1));
+        assert_eq!(contract.b.get(), U128::from(2));
+        assert_eq!(contract.c.get(), U64::from(3));
+        assert_eq!(contract.d.get(), U32::from(4));
+        assert_eq!(contract.e.get(), U16::from(5));
+        assert_eq!(contract.f.get(), U8::from(6));
+        assert_eq!(contract.g.get(), U8::from(7));
+    }
+}
+
+mod address {
+    use alloy_primitives::{address, Address};
+    use stylus_sdk::stylus_proc::sol_storage;
+
+    sol_storage! {
+        #[derive(motsu_proc::DefaultStorageLayout)]
+        pub struct AddressContract {
+            address lender;
+            address borrower;
+        }
+    }
+
+    #[motsu::test]
+    fn address_initiates_correctly(contract: AddressContract) {
+        assert_eq!(contract.lender.get(), Address::ZERO);
+        assert_eq!(contract.borrower.get(), Address::ZERO);
+    }
+
+    #[motsu::test]
+    fn address_updates_correctly(contract: AddressContract) {
+        let lender = address!("a935CEC3c5Ef99D7F1016674DEFd455Ef06776C5");
+        let borrower = address!("DeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF");
+        contract.lender.set(lender);
+        contract.borrower.set(borrower);
+        assert_eq!(contract.lender.get(), lender);
+        assert_eq!(contract.borrower.get(), borrower);
+    }
 }

--- a/lib/motsu/src/lib.rs
+++ b/lib/motsu/src/lib.rs
@@ -75,3 +75,4 @@ mod shims;
 mod storage;
 
 pub use motsu_proc::test;
+pub use motsu_proc::StylusDefault;

--- a/lib/motsu/src/lib.rs
+++ b/lib/motsu/src/lib.rs
@@ -74,5 +74,4 @@ pub mod prelude;
 mod shims;
 mod storage;
 
-pub use motsu_proc::test;
-pub use motsu_proc::StylusDefault;
+pub use motsu_proc::{test, StylusDefault};

--- a/lib/motsu/src/lib.rs
+++ b/lib/motsu/src/lib.rs
@@ -74,4 +74,4 @@ pub mod prelude;
 mod shims;
 mod storage;
 
-pub use motsu_proc::{test, StylusDefault};
+pub use motsu_proc::{test, DefaultStorageLayout};


### PR DESCRIPTION
Resolves #51 

This PR implements a custom derive macro for Default inside `motsu-proc` crate that makes it available inside all unit tests. This follows the rules of solidity storage and only works with  `sol_storage!` structs for now.
- All places where Default was implemented were updated and tests are passing

#### PR Checklist

- [x] Tests
- [x] Documentation
