### PR TITLE
ci: ignore nitro test node directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ docs/build/
 
 **/.DS_Store
 
-**/nitro-testnode
+/nitro-testnode


### PR DESCRIPTION
Since in previously local nitro-testnode clone was lifted up will add a new path to .gitignore
Follow ups #53
