### PR TITLE
chore: enforce uint macro for const evaluation

### DIFF
--- a/contracts/src/token/erc20/extensions/burnable.rs
+++ b/contracts/src/token/erc20/extensions/burnable.rs
@@ -71,7 +71,7 @@ impl IErc20Burnable for Erc20 {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use alloy_primitives::{address, Address, U256};
+    use alloy_primitives::{address, uint, Address, U256};
     use stylus_sdk::msg;
 
     use super::IErc20Burnable;
@@ -80,14 +80,14 @@ mod tests {
     #[motsu::test]
     fn burns(contract: Erc20) {
         let zero = U256::ZERO;
-        let one = U256::from(1);
+        let one = uint!(1_U256);
 
         assert_eq!(zero, contract.total_supply());
 
         // Mint some tokens for msg::sender().
         let sender = msg::sender();
 
-        let two = U256::from(2);
+        let two = uint!(2_U256);
         contract._update(Address::ZERO, sender, two).unwrap();
         assert_eq!(two, contract.balance_of(sender));
         assert_eq!(two, contract.total_supply());
@@ -101,7 +101,7 @@ mod tests {
     #[motsu::test]
     fn burns_errors_when_insufficient_balance(contract: Erc20) {
         let zero = U256::ZERO;
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         let sender = msg::sender();
 
         assert_eq!(zero, contract.balance_of(sender));
@@ -116,11 +116,11 @@ mod tests {
         let sender = msg::sender();
 
         // Alice approves `msg::sender`.
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         contract._allowances.setter(alice).setter(sender).set(one);
 
         // Mint some tokens for Alice.
-        let two = U256::from(2);
+        let two = uint!(2_U256);
         contract._update(Address::ZERO, alice, two).unwrap();
         assert_eq!(two, contract.balance_of(alice));
         assert_eq!(two, contract.total_supply());
@@ -138,12 +138,12 @@ mod tests {
 
         // Alice approves `msg::sender`.
         let zero = U256::ZERO;
-        let one = U256::from(1);
+        let one = uint!(1_U256);
 
         contract._allowances.setter(alice).setter(msg::sender()).set(one);
         assert_eq!(zero, contract.balance_of(alice));
 
-        let one = U256::from(1);
+        let one = uint!(1_U256);
 
         let result = contract.burn_from(alice, one);
         assert!(matches!(result, Err(Error::InsufficientBalance(_))));
@@ -151,7 +151,7 @@ mod tests {
 
     #[motsu::test]
     fn burns_from_errors_when_invalid_sender(contract: Erc20) {
-        let one = U256::from(1);
+        let one = uint!(1_U256);
 
         contract
             ._allowances
@@ -168,7 +168,7 @@ mod tests {
         let alice = address!("A11CEacF9aa32246d767FCCD72e02d6bCbcC375d");
 
         // Mint some tokens for Alice.
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         contract._update(Address::ZERO, alice, one).unwrap();
         assert_eq!(one, contract.balance_of(alice));
 

--- a/contracts/src/token/erc20/extensions/capped.rs
+++ b/contracts/src/token/erc20/extensions/capped.rs
@@ -54,7 +54,7 @@ impl Capped {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use alloy_primitives::{U256, uint};
+    use alloy_primitives::{uint, U256};
     use stylus_sdk::storage::{StorageType, StorageU256};
 
     use super::Capped;

--- a/contracts/src/token/erc20/extensions/capped.rs
+++ b/contracts/src/token/erc20/extensions/capped.rs
@@ -54,18 +54,18 @@ impl Capped {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use alloy_primitives::U256;
+    use alloy_primitives::{U256, uint};
     use stylus_sdk::storage::{StorageType, StorageU256};
 
     use super::Capped;
 
     #[motsu::test]
     fn cap_works(contract: Capped) {
-        let value = U256::from(2024);
+        let value = uint!(2024_U256);
         contract._cap.set(value);
         assert_eq!(contract.cap(), value);
 
-        let value = U256::from(1);
+        let value = uint!(1_U256);
         contract._cap.set(value);
         assert_eq!(contract.cap(), value);
     }

--- a/contracts/src/token/erc20/mod.rs
+++ b/contracts/src/token/erc20/mod.rs
@@ -498,11 +498,8 @@ impl Erc20 {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use alloy_primitives::{address, Address, U256};
-    use stylus_sdk::{
-        msg,
-        storage::{StorageMap, StorageType, StorageU256},
-    };
+    use alloy_primitives::{address, uint, Address, U256};
+    use stylus_sdk::{msg, storage::StorageType};
 
     use super::{Erc20, Error, IErc20};
 
@@ -512,7 +509,7 @@ mod tests {
         assert_eq!(U256::ZERO, balance);
 
         let owner = msg::sender();
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         contract._balances.setter(owner).set(one);
         let balance = contract.balance_of(owner);
         assert_eq!(one, balance);
@@ -521,7 +518,7 @@ mod tests {
     #[motsu::test]
     fn update_mint(contract: Erc20) {
         let alice = address!("A11CEacF9aa32246d767FCCD72e02d6bCbcC375d");
-        let one = U256::from(1);
+        let one = uint!(1_U256);
 
         // Store initial balance & supply.
         let initial_balance = contract.balance_of(alice);
@@ -540,7 +537,7 @@ mod tests {
     #[should_panic = "should not exceed `U256::MAX` for `_total_supply`"]
     fn update_mint_errors_arithmetic_overflow(contract: Erc20) {
         let alice = address!("A11CEacF9aa32246d767FCCD72e02d6bCbcC375d");
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         assert_eq!(U256::ZERO, contract.balance_of(alice));
         assert_eq!(U256::ZERO, contract.total_supply());
 
@@ -557,7 +554,7 @@ mod tests {
     #[motsu::test]
     fn mint_works(contract: Erc20) {
         let alice = address!("A11CEacF9aa32246d767FCCD72e02d6bCbcC375d");
-        let one = U256::from(1);
+        let one = uint!(1_U256);
 
         // Store initial balance & supply.
         let initial_balance = contract.balance_of(alice);
@@ -575,7 +572,7 @@ mod tests {
     #[motsu::test]
     fn mint_errors_invalid_receiver(contract: Erc20) {
         let receiver = Address::ZERO;
-        let one = U256::from(1);
+        let one = uint!(1_U256);
 
         // Store initial balance & supply.
         let initial_balance = contract.balance_of(receiver);
@@ -594,7 +591,7 @@ mod tests {
     #[should_panic = "should not exceed `U256::MAX` for `_total_supply`"]
     fn mint_errors_arithmetic_overflow(contract: Erc20) {
         let alice = address!("A11CEacF9aa32246d767FCCD72e02d6bCbcC375d");
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         assert_eq!(U256::ZERO, contract.balance_of(alice));
         assert_eq!(U256::ZERO, contract.total_supply());
 
@@ -610,8 +607,8 @@ mod tests {
     #[motsu::test]
     fn update_burn(contract: Erc20) {
         let alice = address!("A11CEacF9aa32246d767FCCD72e02d6bCbcC375d");
-        let one = U256::from(1);
-        let two = U256::from(2);
+        let one = uint!(1_U256);
+        let two = uint!(2_U256);
 
         // Initialize state for the test case:
         // Alice's balance as `two`.
@@ -635,8 +632,8 @@ mod tests {
     #[motsu::test]
     fn update_burn_errors_insufficient_balance(contract: Erc20) {
         let alice = address!("A11CEacF9aa32246d767FCCD72e02d6bCbcC375d");
-        let one = U256::from(1);
-        let two = U256::from(2);
+        let one = uint!(1_U256);
+        let two = uint!(2_U256);
 
         // Initialize state for the test case:
         // Alice's balance as `one`.
@@ -661,7 +658,7 @@ mod tests {
     fn update_transfer(contract: Erc20) {
         let alice = address!("A11CEacF9aa32246d767FCCD72e02d6bCbcC375d");
         let bob = address!("B0B0cB49ec2e96DF5F5fFB081acaE66A2cBBc2e2");
-        let one = U256::from(1);
+        let one = uint!(1_U256);
 
         // Initialize state for the test case:
         //  Alice's & Bob's balance as `one`.
@@ -689,7 +686,7 @@ mod tests {
     fn update_transfer_errors_insufficient_balance(contract: Erc20) {
         let alice = address!("A11CEacF9aa32246d767FCCD72e02d6bCbcC375d");
         let bob = address!("B0B0cB49ec2e96DF5F5fFB081acaE66A2cBBc2e2");
-        let one = U256::from(1);
+        let one = uint!(1_U256);
 
         // Initialize state for the test case:
         // Alice's & Bob's balance as `one`.
@@ -719,11 +716,11 @@ mod tests {
         let bob = address!("B0B0cB49ec2e96DF5F5fFB081acaE66A2cBBc2e2");
 
         // Alice approves `msg::sender`.
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         contract._allowances.setter(alice).setter(msg::sender()).set(one);
 
         // Mint some tokens for Alice.
-        let two = U256::from(2);
+        let two = uint!(2_U256);
         contract._update(Address::ZERO, alice, two).unwrap();
         assert_eq!(two, contract.balance_of(alice));
 
@@ -740,11 +737,11 @@ mod tests {
         let sender = msg::sender();
 
         // Alice approves `msg::sender`.
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         contract._allowances.setter(alice).setter(sender).set(one);
 
         // Mint some tokens for Alice.
-        let two = U256::from(2);
+        let two = uint!(2_U256);
         contract._update(Address::ZERO, alice, two).unwrap();
         assert_eq!(two, contract.balance_of(alice));
 
@@ -761,11 +758,11 @@ mod tests {
         let bob = address!("B0B0cB49ec2e96DF5F5fFB081acaE66A2cBBc2e2");
 
         // Alice approves `msg::sender`.
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         contract._allowances.setter(alice).setter(msg::sender()).set(one);
         assert_eq!(U256::ZERO, contract.balance_of(alice));
 
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         let result = contract.transfer_from(alice, bob, one);
         assert!(matches!(result, Err(Error::InsufficientBalance(_))));
     }
@@ -773,7 +770,7 @@ mod tests {
     #[motsu::test]
     fn transfer_from_errors_when_invalid_sender(contract: Erc20) {
         let alice = address!("A11CEacF9aa32246d767FCCD72e02d6bCbcC375d");
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         contract
             ._allowances
             .setter(Address::ZERO)
@@ -786,7 +783,7 @@ mod tests {
     #[motsu::test]
     fn transfer_from_errors_when_invalid_receiver(contract: Erc20) {
         let alice = address!("A11CEacF9aa32246d767FCCD72e02d6bCbcC375d");
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         contract._allowances.setter(alice).setter(msg::sender()).set(one);
         let result = contract.transfer_from(alice, Address::ZERO, one);
         assert!(matches!(result, Err(Error::InvalidReceiver(_))));
@@ -798,7 +795,7 @@ mod tests {
         let bob = address!("B0B0cB49ec2e96DF5F5fFB081acaE66A2cBBc2e2");
 
         // Mint some tokens for Alice.
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         contract._update(Address::ZERO, alice, one).unwrap();
         assert_eq!(one, contract.balance_of(alice));
 
@@ -814,7 +811,7 @@ mod tests {
         let allowance = contract.allowance(owner, alice);
         assert_eq!(U256::ZERO, allowance);
 
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         contract._allowances.setter(owner).setter(alice).set(one);
         let allowance = contract.allowance(owner, alice);
         assert_eq!(one, allowance);
@@ -825,7 +822,7 @@ mod tests {
         let alice = address!("A11CEacF9aa32246d767FCCD72e02d6bCbcC375d");
 
         // `msg::sender` approves Alice.
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         contract.approve(alice, one).unwrap();
         assert_eq!(one, contract._allowances.get(msg::sender()).get(alice));
     }
@@ -833,7 +830,7 @@ mod tests {
     #[motsu::test]
     fn approve_errors_when_invalid_spender(contract: Erc20) {
         // `msg::sender` approves `Address::ZERO`.
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         let result = contract.approve(Address::ZERO, one);
         assert!(matches!(result, Err(Error::InvalidSpender(_))));
     }

--- a/contracts/src/token/erc721/extensions/burnable.rs
+++ b/contracts/src/token/erc721/extensions/burnable.rs
@@ -47,7 +47,7 @@ impl IErc721Burnable for Erc721 {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use alloy_primitives::{address, Address, U256};
+    use alloy_primitives::{address, uint, Address, U256};
     use stylus_sdk::msg;
 
     use super::IErc721Burnable;
@@ -60,7 +60,7 @@ mod tests {
     #[motsu::test]
     fn burns(contract: Erc721) {
         let alice = msg::sender();
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         let token_id = random_token_id();
 
         contract._mint(alice, token_id).expect("should mint a token for Alice");
@@ -118,7 +118,7 @@ mod tests {
 
         contract._mint(alice, token_id).expect("should mint a token for Alice");
 
-        let err = contract.burn(token_id + U256::from(1)).unwrap_err();
+        let err = contract.burn(token_id + uint!(1_U256)).unwrap_err();
 
         assert!(matches!(err, Error::NonexistentToken(_)));
     }

--- a/contracts/src/token/erc721/extensions/enumerable.rs
+++ b/contracts/src/token/erc721/extensions/enumerable.rs
@@ -7,7 +7,7 @@
 //! CAUTION: [`Erc721`] extensions that implement custom
 //! [`Erc721::balance_of`] logic, such as [`Erc721Consecutive`], interfere with
 //! enumerability and should not be used together with [`Erc721Enumerable`].
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{uint, Address, U256};
 use alloy_sol_types::sol;
 use stylus_proc::{external, sol_storage, SolidityError};
 
@@ -157,7 +157,7 @@ impl Erc721Enumerable {
         token_id: U256,
         erc721: &impl IErc721,
     ) -> Result<(), crate::token::erc721::Error> {
-        let length = erc721.balance_of(to)? - U256::from(1);
+        let length = erc721.balance_of(to)? - uint!(1_U256);
         self._owned_tokens.setter(to).setter(length).set(token_id);
         self._owned_tokens_index.setter(token_id).set(length);
 
@@ -308,7 +308,7 @@ impl Erc721Enumerable {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use alloy_primitives::{address, Address, U256};
+    use alloy_primitives::{address, uint, Address, U256};
     use stylus_sdk::{
         msg,
         prelude::StorageType,
@@ -331,7 +331,7 @@ mod tests {
     ) {
         assert_eq!(U256::ZERO, contract.total_supply());
 
-        let token_idx = U256::from(2024);
+        let token_idx = uint!(2024_U256);
 
         let err = contract.token_by_index(token_idx).unwrap_err();
         assert!(matches!(err, Error::OutOfBoundsIndex(_)));
@@ -473,7 +473,7 @@ mod tests {
         assert!(res.is_ok());
 
         let err =
-            contract.token_of_owner_by_index(alice, U256::from(1)).unwrap_err();
+            contract.token_of_owner_by_index(alice, uint!(1_U256)).unwrap_err();
         assert!(matches!(err, Error::OutOfBoundsIndex(_)));
     }
 

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -1,7 +1,7 @@
 //! Implementation of the [`Erc721`] token standard.
 use alloc::vec;
 
-use alloy_primitives::{fixed_bytes, Address, FixedBytes, U128, U256};
+use alloy_primitives::{fixed_bytes, uint, Address, FixedBytes, U128, U256};
 use stylus_sdk::{
     abi::Bytes, alloy_sol_types::sol, call::Call, evm, msg, prelude::*,
 };
@@ -695,11 +695,11 @@ impl Erc721 {
             // Clear approval. No need to re-authorize or emit the `Approval`
             // event.
             self._approve(Address::ZERO, token_id, Address::ZERO, false)?;
-            self._balances.setter(from).sub_assign_unchecked(U256::from(1));
+            self._balances.setter(from).sub_assign_unchecked(uint!(1_U256));
         }
 
         if !to.is_zero() {
-            self._balances.setter(to).add_assign_unchecked(U256::from(1));
+            self._balances.setter(to).add_assign_unchecked(uint!(1_U256));
         }
 
         self._owners.setter(token_id).set(to);
@@ -1110,7 +1110,7 @@ impl Erc721 {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use alloy_primitives::{address, Address, U256};
+    use alloy_primitives::{address, uint, Address, U256};
     use stylus_sdk::{msg, prelude::StorageType, storage::StorageMap};
 
     use super::{
@@ -1138,7 +1138,7 @@ mod tests {
         let balance = contract
             .balance_of(alice)
             .expect("should return the balance of Alice");
-        let one = U256::from(1);
+        let one = uint!(1_U256);
         assert!(balance >= one);
     }
 

--- a/contracts/src/utils/structs/bitmap.rs
+++ b/contracts/src/utils/structs/bitmap.rs
@@ -13,7 +13,7 @@
 //! - Accessing the same warm slot for every 256 _sequential_ indices
 //!
 //! [merkle-distributor]: https://github.com/Uniswap/merkle-distributor/blob/master/contracts/MerkleDistributor.sol
-use alloy_primitives::{U256, uint};
+use alloy_primitives::{uint, U256};
 use stylus_proc::sol_storage;
 
 const ONE: U256 = uint!(0x1_U256);

--- a/contracts/src/utils/structs/bitmap.rs
+++ b/contracts/src/utils/structs/bitmap.rs
@@ -13,11 +13,11 @@
 //! - Accessing the same warm slot for every 256 _sequential_ indices
 //!
 //! [merkle-distributor]: https://github.com/Uniswap/merkle-distributor/blob/master/contracts/MerkleDistributor.sol
-use alloy_primitives::U256;
+use alloy_primitives::{U256, uint};
 use stylus_proc::sol_storage;
 
-const ONE: U256 = U256::from_limbs([1, 0, 0, 0]);
-const HEX_FF: U256 = U256::from_limbs([255, 0, 0, 0]);
+const ONE: U256 = uint!(0x1_U256);
+const HEX_FF: U256 = uint!(0xff_U256);
 
 sol_storage! {
     /// State of bit map.

--- a/examples/erc20/tests/erc20.rs
+++ b/examples/erc20/tests/erc20.rs
@@ -5,6 +5,7 @@ use alloy::{
     sol,
     sol_types::{SolConstructor, SolError},
 };
+use alloy_primitives::uint;
 use e2e::{receipt, send, watch, EventExt, Panic, PanicCode, Revert, User};
 use eyre::Result;
 
@@ -16,7 +17,7 @@ sol!("src/constructor.sol");
 
 const TOKEN_NAME: &str = "Test Token";
 const TOKEN_SYMBOL: &str = "TTK";
-const CAP: usize = 1_000_000;
+const CAP: U256 = uint!(1_000_000_U256);
 
 async fn deploy(
     rpc_url: &str,
@@ -26,7 +27,7 @@ async fn deploy(
     let args = Erc20Example::constructorCall {
         name_: TOKEN_NAME.to_owned(),
         symbol_: TOKEN_SYMBOL.to_owned(),
-        cap_: cap.unwrap_or(U256::from(CAP)),
+        cap_: cap.unwrap_or(CAP),
     };
     let args = alloy::hex::encode(args.abi_encode());
     e2e::deploy(rpc_url, private_key, Some(args)).await
@@ -50,7 +51,7 @@ async fn constructs(alice: User) -> Result<()> {
 
     assert_eq!(name, TOKEN_NAME.to_owned());
     assert_eq!(symbol, TOKEN_SYMBOL.to_owned());
-    assert_eq!(cap, U256::from(CAP));
+    assert_eq!(cap, CAP);
     assert_eq!(decimals, 10);
     assert_eq!(total_supply, U256::ZERO);
     Ok(())
@@ -70,7 +71,7 @@ async fn mints(alice: User) -> Result<()> {
     assert_eq!(U256::ZERO, initial_balance);
     assert_eq!(U256::ZERO, initial_supply);
 
-    let one = U256::from(1);
+    let one = uint!(1_U256);
     let receipt = receipt!(contract.mint(alice_addr, one))?;
     receipt.emits(Erc20::Transfer {
         from: Address::ZERO,
@@ -99,7 +100,7 @@ async fn mints_rejects_invalid_receiver(alice: User) -> Result<()> {
     let Erc20::totalSupplyReturn { totalSupply: initial_supply } =
         contract.totalSupply().call().await?;
 
-    let value = U256::from(10);
+    let value = uint!(10_U256);
     let err = send!(contract.mint(invalid_receiver, value))
         .expect_err("should not mint tokens for Address::ZERO");
     assert!(err.reverted_with(Erc20::ERC20InvalidReceiver {
@@ -124,7 +125,7 @@ async fn mints_rejects_overflow(alice: User) -> Result<()> {
     let contract = Erc20::new(contract_addr, &alice.signer);
     let alice_addr = alice.address();
 
-    let one = U256::from(1);
+    let one = uint!(1_U256);
 
     let _ = watch!(contract.mint(alice_addr, max_cap))?;
 
@@ -158,8 +159,8 @@ async fn transfers(alice: User, bob: User) -> Result<()> {
     let alice_addr = alice.address();
     let bob_addr = bob.address();
 
-    let balance = U256::from(10);
-    let value = U256::from(1);
+    let balance = uint!(10_U256);
+    let value = uint!(1_U256);
 
     let _ = watch!(contract_alice.mint(alice.address(), balance))?;
 
@@ -198,8 +199,8 @@ async fn transfer_rejects_insufficient_balance(
     let alice_addr = alice.address();
     let bob_addr = bob.address();
 
-    let balance = U256::from(10);
-    let value = U256::from(11);
+    let balance = uint!(10_U256);
+    let value = uint!(11_U256);
 
     let _ = watch!(contract_alice.mint(alice.address(), balance))?;
 
@@ -239,8 +240,8 @@ async fn transfer_rejects_invalid_receiver(alice: User) -> Result<()> {
     let alice_addr = alice.address();
     let invalid_receiver = Address::ZERO;
 
-    let balance = U256::from(10);
-    let value = U256::from(1);
+    let balance = uint!(10_U256);
+    let value = uint!(1_U256);
 
     let _ = watch!(contract_alice.mint(alice.address(), balance))?;
 
@@ -278,8 +279,8 @@ async fn approves(alice: User, bob: User) -> Result<()> {
     let alice_addr = alice.address();
     let bob_addr = bob.address();
 
-    let one = U256::from(1);
-    let ten = U256::from(10);
+    let one = uint!(1_U256);
+    let ten = uint!(10_U256);
 
     let Erc20::allowanceReturn { allowance: initial_alice_bob_allowance } =
         contract.allowance(alice_addr, bob_addr).call().await?;
@@ -345,7 +346,7 @@ async fn approve_rejects_invalid_spender(alice: User) -> Result<()> {
     let alice_addr = alice.address();
     let invalid_spender = Address::ZERO;
 
-    let ten = U256::from(10);
+    let ten = uint!(10_U256);
 
     let Erc20::allowanceReturn { allowance: initial_alice_spender_allowance } =
         contract.allowance(alice_addr, invalid_spender).call().await?;
@@ -397,8 +398,8 @@ async fn transfers_from(alice: User, bob: User) -> Result<()> {
     let alice_addr = alice.address();
     let bob_addr = bob.address();
 
-    let balance = U256::from(10);
-    let value = U256::from(1);
+    let balance = uint!(10_U256);
+    let value = uint!(1_U256);
 
     let _ = watch!(contract_alice.mint(alice.address(), balance))?;
 
@@ -448,8 +449,8 @@ async fn transfer_from_reverts_insufficient_balance(
     let alice_addr = alice.address();
     let bob_addr = bob.address();
 
-    let balance = U256::from(1);
-    let value = U256::from(10);
+    let balance = uint!(1_U256);
+    let value = uint!(10_U256);
 
     let _ = watch!(contract_alice.mint(alice.address(), balance))?;
 
@@ -503,8 +504,8 @@ async fn transfer_from_rejects_insufficient_allowance(
     let alice_addr = alice.address();
     let bob_addr = bob.address();
 
-    let balance = U256::from(10);
-    let value = U256::from(1);
+    let balance = uint!(10_U256);
+    let value = uint!(1_U256);
 
     let _ = watch!(contract_alice.mint(alice.address(), balance))?;
 
@@ -559,8 +560,8 @@ async fn transfer_from_rejects_invalid_receiver(
     let bob_addr = bob.address();
     let invalid_receiver = Address::ZERO;
 
-    let balance = U256::from(10);
-    let value = U256::from(1);
+    let balance = uint!(10_U256);
+    let value = uint!(1_U256);
 
     let _ = watch!(contract_alice.mint(alice.address(), balance))?;
 
@@ -611,8 +612,8 @@ async fn burns(alice: User) -> Result<()> {
     let contract_alice = Erc20::new(contract_addr, &alice.signer);
     let alice_addr = alice.address();
 
-    let balance = U256::from(10);
-    let value = U256::from(1);
+    let balance = uint!(10_U256);
+    let value = uint!(1_U256);
 
     let _ = watch!(contract_alice.mint(alice.address(), balance))?;
 
@@ -646,8 +647,8 @@ async fn burn_rejects_insufficient_balance(alice: User) -> Result<()> {
     let contract_alice = Erc20::new(contract_addr, &alice.signer);
     let alice_addr = alice.address();
 
-    let balance = U256::from(10);
-    let value = U256::from(11);
+    let balance = uint!(10_U256);
+    let value = uint!(11_U256);
 
     let _ = watch!(contract_alice.mint(alice.address(), balance))?;
 
@@ -684,8 +685,8 @@ async fn burns_from(alice: User, bob: User) -> Result<()> {
     let alice_addr = alice.address();
     let bob_addr = bob.address();
 
-    let balance = U256::from(10);
-    let value = U256::from(1);
+    let balance = uint!(10_U256);
+    let value = uint!(1_U256);
 
     let _ = watch!(contract_alice.mint(alice.address(), balance))?;
 
@@ -738,8 +739,8 @@ async fn burn_from_reverts_insufficient_balance(
     let alice_addr = alice.address();
     let bob_addr = bob.address();
 
-    let balance = U256::from(1);
-    let value = U256::from(10);
+    let balance = uint!(1_U256);
+    let value = uint!(10_U256);
 
     let _ = watch!(contract_alice.mint(alice.address(), balance))?;
 
@@ -793,8 +794,8 @@ async fn burn_from_rejects_insufficient_allowance(
     let alice_addr = alice.address();
     let bob_addr = bob.address();
 
-    let balance = U256::from(10);
-    let value = U256::from(1);
+    let balance = uint!(10_U256);
+    let value = uint!(1_U256);
 
     let _ = watch!(contract_alice.mint(alice.address(), balance))?;
 
@@ -846,9 +847,9 @@ async fn mint_rejects_exceeding_cap(alice: User) -> Result<()> {
     let contract_alice = Erc20::new(contract_addr, &alice.signer);
     let alice_addr = alice.address();
 
-    let one = U256::from(1);
+    let one = uint!(1_U256);
     let two = U256::from(2);
-    let cap = U256::from(CAP);
+    let cap = CAP;
     let balance = cap - one;
 
     let _ = watch!(contract_alice.mint(alice_addr, balance))?;
@@ -882,8 +883,8 @@ async fn mint_rejects_when_cap_reached(alice: User) -> Result<()> {
     let contract_alice = Erc20::new(contract_addr, &alice.signer);
     let alice_addr = alice.address();
 
-    let one = U256::from(1);
-    let cap = U256::from(CAP);
+    let one = uint!(1_U256);
+    let cap = CAP;
     let balance = cap;
 
     let _ = watch!(contract_alice.mint(alice_addr, balance))?;

--- a/examples/erc20/tests/erc20.rs
+++ b/examples/erc20/tests/erc20.rs
@@ -848,7 +848,7 @@ async fn mint_rejects_exceeding_cap(alice: User) -> Result<()> {
     let alice_addr = alice.address();
 
     let one = uint!(1_U256);
-    let two = U256::from(2);
+    let two = uint!(2_U256);
     let cap = CAP;
     let balance = cap - one;
 

--- a/examples/erc721/tests/erc721.rs
+++ b/examples/erc721/tests/erc721.rs
@@ -5,6 +5,7 @@ use alloy::{
     sol,
     sol_types::SolConstructor,
 };
+use alloy_primitives::uint;
 use e2e::{receipt, send, watch, EventExt, Revert, User};
 
 use crate::abi::Erc721;
@@ -55,7 +56,7 @@ async fn mints(alice: User) -> eyre::Result<()> {
     assert_eq!(owner_of, alice_addr);
 
     let balance = contract.balanceOf(alice_addr).call().await?.balance;
-    assert!(balance >= U256::from(1));
+    assert!(balance >= uint!(1_U256));
     Ok(())
 }
 

--- a/lib/motsu-proc/tests/default.rs
+++ b/lib/motsu-proc/tests/default.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{address, Address, U128, U16, U256, U32, U64, U8};
+use alloy_primitives::{address, uint, Address, U128, U16, U256, U32, U64, U8};
 use stylus_sdk::stylus_proc::sol_storage;
 
 sol_storage! {
@@ -13,7 +13,7 @@ sol_storage! {
 #[motsu::test]
 fn mapping_initializes_and_updates(contract: Erc20) {
     let key = address!("a935CEC3c5Ef99D7F1016674DEFd455Ef06776C5");
-    let value = U256::from(100);
+    let value = uint!(100_U256);
     contract._balances.insert(key, value);
     let balance = contract._balances.get(key);
     assert_eq!(balance, value);
@@ -45,21 +45,21 @@ fn uint_sorted_initializes(contract: UintSorted) {
 
 #[motsu::test]
 fn uint_sorted_updates(contract: UintSorted) {
-    contract.a.set(U256::from(1));
-    contract.b.set(U128::from(2));
-    contract.c.set(U64::from(3));
-    contract.d.set(U32::from(4));
-    contract.e.set(U16::from(5));
-    contract.f.set(U8::from(6));
-    contract.g.set(U8::from(7));
+    contract.a.set(uint!(1_U256));
+    contract.b.set(uint!(2_U128));
+    contract.c.set(uint!(3_U64));
+    contract.d.set(uint!(4_U32));
+    contract.e.set(uint!(5_U16));
+    contract.f.set(uint!(6_U8));
+    contract.g.set(uint!(7_U8));
 
-    assert_eq!(contract.a.get(), U256::from(1));
-    assert_eq!(contract.b.get(), U128::from(2));
-    assert_eq!(contract.c.get(), U64::from(3));
-    assert_eq!(contract.d.get(), U32::from(4));
-    assert_eq!(contract.e.get(), U16::from(5));
-    assert_eq!(contract.f.get(), U8::from(6));
-    assert_eq!(contract.g.get(), U8::from(7));
+    assert_eq!(contract.a.get(), uint!(1_U256));
+    assert_eq!(contract.b.get(), uint!(2_U128));
+    assert_eq!(contract.c.get(), uint!(3_U64));
+    assert_eq!(contract.d.get(), uint!(4_U32));
+    assert_eq!(contract.e.get(), uint!(5_U16));
+    assert_eq!(contract.f.get(), uint!(6_U8));
+    assert_eq!(contract.g.get(), uint!(7_U8));
 }
 
 sol_storage! {
@@ -88,21 +88,21 @@ fn uint_unsorted_initializes(contract: UintUnsorted) {
 
 #[motsu::test]
 fn uint_unsorted_updates(contract: UintUnsorted) {
-    contract.a.set(U256::from(1));
-    contract.b.set(U16::from(5));
-    contract.c.set(U64::from(3));
-    contract.d.set(U8::from(6));
-    contract.e.set(U32::from(4));
-    contract.f.set(U128::from(2));
-    contract.g.set(U8::from(7));
+    contract.a.set(uint!(1_U256));
+    contract.b.set(uint!(5_U16));
+    contract.c.set(uint!(3_U64));
+    contract.d.set(uint!(6_U8));
+    contract.e.set(uint!(4_U32));
+    contract.f.set(uint!(2_U128));
+    contract.g.set(uint!(7_U8));
 
-    assert_eq!(contract.a.get(), U256::from(1));
-    assert_eq!(contract.b.get(), U16::from(5));
-    assert_eq!(contract.c.get(), U64::from(3));
-    assert_eq!(contract.d.get(), U8::from(6));
-    assert_eq!(contract.e.get(), U32::from(4));
-    assert_eq!(contract.f.get(), U128::from(2));
-    assert_eq!(contract.g.get(), U8::from(7));
+    assert_eq!(contract.a.get(), uint!(1_U256));
+    assert_eq!(contract.b.get(), uint!(5_U16));
+    assert_eq!(contract.c.get(), uint!(3_U64));
+    assert_eq!(contract.d.get(), uint!(6_U8));
+    assert_eq!(contract.e.get(), uint!(4_U32));
+    assert_eq!(contract.f.get(), uint!(2_U128));
+    assert_eq!(contract.g.get(), uint!(7_U8));
 }
 
 sol_storage! {


### PR DESCRIPTION
Curious why we are not using const evaluation for alloy number types wherever is possible?
