### PR TITLE
feat(debug): conditionally implement debug for test errors

### DIFF
--- a/contracts/src/access/control.rs
+++ b/contracts/src/access/control.rs
@@ -81,20 +81,21 @@ sol! {
     ///
     /// * `account` - Account that was found to not be authorized.
     /// * `needed_role` - The missing role.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error AccessControlUnauthorizedAccount(address account, bytes32 needed_role);
     /// The caller of a function is not the expected one.
     ///
     /// NOTE: Don't confuse with [`AccessControlUnauthorizedAccount`].
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error AccessControlBadConfirmation();
 }
 
 /// An error that occurred in the implementation of an [`AccessControl`]
 /// contract.
-#[derive(SolidityError, Debug)]
+#[cfg_attr(all(test, feature = "std"), derive(Debug))]
+#[derive(SolidityError)]
 pub enum Error {
     /// The caller account is missing a role.
     UnauthorizedAccount(AccessControlUnauthorizedAccount),

--- a/contracts/src/access/ownable.rs
+++ b/contracts/src/access/ownable.rs
@@ -26,19 +26,20 @@ sol! {
     /// The caller account is not authorized to perform an operation.
     ///
     /// * `account` - Account that was found to not be authorized.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error OwnableUnauthorizedAccount(address account);
     /// The owner is not a valid owner account. (eg. `Address::ZERO`)
     ///
     /// * `owner` - Account that's not allowed to become the owner.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error OwnableInvalidOwner(address owner);
 }
 
 /// An error that occurred in the implementation of an [`Ownable`] contract.
-#[derive(SolidityError, Debug)]
+#[cfg_attr(all(test, feature = "std"), derive(Debug))]
+#[derive(SolidityError)]
 pub enum Error {
     /// The caller account is not authorized to perform an operation.
     UnauthorizedAccount(OwnableUnauthorizedAccount),

--- a/contracts/src/token/erc20/extensions/capped.rs
+++ b/contracts/src/token/erc20/extensions/capped.rs
@@ -12,19 +12,20 @@ use stylus_proc::{external, sol_storage, SolidityError};
 sol! {
     /// Indicates an error related to the operation that failed
     /// because `total_supply` exceeded the `_cap`.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC20ExceededCap(uint256 increased_supply, uint256 cap);
 
     /// Indicates an error related to the operation that failed
     /// because the supplied `cap` is not a valid cap value.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC20InvalidCap(uint256 cap);
 }
 
 /// A Capped error.
-#[derive(SolidityError, Debug)]
+#[cfg_attr(all(test, feature = "std"), derive(Debug))]
+#[derive(SolidityError)]
 pub enum Error {
     /// Indicates an error related to the operation that failed
     /// because `total_supply` exceeded the `_cap`.

--- a/contracts/src/token/erc20/mod.rs
+++ b/contracts/src/token/erc20/mod.rs
@@ -34,19 +34,19 @@ sol! {
     /// * `sender` - Address whose tokens are being transferred.
     /// * `balance` - Current balance for the interacting account.
     /// * `needed` - Minimum amount required to perform a transfer.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);
     /// Indicates a failure with the token `sender`. Used in transfers.
     ///
     /// * `sender` - Address whose tokens are being transferred.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC20InvalidSender(address sender);
     /// Indicates a failure with the token `receiver`. Used in transfers.
     ///
     /// * `receiver` - Address to which the tokens are being transferred.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC20InvalidReceiver(address receiver);
     /// Indicates a failure with the `spender`’s `allowance`. Used in
@@ -57,7 +57,7 @@ sol! {
     /// * `allowance` - Amount of tokens a `spender` is allowed to operate
     /// with.
     /// * `needed` - Minimum amount required to perform a transfer.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);
     /// Indicates a failure with the `spender` to be approved. Used in
@@ -65,7 +65,7 @@ sol! {
     ///
     /// * `spender` - Address that may be allowed to operate on tokens without
     /// being their owner.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC20InvalidSpender(address spender);
 
@@ -74,7 +74,8 @@ sol! {
 /// An [`Erc20`] error defined as described in [ERC-6093].
 ///
 /// [ERC-6093]: https://eips.ethereum.org/EIPS/eip-6093
-#[derive(SolidityError, Debug)]
+#[cfg_attr(all(test, feature = "std"), derive(Debug))]
+#[derive(SolidityError)]
 pub enum Error {
     /// Indicates an error related to the current balance of `sender`. Used in
     /// transfers.

--- a/contracts/src/token/erc721/extensions/enumerable.rs
+++ b/contracts/src/token/erc721/extensions/enumerable.rs
@@ -19,18 +19,19 @@ sol! {
     ///
     /// NOTE: The owner being `Address::ZERO`
     /// indicates a global out of bounds index.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC721OutOfBoundsIndex(address owner, uint256 index);
 
     /// Indicates an error related to batch minting not allowed.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC721EnumerableForbiddenBatchMint();
 }
 
 /// An [`Erc721Enumerable`] extension error.
-#[derive(SolidityError, Debug)]
+#[cfg_attr(all(test, feature = "std"), derive(Debug))]
+#[derive(SolidityError)]
 pub enum Error {
     /// Indicates an error when an `owner`'s token query
     /// was out of bounds for `index`.

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -53,14 +53,14 @@ sol! {
     /// Used in balance queries.
     ///
     /// * `owner` - The address deemed to be an invalid owner.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC721InvalidOwner(address owner);
 
     /// Indicates a `token_id` whose `owner` is the zero address.
     ///
     /// * `token_id` - Token id as a number.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC721NonexistentToken(uint256 token_id);
 
@@ -70,21 +70,21 @@ sol! {
     /// * `sender` - Address whose tokens are being transferred.
     /// * `token_id` - Token id as a number.
     /// * `owner` - Address of the owner of the token.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC721IncorrectOwner(address sender, uint256 token_id, address owner);
 
     /// Indicates a failure with the token `sender`. Used in transfers.
     ///
     /// * `sender` - An address whose token is being transferred.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC721InvalidSender(address sender);
 
     /// Indicates a failure with the token `receiver`. Used in transfers.
     ///
     /// * `receiver` - Address that receives the token.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC721InvalidReceiver(address receiver);
 
@@ -93,7 +93,7 @@ sol! {
     /// * `operator` - Address that may be allowed to operate on tokens
     ///   without being their owner.
     /// * `token_id` - Token id as a number.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC721InsufficientApproval(address operator, uint256 token_id);
 
@@ -101,7 +101,7 @@ sol! {
     /// Used in approvals.
     ///
     /// * `approver` - Address initiating an approval operation.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC721InvalidApprover(address approver);
 
@@ -110,7 +110,7 @@ sol! {
     ///
     /// * `operator` - Address that may be allowed to operate on tokens
     ///   without being their owner.
-    #[derive(Debug)]
+    #[cfg_attr(all(test, feature = "std"), derive(Debug))]
     #[allow(missing_docs)]
     error ERC721InvalidOperator(address operator);
 }
@@ -118,7 +118,8 @@ sol! {
 /// An [`Erc721`] error defined as described in [ERC-6093].
 ///
 /// [ERC-6093]: https://eips.ethereum.org/EIPS/eip-6093
-#[derive(SolidityError, Debug)]
+#[cfg_attr(all(test, feature = "std"), derive(Debug))]
+#[derive(SolidityError)]
 pub enum Error {
     /// Indicates that an address can't be an owner.
     /// For example, `Address::ZERO` is a forbidden owner in [`Erc721`].


### PR DESCRIPTION
Currently, all error types in the project have a default debug implementation necessary only for testing purposes. This unnecessary code in release builds increases the WASM binary size. This commit optimizes the code by implementing         
#[derive(Debug)] 
only for tests.


Resolves #165

#### PR Checklist


- [x]  Tests
- [x]  Documentation
