### PR TITLE
build: bump sdk to v0.5.0

### DIFF
--- a/.github/scripts/check-wasm.sh
+++ b/.github/scripts/check-wasm.sh
@@ -22,9 +22,7 @@ get_example_crate_names () {
   find ./examples -type f -name "Cargo.toml" | xargs grep 'name = ' | grep -oE '".*"' | tr -d "'\""
 }
 
-NIGHTLY_TOOLCHAIN=${NIGHTLY_TOOLCHAIN:-nightly}
-
-cargo +"$NIGHTLY_TOOLCHAIN" build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+cargo build --release --target wasm32-unknown-unknown 
 
 for CRATE_NAME in $(get_example_crate_names)
 do

--- a/.github/scripts/check-wasm.sh
+++ b/.github/scripts/check-wasm.sh
@@ -12,7 +12,7 @@ check_wasm () {
 
   echo
   echo "Checking contract $CONTRACT_CRATE_NAME"
-  cargo stylus check --wasm-file-path ./target/wasm32-unknown-unknown/release/"$CONTRACT_BIN_NAME"
+  cargo stylus check --wasm-file ./target/wasm32-unknown-unknown/release/"$CONTRACT_BIN_NAME"
 }
 
 # Retrieve all alphanumeric contract's crate names in `./examples` directory.

--- a/.github/scripts/check-wasm.sh
+++ b/.github/scripts/check-wasm.sh
@@ -22,7 +22,9 @@ get_example_crate_names () {
   find ./examples -type f -name "Cargo.toml" | xargs grep 'name = ' | grep -oE '".*"' | tr -d "'\""
 }
 
-cargo build --release --target wasm32-unknown-unknown 
+NIGHTLY_TOOLCHAIN=${NIGHTLY_TOOLCHAIN:-nightly}
+
+cargo +"$NIGHTLY_TOOLCHAIN" build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 
 for CRATE_NAME in $(get_example_crate_names)
 do

--- a/.github/workflows/check-wasm.yml
+++ b/.github/workflows/check-wasm.yml
@@ -17,7 +17,7 @@ env:
   CARGO_TERM_COLOR: always
 jobs:
   check-wasm:
-    name: check WASM binary
+    name: Check WASM binary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,12 +40,11 @@ jobs:
           save-always: true
 
       - name: set up rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         id: toolchain
         with:
           target: wasm32-unknown-unknown
           components: rust-src
-          toolchain: nightly-2024-01-01
 
       - name: install cargo-stylus
         run: cargo install --force cargo-stylus cargo-stylus-check

--- a/.github/workflows/check-wasm.yml
+++ b/.github/workflows/check-wasm.yml
@@ -36,7 +36,7 @@ jobs:
           path: |
             ~/.cargo/bin/
             ~/.cargo/.crates.toml
-          key: ${{ runner.os }}-cargo-bin-cargo-stylus@0.2.1
+          key: ${{ runner.os }}-cargo-bin-cargo-stylus
           save-always: true
 
       - name: set up rust
@@ -48,7 +48,7 @@ jobs:
           toolchain: nightly-2024-01-01
 
       - name: install cargo-stylus
-        run: RUSTFLAGS="-C link-args=-rdynamic" cargo install cargo-stylus@0.2.1
+        run: cargo install --force cargo-stylus cargo-stylus-check
 
       - name: run wasm check
         run: |

--- a/.github/workflows/check-wasm.yml
+++ b/.github/workflows/check-wasm.yml
@@ -37,6 +37,4 @@ jobs:
         run: cargo install --force cargo-stylus cargo-stylus-check
 
       - name: run wasm check
-        run: |
-          export NIGHTLY_TOOLCHAIN=${{steps.toolchain.outputs.name}}
-          ./.github/scripts/check-wasm.sh
+        run: ./.github/scripts/check-wasm.sh

--- a/.github/workflows/check-wasm.yml
+++ b/.github/workflows/check-wasm.yml
@@ -23,11 +23,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: set up rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         id: toolchain
         with:
           target: wasm32-unknown-unknown
           components: rust-src
