### PR TITLE
ci: rust-cache gh action

### DIFF
--- a/.github/workflows/check-wasm.yml
+++ b/.github/workflows/check-wasm.yml
@@ -21,23 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-
-      - name: cache cargo-stylus
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/.crates.toml
-          key: ${{ runner.os }}-cargo-bin-cargo-stylus@0.2.1
-          save-always: true
 
       - name: set up rust
         uses: dtolnay/rust-toolchain@master
@@ -46,6 +29,10 @@ jobs:
           target: wasm32-unknown-unknown
           components: rust-src
           toolchain: nightly-2024-01-01
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
 
       - name: install cargo-stylus
         run: RUSTFLAGS="-C link-args=-rdynamic" cargo install cargo-stylus@0.2.1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,26 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}-${{ github.event.number }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-
-      - name: cache cargo-stylus
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/.crates.toml
-          key: ${{ runner.os }}-cargo-bin-cargo-stylus@0.2.1
-          save-always: true
-
+        
       - name: set up rust
         uses: dtolnay/rust-toolchain@master
         id: toolchain
@@ -52,6 +33,10 @@ jobs:
           target: wasm32-unknown-unknown
           components: rust-src, llvm-tools-preview
           toolchain: nightly-2024-01-01
+          
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
 
       - name: install cargo-stylus
         run: RUSTFLAGS="-C link-args=-rdynamic" cargo install cargo-stylus@0.2.1


### PR DESCRIPTION
Experimental github action cache pr.
Replace caching steps in gh e2e workflow with [rust-cache gh action](https://github.com/marketplace/actions/rust-cache).
This action workflow also used by [alloy-rs](https://github.com/alloy-rs/core/blob/main/.github/workflows/ci.yml).