### PR TITLE
fix(ci): remove useless coverage workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,12 +1,10 @@
-# This workflow runs our end-to-end tests suite and collects coverage.
+# This workflow runs our end-to-end tests suite.
 #
 # It roughly follows these steps:
 # - Install Rust
 # - Install `cargo-stylus`
 # - Install `solc`
 # - Spin up `nitro-testnode`
-#
-# And then we either run the test suite or run `cargo llvm-cov`.
 #
 # Contract deployments and account funding happen on a per-test basis.
 name: e2e
@@ -69,63 +67,3 @@ jobs:
           export NIGHTLY_TOOLCHAIN=${{steps.toolchain.outputs.name}}
           ./scripts/e2e-tests.sh
 
-  coverage:
-    name: coverage
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-
-      - name: cache cargo-stylus
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/.crates.toml
-          key: ${{ runner.os }}-cargo-bin-cargo-stylus@0.2.1
-          save-always: true
-
-      - name: set up rust
-        uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          target: wasm32-unknown-unknown
-          components: rust-src, llvm-tools-preview
-          toolchain: nightly-2024-01-01
-
-      - name: install cargo-stylus
-        run: RUSTFLAGS="-C link-args=-rdynamic" cargo install cargo-stylus@0.2.1
-
-      - name: install solc
-        run: |
-          curl -LO https://github.com/ethereum/solidity/releases/download/v0.8.21/solc-static-linux
-          sudo mv solc-static-linux /usr/bin/solc
-          sudo chmod a+x /usr/bin/solc
-
-      - name: setup nitro node
-        run: ./scripts/nitro-testnode.sh -d -i
-
-      - name: compile contracts
-        run: cargo build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
-      - name: cargo install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
-      - name: cargo generate-lockfile
-        if: hashFiles('Cargo.lock') == ''
-        run: cargo generate-lockfile
-      - name: cargo llvm-cov
-        run: RPC_URL=http://localhost:8547 cargo llvm-cov --locked --features std,e2e --test '*' --lcov --output-path lcov.info
-      - name: Record Rust version
-        run: echo "RUST=$(rustc --version)" >> "$GITHUB_ENV"
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v4
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
-          env_vars: OS,RUST


### PR DESCRIPTION
Follow-up to #114 

Removes the end-to-end tests coverage workflow until we have a clearer idea of how to make it work, which may entail delegating to the Stylus codebase.

The rationale is: `llvm-cov` instruments binaries in order to collect data used in computing coverage. The output of the instrumented binaries is written to the filesystem, and then uploaded to codecov.io.

Writing to the filesystem is not an operation allowed in the sandboxed webassembly environment where contracts run, namely, the host (Stylus VM).