+          toolchain: nightly-2024-01-01
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -37,4 +38,6 @@ jobs:
         run: cargo install --force cargo-stylus cargo-stylus-check
 
       - name: run wasm check
-        run: ./.github/scripts/check-wasm.sh
+        run: |
+          export NIGHTLY_TOOLCHAIN=${{steps.toolchain.outputs.name}}
+          ./.github/scripts/check-wasm.sh

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -64,7 +64,5 @@ jobs:
       - name: setup nitro node
         run: ./scripts/nitro-testnode.sh -d -i
       - name: run integration tests
-        run: |
-          export NIGHTLY_TOOLCHAIN=${{steps.toolchain.outputs.name}}
-          ./scripts/e2e-tests.sh
+        run: ./scripts/e2e-tests.sh
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,11 +27,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: set up rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         id: toolchain
         with:
           target: wasm32-unknown-unknown
-          components: rust-src, llvm-tools-preview
+          components: rust-src
+          toolchain: nightly-2024-01-01
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -49,5 +50,7 @@ jobs:
       - name: setup nitro node
         run: ./scripts/nitro-testnode.sh -d -i
       - name: run integration tests
-        run: ./scripts/e2e-tests.sh
+        run: |
+          export NIGHTLY_TOOLCHAIN=${{steps.toolchain.outputs.name}}
+          ./scripts/e2e-tests.sh
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,7 +40,7 @@ jobs:
           path: |
             ~/.cargo/bin/
             ~/.cargo/.crates.toml
-          key: ${{ runner.os }}-cargo-bin-cargo-stylus@0.2.1
+          key: ${{ runner.os }}-cargo-bin-cargo-stylus
           save-always: true
 
       - name: set up rust
@@ -52,7 +52,7 @@ jobs:
           toolchain: nightly-2024-01-01
 
       - name: install cargo-stylus
-        run: RUSTFLAGS="-C link-args=-rdynamic" cargo install cargo-stylus@0.2.1
+        run: cargo install --force cargo-stylus cargo-stylus-check
 
       - name: install solc
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -46,12 +46,11 @@ jobs:
           save-always: true
 
       - name: set up rust
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         id: toolchain
         with:
           target: wasm32-unknown-unknown
           components: rust-src, llvm-tools-preview
