### PR TITLE
feat: benchmark ERC-20 gas usage

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -102,7 +102,7 @@ jobs:
         # target in this context means one of `--lib`, `--bin`, etc, and not the
         # target triple.
       - name: cargo hack
-        run: cargo hack check --feature-powerset --depth 2 --release --target wasm32-unknown-unknown --skip std --workspace --exclude e2e --exclude basic-example-script
+        run: cargo hack check --feature-powerset --depth 2 --release --target wasm32-unknown-unknown --skip std --workspace --exclude e2e --exclude basic-example-script --exclude benches
   typos:
     runs-on: ubuntu-latest
     name: ubuntu / stable / typos

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,6 +835,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "benches"
+version = "0.0.0"
+dependencies = [
+ "alloy",
+ "alloy-primitives 0.3.3",
+ "e2e",
+ "eyre",
+ "tokio",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,7 @@ dependencies = [
  "e2e",
  "eyre",
  "koba",
+ "serde",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -842,6 +842,7 @@ dependencies = [
  "alloy-primitives 0.3.3",
  "e2e",
  "eyre",
+ "koba",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "examples/access-control",
   "lib/e2e",
   "lib/e2e-proc",
+  "benches",
 ]
 default-members = [
   "contracts",

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "benches"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+version = "0.0.0"
+
+[dependencies]
+alloy-primitives.workspace = true
+alloy.workspace = true
+tokio.workspace = true
+eyre.workspace = true
+e2e = { path = "../lib/e2e" }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,4 +11,5 @@ alloy-primitives.workspace = true
 alloy.workspace = true
 tokio.workspace = true
 eyre.workspace = true
+koba.workspace = true
 e2e = { path = "../lib/e2e" }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -13,3 +13,4 @@ tokio.workspace = true
 eyre.workspace = true
 koba.workspace = true
 e2e = { path = "../lib/e2e" }
+serde = "1.0.203"

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -73,10 +73,7 @@ pub async fn bench() -> eyre::Result<()> {
     let contract_addr = deploy(&alice).await;
     let contract = Erc20::new(contract_addr, &alice_wallet);
 
-    println!("+------------------------------------------------------+");
-    println!("| Function Name      | L2 Gas | L1 Gas | Effective Gas |");
-    println!("|--------------------|--------|--------|---------------|");
-
+    println!("Running benches...");
     let receipts = vec![
         ("name()", receipt!(contract.name())?),
         ("symbol()", receipt!(contract.symbol())?),
@@ -86,11 +83,11 @@ pub async fn bench() -> eyre::Result<()> {
         ("balanceOf(account)", receipt!(contract.balanceOf(alice_addr))?),
         (
             "mint(account, amount)",
-            receipt!(contract.mint(alice_addr, uint!(100_U256)))?,
+            receipt!(contract.mint(alice_addr, uint!(10_U256)))?,
         ),
         (
             "burn(amount)",
-            receipt!(contract.burn(uint!(100_U256)).from(alice_addr))?,
+            receipt!(contract.burn(uint!(1_U256)).from(alice_addr))?,
         ),
         (
             "transfer(account, amount)",
@@ -99,6 +96,10 @@ pub async fn bench() -> eyre::Result<()> {
                 .from(alice_addr))?,
         ),
     ];
+
+    println!("+------------------------------------------------------+");
+    println!("| Function Name      | L2 Gas | L1 Gas | Effective Gas |");
+    println!("|--------------------|--------|--------|---------------|");
 
     for (func_name, receipt) in receipts {
         let l2_gas = receipt.gas_used;

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -1,5 +1,5 @@
 use alloy::{
-    network::AnyNetwork,
+    network::{AnyNetwork, EthereumWallet},
     primitives::Address,
     providers::{fillers::ChainIdFiller, ProviderBuilder},
     rpc::types::TransactionReceipt,
@@ -63,7 +63,8 @@ pub async fn bench() -> eyre::Result<()> {
     let alice_addr = alice.address();
     let alice_wallet = ProviderBuilder::new()
         .network::<AnyNetwork>()
-        .filler(ChainIdFiller::default())
+        .with_recommended_fillers()
+        .wallet(EthereumWallet::from(alice.signer.clone()))
         .on_http(alice.url().parse()?);
 
     let contract_addr = deploy(&alice).await;

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -1,4 +1,7 @@
-use alloy::{primitives::Address, sol, sol_types::SolConstructor, uint};
+use alloy::{
+    primitives::Address, providers::WalletProvider, sol,
+    sol_types::SolConstructor, uint,
+};
 use alloy_primitives::U256;
 use e2e::Account;
 use koba::config::Deploy;
@@ -69,18 +72,24 @@ pub async fn bench() -> eyre::Result<()> {
     let gas =
         contract.mint(alice.address(), uint!(100_U256)).estimate_gas().await?;
     println!("mint(account, amount): {gas}");
-    let receipt = contract
+
+    let _ = contract
         .mint(alice.address(), uint!(100_U256))
         .send()
         .await?
-        .get_receipt()
+        .watch()
         .await?;
-    println!("mint(account, amount): receipt {receipt:?}");
-
-    let gas = contract.burn(uint!(100_U256)).estimate_gas().await?;
+    let gas = contract
+        .burn(uint!(100_U256))
+        .from(alice.address())
+        .estimate_gas()
+        .await?;
     println!("burn(amount): {gas}");
-    let gas =
-        contract.transfer(bob.address(), uint!(1_U256)).estimate_gas().await?;
+    let gas = contract
+        .transfer(bob.address(), uint!(1_U256))
+        .from(alice.address())
+        .estimate_gas()
+        .await?;
     println!("transfer(account, amount): {gas}");
 
     Ok(())

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -98,7 +98,7 @@ pub async fn bench() -> eyre::Result<()> {
             receipt!(contract_bob.transferFrom(
                 alice_addr,
                 bob_addr,
-                uint!(5_U256)
+                uint!(4_U256)
             ))?,
         ),
     ];

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -81,7 +81,7 @@ async fn deploy(account: &Account) -> Address {
         .join("target")
         .join("wasm32-unknown-unknown")
         .join("release")
-        .join("basic_example.wasm");
+        .join("erc20_example.wasm");
     let sol_path = manifest_dir
         .join("examples")
         .join("erc20")

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -1,0 +1,78 @@
+use alloy::{primitives::Address, sol, sol_types::SolConstructor, uint};
+use alloy_primitives::U256;
+use e2e::Account;
+
+sol!(
+    #[sol(rpc)]
+    contract Erc20 {
+        function name() external view returns (string name);
+        function symbol() external view returns (string symbol);
+        function decimals() external view returns (uint8 decimals);
+        function totalSupply() external view returns (uint256 totalSupply);
+        function balanceOf(address account) external view returns (uint256 balance);
+        function transfer(address recipient, uint256 amount) external returns (bool);
+        function allowance(address owner, address spender) external view returns (uint256 allowance);
+        function approve(address spender, uint256 amount) external returns (bool);
+        function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+        function cap() public view virtual returns (uint256 cap);
+
+        function mint(address account, uint256 amount) external;
+        function burn(uint256 amount) external;
+        function burnFrom(address account, uint256 amount) external;
+
+        error ERC20ExceededCap(uint256 increased_supply, uint256 cap);
+        error ERC20InvalidCap(uint256 cap);
+
+        error ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed);
+        error ERC20InvalidSender(address sender);
+        error ERC20InvalidReceiver(address receiver);
+        error ERC20InsufficientAllowance(address spender, uint256 allowance, uint256 needed);
+        error ERC20InvalidSpender(address spender);
+
+        #[derive(Debug, PartialEq)]
+        event Transfer(address indexed from, address indexed to, uint256 value);
+
+        #[derive(Debug, PartialEq)]
+        event Approval(address indexed owner, address indexed spender, uint256 value);
+    }
+);
+
+sol!("../examples/erc20/src/constructor.sol");
+
+const TOKEN_NAME: &str = "Test Token";
+const TOKEN_SYMBOL: &str = "TTK";
+const CAP: U256 = uint!(1_000_000_U256);
+
+async fn deploy(
+    rpc_url: &str,
+    private_key: &str,
+    cap: Option<U256>,
+) -> eyre::Result<Address> {
+    let args = Erc20Example::constructorCall {
+        name_: TOKEN_NAME.to_owned(),
+        symbol_: TOKEN_SYMBOL.to_owned(),
+        cap_: cap.unwrap_or(CAP),
+    };
+    let args = alloy::hex::encode(args.abi_encode());
+    e2e::deploy(rpc_url, private_key, Some(args)).await
+}
+
+pub async fn bench() -> eyre::Result<()> {
+    let alice = Account::new().await?;
+    let contract_addr = deploy(alice.url(), &alice.pk(), None).await?;
+    let contract = Erc20::new(contract_addr, &alice.wallet);
+
+    let gas = contract.name().estimate_gas().await?;
+    println!("name(): {gas}");
+    let gas = contract.symbol().estimate_gas().await?;
+    println!("symbol(): {gas}");
+    let gas = contract.cap().estimate_gas().await?;
+    println!("cap(): {gas}");
+    let gas = contract.decimals().estimate_gas().await?;
+    println!("decimals(): {gas}");
+    let gas = contract.totalSupply().estimate_gas().await?;
+    println!("totalSupply(): {gas}");
+
+    Ok(())
+}

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -1,7 +1,12 @@
 use alloy::{
-    network::AnyNetwork, primitives::Address, providers::ProviderBuilder,
-    rpc::types::TransactionReceipt, signers::local::PrivateKeySigner, sol,
-    sol_types::SolConstructor, uint,
+    network::AnyNetwork,
+    primitives::Address,
+    providers::{fillers::ChainIdFiller, ProviderBuilder},
+    rpc::types::TransactionReceipt,
+    signers::local::PrivateKeySigner,
+    sol,
+    sol_types::SolConstructor,
+    uint,
 };
 use alloy_primitives::U256;
 use e2e::{fund_account, receipt, Account};
@@ -58,7 +63,7 @@ pub async fn bench() -> eyre::Result<()> {
     let alice_addr = alice.address();
     let alice_wallet = ProviderBuilder::new()
         .network::<AnyNetwork>()
-        .with_recommended_fillers()
+        .filler(ChainIdFiller::default())
         .on_http(alice.url().parse()?);
 
     let contract_addr = deploy(&alice).await;

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -63,13 +63,22 @@ pub async fn bench() -> eyre::Result<()> {
     println!("decimals(): {gas}");
     let gas = contract.totalSupply().estimate_gas().await?;
     println!("totalSupply(): {gas}");
+    let gas = contract.balanceOf(alice.address()).estimate_gas().await?;
+    println!("balanceOf(account): {gas}");
+
     let gas =
         contract.mint(alice.address(), uint!(100_U256)).estimate_gas().await?;
     println!("mint(account, amount): {gas}");
-    // let gas = contract.burn(uint!(10_U256)).estimate_gas().await?;
-    // println!("burn(amount): {gas}");
-    let gas = contract.balanceOf(alice.address()).estimate_gas().await?;
-    println!("balanceOf(account): {gas}");
+    let receipt = contract
+        .mint(alice.address(), uint!(100_U256))
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    println!("mint(account, amount): receipt {receipt:?}");
+
+    let gas = contract.burn(uint!(100_U256)).estimate_gas().await?;
+    println!("burn(amount): {gas}");
     let gas =
         contract.transfer(bob.address(), uint!(1_U256)).estimate_gas().await?;
     println!("transfer(account, amount): {gas}");

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -101,6 +101,31 @@ pub async fn bench() -> eyre::Result<()> {
     println!("| Function Name      | L2 Gas | L1 Gas | Effective Gas |");
     println!("|--------------------|--------|--------|---------------|");
 
+    // Calculate the width of the longest function name.
+    let max_name_width = receipts
+        .iter()
+        .max_by_key(|x| x.0.len())
+        .expect("should at least bench one function")
+        .0
+        .len();
+    let name_width = max_name_width.max("Function".len());
+
+    // Calculate the total width of the table.
+    let total_width = name_width + 3 + 6 + 3 + 6 + 3 + 20 + 4; // 3 for padding, 4 for outer borders
+
+    // Print the table header.
+    println!("+{}+", "-".repeat(total_width - 2));
+    println!(
+        "| {:<width$} | L2 Gas | L1 Gas | Effective Gas        |",
+        "Function Name",
+        width = name_width
+    );
+    println!(
+        "|{}+--------+--------+----------------------|",
+        "-".repeat(name_width + 1)
+    );
+
+    // Print each row.
     for (func_name, receipt) in receipts {
         let l2_gas = receipt.gas_used;
         let arb_fields: ArbOtherFields = receipt.other.deserialize_into()?;
@@ -108,11 +133,17 @@ pub async fn bench() -> eyre::Result<()> {
         let effective_gas = l2_gas - l1_gas;
 
         println!(
-            "| {:<18} | {:>6} | {:>6} | {:>13} |",
-            func_name, l2_gas, l1_gas, effective_gas
+            "| {:<width$} | {:>6} | {:>6} | {:>20} |",
+            func_name,
+            l2_gas,
+            l1_gas,
+            effective_gas,
+            width = name_width
         );
     }
-    println!("+------------------------------------------------------+");
+
+    // Print the table footer.
+    println!("+{}+", "-".repeat(total_width - 2));
 
     Ok(())
 }

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -66,7 +66,7 @@ pub async fn bench() -> eyre::Result<()> {
     let gas =
         contract.mint(alice.address(), uint!(100_U256)).estimate_gas().await?;
     println!("mint(account, amount): {gas}");
-    let gas = contract.burn(uint!(100_U256)).estimate_gas().await?;
+    let gas = contract.burn(uint!(10_U256)).estimate_gas().await?;
     println!("burn(amount): {gas}");
     let gas = contract.balanceOf(alice.address()).estimate_gas().await?;
     println!("balanceOf(account): {gas}");

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -49,6 +49,7 @@ const CAP: U256 = uint!(1_000_000_U256);
 
 pub async fn bench() -> eyre::Result<()> {
     let alice = Account::new().await?;
+    let bob = Account::new().await?;
     let contract_addr = deploy(&alice).await;
     let contract = Erc20::new(contract_addr, &alice.wallet);
 
@@ -62,6 +63,16 @@ pub async fn bench() -> eyre::Result<()> {
     println!("decimals(): {gas}");
     let gas = contract.totalSupply().estimate_gas().await?;
     println!("totalSupply(): {gas}");
+    let gas =
+        contract.mint(alice.address(), uint!(100_U256)).estimate_gas().await?;
+    println!("mint(account, amount): {gas}");
+    let gas = contract.burn(uint!(100_U256)).estimate_gas().await?;
+    println!("burn(amount): {gas}");
+    let gas = contract.balanceOf(alice.address()).estimate_gas().await?;
+    println!("balanceOf(account): {gas}");
+    let gas =
+        contract.transfer(bob.address(), uint!(1_U256)).estimate_gas().await?;
+    println!("transfer(account, amount): {gas}");
 
     Ok(())
 }

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -91,7 +91,7 @@ pub async fn bench() -> eyre::Result<()> {
         ),
         (
             "burnFrom(alice, 1)",
-            receipt!(contract.burnFrom(alice_addr, uint!(1_U256)))?,
+            receipt!(contract_bob.burnFrom(alice_addr, uint!(1_U256)))?,
         ),
         (
             "transferFrom(alice, bob, 5)",

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -1,7 +1,4 @@
-use alloy::{
-    primitives::Address, providers::WalletProvider, sol,
-    sol_types::SolConstructor, uint,
-};
+use alloy::{primitives::Address, sol, sol_types::SolConstructor, uint};
 use alloy_primitives::U256;
 use e2e::Account;
 use koba::config::Deploy;

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -64,6 +64,7 @@ pub async fn bench() -> eyre::Result<()> {
     let contract_bob = Erc20::new(contract_addr, &bob_wallet);
 
     println!("Running benches...");
+    // IMPORTANT: Order matters!
     let receipts = vec![
         ("name()", receipt!(contract.name())?),
         ("symbol()", receipt!(contract.symbol())?),
@@ -81,16 +82,16 @@ pub async fn bench() -> eyre::Result<()> {
         ),
         ("burn(1)", receipt!(contract.burn(uint!(1_U256)))?),
         (
-            "burnFrom(alice, 1)",
-            receipt!(contract.burnFrom(alice_addr, uint!(1_U256)))?,
-        ),
-        (
             "transfer(bob, 1)",
             receipt!(contract.transfer(bob_addr, uint!(1_U256)))?,
         ),
         (
             "approve(bob, 5)",
             receipt!(contract.approve(bob_addr, uint!(5_U256)))?,
+        ),
+        (
+            "burnFrom(alice, 1)",
+            receipt!(contract.burnFrom(alice_addr, uint!(1_U256)))?,
         ),
         (
             "transferFrom(alice, bob, 5)",

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -66,8 +66,8 @@ pub async fn bench() -> eyre::Result<()> {
     let gas =
         contract.mint(alice.address(), uint!(100_U256)).estimate_gas().await?;
     println!("mint(account, amount): {gas}");
-    let gas = contract.burn(uint!(10_U256)).estimate_gas().await?;
-    println!("burn(amount): {gas}");
+    // let gas = contract.burn(uint!(10_U256)).estimate_gas().await?;
+    // println!("burn(amount): {gas}");
     let gas = contract.balanceOf(alice.address()).estimate_gas().await?;
     println!("balanceOf(account): {gas}");
     let gas =

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod erc20;

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -1,1 +1,12 @@
+use alloy_primitives::U128;
+use serde::Deserialize;
+
 pub mod erc20;
+
+#[derive(Debug, Deserialize)]
+struct ArbOtherFields {
+    #[serde(rename = "gasUsedForL1")]
+    gas_used_for_l1: U128,
+    #[serde(rename = "l1BlockNumber")]
+    l1_block_number: String,
+}

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -7,6 +7,7 @@ pub mod erc20;
 struct ArbOtherFields {
     #[serde(rename = "gasUsedForL1")]
     gas_used_for_l1: U128,
+    #[allow(dead_code)]
     #[serde(rename = "l1BlockNumber")]
     l1_block_number: String,
 }

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -1,0 +1,8 @@
+use benches::erc20;
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    erc20::bench().await?;
+
+    Ok(())
+}

--- a/contracts/src/token/erc20/mod.rs
+++ b/contracts/src/token/erc20/mod.rs
@@ -346,12 +346,11 @@ impl Erc20 {
         self._update(Address::ZERO, account, value)
     }
 
-    /// Transfers a `value` amount of tokens from `from` to `to`,
-    /// or alternatively mints (or burns)
-    /// if `from` (or `to`) is the zero address.
+    /// Transfers a `value` amount of tokens from `from` to `to`, or
+    /// alternatively mints (or burns) if `from` (or `to`) is the zero address.
     ///
-    /// All customizations to transfers, mints, and burns
-    /// should be done by using this function.
+    /// All customizations to transfers, mints, and burns should be done by
+    /// using this function.
     ///
     /// # Arguments
     ///
@@ -361,8 +360,8 @@ impl Erc20 {
     ///
     /// # Panics
     ///
-    /// If `_total_supply` exceeds `U256::MAX`.
-    /// It may happen during `mint` operation.
+    /// If `_total_supply` exceeds `U256::MAX`. It may happen during `mint`
+    /// operation.
     ///
     /// # Errors
     ///

--- a/contracts/src/utils/pausable.rs
+++ b/contracts/src/utils/pausable.rs
@@ -103,8 +103,8 @@ impl Pausable {
         Ok(())
     }
 
-    /// Modifier to make a function callable
-    /// only when the contract is NOT paused.
+    /// Modifier to make a function callable only when the contract is NOT
+    /// paused.
     ///
     /// # Arguments
     ///
@@ -112,7 +112,7 @@ impl Pausable {
     ///
     /// # Errors
     ///
-    /// If the contract is in `Paused` state, then the error
+    /// If the contract is in the `Paused` state, then the error
     /// [`Error::EnforcedPause`] is returned.
     pub fn when_not_paused(&self) -> Result<(), Error> {
         if self._paused.get() {

--- a/lib/e2e/src/lib.rs
+++ b/lib/e2e/src/lib.rs
@@ -12,7 +12,7 @@ pub use deploy::deploy;
 pub use e2e_proc::test;
 pub use error::{Panic, PanicCode, Revert};
 pub use event::EventExt;
-pub use system::{provider, Provider, Wallet};
+pub use system::{fund_account, provider, Provider, Wallet};
 
 /// This macro provides a shorthand for broadcasting the transaction to the
 /// network.
@@ -60,7 +60,7 @@ macro_rules! send {
 #[macro_export]
 macro_rules! watch {
     ($e:expr) => {
-        send!($e)?.watch().await
+        $crate::send!($e)?.watch().await
     };
 }
 
@@ -86,6 +86,6 @@ macro_rules! watch {
 #[macro_export]
 macro_rules! receipt {
     ($e:expr) => {
-        send!($e)?.get_receipt().await
+        $crate::send!($e)?.get_receipt().await
     };
 }

--- a/lib/e2e/src/system.rs
+++ b/lib/e2e/src/system.rs
@@ -1,5 +1,6 @@
 use alloy::{
     network::{Ethereum, EthereumWallet},
+    primitives::Address,
     providers::{
         fillers::{
             ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
@@ -9,7 +10,9 @@ use alloy::{
     },
     transports::http::{Client, Http},
 };
-use eyre::Context;
+use eyre::{bail, Context};
+
+use crate::environment::get_node_path;
 
 pub(crate) const RPC_URL_ENV_VAR_NAME: &str = "RPC_URL";
 
@@ -44,10 +47,6 @@ fn env(name: &str) -> eyre::Result<String> {
 }
 
 /// Returns an alloy provider connected to the `RPC_URL` rpc endpoint.
-///
-/// # Panics
-///
-/// May panic if unable to load the `RPC_URL` environment variable.
 #[must_use]
 pub fn provider() -> Provider {
     let rpc_url = env(RPC_URL_ENV_VAR_NAME)
@@ -55,4 +54,25 @@ pub fn provider() -> Provider {
         .parse()
         .expect("failed to parse RPC_URL string into a URL");
     ProviderBuilder::new().with_recommended_fillers().on_http(rpc_url)
+}
+
+pub fn fund_account(addr: Address, amount: &str) -> eyre::Result<()> {
+    // ./test-node.bash script send-l2 --to
+    // address_0x01fA6bf4Ee48B6C95900BCcf9BEA172EF5DBd478 --ethamount 10
+    let node_script = get_node_path()?.join("test-node.bash");
+    let output = std::process::Command::new(node_script)
+        .arg("script")
+        .arg("send-l2")
+        .arg("--to")
+        .arg(format!("address_{addr}"))
+        .arg("--ethamount")
+        .arg(amount)
+        .output()?;
+
+    if !output.status.success() {
+        let err = String::from_utf8_lossy(&output.stderr);
+        bail!("account's wallet wasn't funded - address is {addr}:\n{err}")
+    }
+
+    Ok(())
 }

--- a/lib/e2e/src/system.rs
+++ b/lib/e2e/src/system.rs
@@ -47,6 +47,10 @@ fn env(name: &str) -> eyre::Result<String> {
 }
 
 /// Returns an alloy provider connected to the `RPC_URL` rpc endpoint.
+///
+/// # Panics
+///
+/// May panic if unable to load the `RPC_URL` environment variable.
 #[must_use]
 pub fn provider() -> Provider {
     let rpc_url = env(RPC_URL_ENV_VAR_NAME)

--- a/lib/e2e/src/system.rs
+++ b/lib/e2e/src/system.rs
@@ -56,7 +56,8 @@ pub fn provider() -> Provider {
     ProviderBuilder::new().with_recommended_fillers().on_http(rpc_url)
 }
 
-pub fn fund_account(addr: Address, amount: &str) -> eyre::Result<()> {
+/// Send `amount` eth to `address` in the nitro-tesnode.
+pub fn fund_account(address: Address, amount: &str) -> eyre::Result<()> {
     // ./test-node.bash script send-l2 --to
     // address_0x01fA6bf4Ee48B6C95900BCcf9BEA172EF5DBd478 --ethamount 10
     let node_script = get_node_path()?.join("test-node.bash");
@@ -64,14 +65,14 @@ pub fn fund_account(addr: Address, amount: &str) -> eyre::Result<()> {
         .arg("script")
         .arg("send-l2")
         .arg("--to")
-        .arg(format!("address_{addr}"))
+        .arg(format!("address_{address}"))
         .arg("--ethamount")
         .arg(amount)
         .output()?;
 
     if !output.status.success() {
         let err = String::from_utf8_lossy(&output.stderr);
-        bail!("account's wallet wasn't funded - address is {addr}:\n{err}")
+        bail!("account's wallet wasn't funded - address is {address}:\n{err}")
     }
 
     Ok(())


### PR DESCRIPTION
Resolves #167 

Initial work towards having a full gas benchmarking suite.

It's tested running against `nitro-testnode`, but should be good to test against Arbitrum Sepolia or any other Stylus-enabled RPC endpoint.

The output looks like this:

![Screenshot 2024-07-01 at 14 55 13](https://github.com/OpenZeppelin/rust-contracts-stylus/assets/22298999/89d38ec7-a431-450a-9b2d-932a096b0358)

You can see that the `L1 Gas` is 0, and this is because of the configuration of `nitro-testnode`, for a testnet like Arbitrum Sepolia this number would be different than zero most of the time.

Note that we need to deserialize the extra fields of the transaction receipt in order to access the gas usage in the L1.

```rust
#[derive(Debug, Deserialize)]
struct ArbOtherFields {
    #[serde(rename = "gasUsedForL1")]
    gas_used_for_l1: U128,
    #[allow(dead_code)]
    #[serde(rename = "l1BlockNumber")]
    l1_block_number: String,
}
```