### PR TITLE
docs(ci): remove minimal from workflow description

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,6 @@ name: test
 # and all pull requests. It runs the following jobs:
 # - required: runs the test suite on ubuntu with stable and beta rust
 # toolchains.
-# - minimal: runs the test suite with the minimal versions of the dependencies
-# that satisfy the requirements of this crate, and its dependencies.
 # - os-check: runs the test suite on mac and windows.
 # - coverage: runs the test suite and collects coverage information.
 # See `check.yml` for information about how the concurrency cancellation and


### PR DESCRIPTION
This is super minor, but I noticed that on the description of this workflow we say that we have a job called `minimal` but we don't.