-          toolchain: nightly-2024-01-01
 
       - name: install cargo-stylus
         run: cargo install --force cargo-stylus cargo-stylus-check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,9 +3605,9 @@ dependencies = [
 
 [[package]]
 name = "stylus-proc"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366c3323b03fc99c7d0124cec4eee10e37a226a14b08829a416feec9f2ebb641"
+checksum = "9f274700c5c74abfcc9068f96564615173d8fed72ea44afd1e4404bb04478c00"
 dependencies = [
  "alloy-primitives 0.3.3",
  "alloy-sol-types 0.3.1",
@@ -3624,9 +3624,9 @@ dependencies = [
 
 [[package]]
 name = "stylus-sdk"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74778bf11048b0155b937ee6d52440709d864aa488843238b62272e6c9bdbc1a"
+checksum = "f4424e5f067b1b0922a4294efc01acaa1e36bfc7b31e6b0aed33d7221680f974"
 dependencies = [
  "alloy-primitives 0.3.3",
  "alloy-sol-types 0.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ repository = "https://github.com/OpenZeppelin/rust-contracts-stylus"
 alloy-primitives = { version = "0.3.1", default-features = false }
 alloy-sol-types = { version = "0.3.1", default-features = false }
 # TODO: lift stylus-sdk and stylus-proc versions once nitro test node will be compatible
-stylus-sdk = { version = "0.4.3", default-features = false }
-stylus-proc = { version = "0.4.3", default-features = false }
+stylus-sdk = { version = "0.5.0", default-features = false }
+stylus-proc = { version = "0.5.0", default-features = false }
 mini-alloc = "0.4.2"
 
 alloy = { git = "https://github.com/alloy-rs/alloy", rev = "0928b92", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ repository = "https://github.com/OpenZeppelin/rust-contracts-stylus"
 [workspace.dependencies]
 alloy-primitives = { version = "0.3.1", default-features = false }
 alloy-sol-types = { version = "0.3.1", default-features = false }
-# TODO: lift stylus-sdk and stylus-proc versions once nitro test node will be compatible
 stylus-sdk = { version = "0.5.0", default-features = false }
 stylus-proc = { version = "0.5.0", default-features = false }
 mini-alloc = "0.4.2"

--- a/contracts/src/token/erc721/extensions/enumerable.rs
+++ b/contracts/src/token/erc721/extensions/enumerable.rs
@@ -7,7 +7,7 @@
 //! CAUTION: [`Erc721`] extensions that implement custom
 //! [`Erc721::balance_of`] logic, such as [`Erc721Consecutive`], interfere with
 //! enumerability and should not be used together with [`Erc721Enumerable`].
-use alloy_primitives::{private::derive_more::From, Address, U256};
+use alloy_primitives::{Address, U256};
 use alloy_sol_types::sol;
 use stylus_proc::{external, sol_storage, SolidityError};
 
@@ -30,7 +30,7 @@ sol! {
 }
 
 /// An [`Erc721Enumerable`] extension error.
-#[derive(SolidityError, Debug, From)]
+#[derive(SolidityError, Debug)]
 pub enum Error {
     /// Indicates an error when an `owner`'s token query
     /// was out of bounds for `index`.

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -1,9 +1,7 @@
 //! Implementation of the [`Erc721`] token standard.
 use alloc::vec;
 
-use alloy_primitives::{
-    fixed_bytes, private::derive_more::From, Address, FixedBytes, U128, U256,
-};
+use alloy_primitives::{fixed_bytes, Address, FixedBytes, U128, U256};
 use stylus_sdk::{
     abi::Bytes, alloy_sol_types::sol, call::Call, evm, msg, prelude::*,
 };
@@ -120,7 +118,7 @@ sol! {
 /// An [`Erc721`] error defined as described in [ERC-6093].
 ///
 /// [ERC-6093]: https://eips.ethereum.org/EIPS/eip-6093
-#[derive(SolidityError, Debug, From)]
+#[derive(SolidityError, Debug)]
 pub enum Error {
     /// Indicates that an address can't be an owner.
     /// For example, `Address::ZERO` is a forbidden owner in [`Erc721`].

--- a/lib/e2e/src/deploy.rs
+++ b/lib/e2e/src/deploy.rs
@@ -26,7 +26,7 @@ pub async fn deploy(
             wasm: wasm_path.clone(),
             sol: sol_path,
             args,
-            legacy: true,
+            legacy: false,
         },
         auth: koba::config::PrivateKey {
             private_key_path: None,

--- a/lib/motsu/src/shims.rs
+++ b/lib/motsu/src/shims.rs
@@ -118,25 +118,32 @@ pub unsafe extern "C" fn storage_load_bytes32(key: *const u8, out: *mut u8) {
     unsafe { write_bytes32(out, value) };
 }
 
-// TODO: change it when 0.5.0 release will work with a nitro test node
-/// Stores a 32-byte value to permanent storage. Stylus's storage format is
-/// identical to that of the EVM. This means that, under the hood, this hostio
-/// is storing a 32-byte value into the EVM state trie at offset `key`.
-/// Furthermore, refunds are tabulated exactly as in the EVM. The semantics,
+/// Writes a 32-byte value to the permanent storage cache. Stylus's storage
+/// format is identical to that of the EVM. This means that, under the hood,
+/// this hostio represents storing a 32-byte value into the EVM state trie at
+/// offset `key`. Refunds are tabulated exactly as in the EVM. The semantics,
 /// then, are equivalent to that of the EVM's [`SSTORE`] opcode.
 ///
-/// Note: we require the [`SSTORE`] sentry per EVM rules. The `gas_cost`
-/// returned by the EVM API may exceed this amount, but that's ok because the
-/// predominant cost is due to state bloat concerns.
+/// Note: because the value is cached, one must call `storage_flush_cache` to
+/// persist it.
 ///
 /// [`SSTORE`]: https://www.evm.codes/#55
 #[no_mangle]
-pub unsafe extern "C" fn storage_store_bytes32(
+pub unsafe extern "C" fn storage_cache_bytes32(
     key: *const u8,
     value: *const u8,
 ) {
     let (key, value) = unsafe { (read_bytes32(key), read_bytes32(value)) };
     STORAGE.lock().unwrap().insert(key, value);
+}
+
+/// Persists any dirty values in the storage cache to the EVM state trie,
+/// dropping the cache entirely if requested. Analogous to repeated invocations
+/// of [`SSTORE`].
+///
+/// [`SSTORE`]: https://www.evm.codes/#55
+pub fn storage_flush_cache(_: bool) {
+    // No-op: we don't use the cache in our unit-tests.
 }
 
 /// Dummy msg sender set for tests.

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -5,9 +5,10 @@ MYDIR=$(realpath "$(dirname "$0")")
 cd "$MYDIR"
 cd ..
 
-cargo build --release --target wasm32-unknown-unknown
+NIGHTLY_TOOLCHAIN=${NIGHTLY_TOOLCHAIN:-nightly}
+cargo +"$NIGHTLY_TOOLCHAIN" build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 
 export RPC_URL=http://localhost:8547
 # We should use stable here once nitro-testnode is updated and the contracts fit
 # the size limit. Work tracked [here](https://github.com/OpenZeppelin/rust-contracts-stylus/issues/87)
-cargo test --features std,e2e --test "*"
+cargo +"$NIGHTLY_TOOLCHAIN" test --features std,e2e --test "*"

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -5,10 +5,9 @@ MYDIR=$(realpath "$(dirname "$0")")
 cd "$MYDIR"
 cd ..
 
-NIGHTLY_TOOLCHAIN=${NIGHTLY_TOOLCHAIN:-nightly}
-cargo +"$NIGHTLY_TOOLCHAIN" build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+cargo build --release --target wasm32-unknown-unknown
 
 export RPC_URL=http://localhost:8547
 # We should use stable here once nitro-testnode is updated and the contracts fit
 # the size limit. Work tracked [here](https://github.com/OpenZeppelin/rust-contracts-stylus/issues/87)
-cargo +"$NIGHTLY_TOOLCHAIN" test --features std,e2e --test "*"
+cargo test --features std,e2e --test "*"

--- a/scripts/nitro-testnode.sh
+++ b/scripts/nitro-testnode.sh
@@ -40,12 +40,12 @@ if $HAS_INIT
 then
   cd "$MYDIR" || exit
   cd ..
-  # clone nitro test node repo
-  git clone -b stylus --recurse-submodules https://github.com/OffchainLabs/nitro-testnode.git
-  cd ./nitro-testnode || exit
-  git checkout 1886f4b89f5c20fd5b0c2cf3d08a009ee73e45ca || exit
 
-  # setup nitro test node
+  git clone --recurse-submodules https://github.com/OffchainLabs/nitro-testnode.git
+  cd ./nitro-testnode || exit
+  # `release` branch.
+  git checkout b8475cecdc118aad906ac4bf5262c0790bf847de || exit
+
   ./test-node.bash --no-run --init --no-tokenbridge || exit
 fi
 

--- a/scripts/nitro-testnode.sh
+++ b/scripts/nitro-testnode.sh
@@ -44,7 +44,7 @@ then
   git clone --recurse-submodules https://github.com/OffchainLabs/nitro-testnode.git
   cd ./nitro-testnode || exit
   # `release` branch.
-  git checkout b8475cecdc118aad906ac4bf5262c0790bf847de || exit
+  git checkout 7e490fdf8175da1edddd1855ea123499a6afec76 || exit
 
   ./test-node.bash --no-run --init --no-tokenbridge || exit
 fi


### PR DESCRIPTION
Resolves #57 

Now that `nitro-testnode` has been updated, we are safe to bump the SDK version.