### PR TITLE
feat(e2e): enable checking whether an event was not emitted

### DIFF
--- a/examples/erc20/tests/erc20.rs
+++ b/examples/erc20/tests/erc20.rs
@@ -73,11 +73,11 @@ async fn mints(alice: Account) -> Result<()> {
 
     let one = uint!(1_U256);
     let receipt = receipt!(contract.mint(alice_addr, one))?;
-    receipt.emits(Erc20::Transfer {
+    assert!(receipt.emits(Erc20::Transfer {
         from: Address::ZERO,
         to: alice_addr,
         value: one,
-    });
+    }));
 
     let Erc20::balanceOfReturn { balance } =
         contract.balanceOf(alice_addr).call().await?;
@@ -180,7 +180,11 @@ async fn transfers(alice: Account, bob: Account) -> Result<()> {
     let Erc20::totalSupplyReturn { totalSupply: supply } =
         contract_alice.totalSupply().call().await?;
 
-    receipt.emits(Erc20::Transfer { from: alice_addr, to: bob_addr, value });
+    assert!(receipt.emits(Erc20::Transfer {
+        from: alice_addr,
+        to: bob_addr,
+        value
+    }));
 
     assert_eq!(initial_alice_balance - value, alice_balance);
     assert_eq!(initial_bob_balance + value, bob_balance);
@@ -297,11 +301,11 @@ async fn approves(alice: Account, bob: Account) -> Result<()> {
     assert_eq!(U256::ZERO, initial_bob_alice_allowance);
 
     let receipt = receipt!(contract.approve(bob_addr, one))?;
-    receipt.emits(Erc20::Approval {
+    assert!(receipt.emits(Erc20::Approval {
         owner: alice_addr,
         spender: bob_addr,
         value: one,
-    });
+    }));
 
     let Erc20::allowanceReturn { allowance: alice_bob_allowance } =
         contract.allowance(alice_addr, bob_addr).call().await?;
@@ -312,11 +316,11 @@ async fn approves(alice: Account, bob: Account) -> Result<()> {
     assert_eq!(initial_bob_alice_allowance, bob_alice_allowance);
 
     let receipt = receipt!(contract.approve(bob_addr, ten))?;
-    receipt.emits(Erc20::Approval {
+    assert!(receipt.emits(Erc20::Approval {
         owner: alice_addr,
         spender: bob_addr,
         value: ten,
-    });
+    }));
 
     let Erc20::allowanceReturn { allowance: alice_bob_allowance } =
         contract.allowance(alice_addr, bob_addr).call().await?;
@@ -427,7 +431,11 @@ async fn transfers_from(alice: Account, bob: Account) -> Result<()> {
     let Erc20::allowanceReturn { allowance } =
         contract_alice.allowance(alice_addr, bob_addr).call().await?;
 
-    receipt.emits(Erc20::Transfer { from: alice_addr, to: bob_addr, value });
+    assert!(receipt.emits(Erc20::Transfer {
+        from: alice_addr,
+        to: bob_addr,
+        value
+    }));
 
     assert_eq!(initial_alice_balance - value, alice_balance);
     assert_eq!(initial_bob_balance + value, bob_balance);
@@ -629,11 +637,11 @@ async fn burns(alice: Account) -> Result<()> {
     let Erc20::totalSupplyReturn { totalSupply: supply } =
         contract_alice.totalSupply().call().await?;
 
-    receipt.emits(Erc20::Transfer {
+    assert!(receipt.emits(Erc20::Transfer {
         from: alice_addr,
         to: Address::ZERO,
         value,
-    });
+    }));
 
     assert_eq!(initial_balance - value, balance);
     assert_eq!(initial_supply - value, supply);
@@ -713,11 +721,11 @@ async fn burns_from(alice: Account, bob: Account) -> Result<()> {
     let Erc20::allowanceReturn { allowance } =
         contract_alice.allowance(alice_addr, bob_addr).call().await?;
 
-    receipt.emits(Erc20::Transfer {
+    assert!(receipt.emits(Erc20::Transfer {
         from: alice_addr,
         to: Address::ZERO,
         value,
-    });
+    }));
 
     assert_eq!(initial_alice_balance - value, alice_balance);
     assert_eq!(initial_bob_balance, bob_balance);

--- a/examples/ownable/tests/ownable.rs
+++ b/examples/ownable/tests/ownable.rs
@@ -89,10 +89,10 @@ async fn transfers_ownership(alice: Account, bob: Account) -> Result<()> {
     let contract = Ownable::new(contract_addr, &alice.wallet);
 
     let receipt = receipt!(contract.transferOwnership(bob_addr))?;
-    receipt.emits(OwnershipTransferred {
+    assert!(receipt.emits(OwnershipTransferred {
         previousOwner: alice_addr,
         newOwner: bob_addr,
-    });
+    }));
 
     let Ownable::ownerReturn { owner } = contract.owner().call().await?;
     assert_eq!(owner, bob_addr);
@@ -143,10 +143,10 @@ async fn loses_ownership_after_renouncement(alice: Account) -> Result<()> {
     let contract = Ownable::new(contract_addr, &alice.wallet);
 
     let receipt = receipt!(contract.renounceOwnership())?;
-    receipt.emits(OwnershipTransferred {
+    assert!(receipt.emits(OwnershipTransferred {
         previousOwner: alice_addr,
         newOwner: Address::ZERO,
-    });
+    }));
 
     let Ownable::ownerReturn { owner } = contract.owner().call().await?;
     assert_eq!(owner, Address::ZERO);

--- a/lib/e2e/src/event.rs
+++ b/lib/e2e/src/event.rs
@@ -3,25 +3,21 @@ use alloy::{rpc::types::eth::TransactionReceipt, sol_types::SolEvent};
 /// Extension trait for asserting an event gets emitted.
 pub trait EventExt<E> {
     /// Asserts the contract emitted the `expected` event.
-    fn emits(&self, expected: E);
+    fn emits(&self, expected: E) -> bool;
 }
 
 impl<E> EventExt<E> for TransactionReceipt
 where
     E: SolEvent,
     E: PartialEq,
-    E: std::fmt::Debug,
 {
-    fn emits(&self, expected: E) {
+    fn emits(&self, expected: E) -> bool {
         // Extract all events that are the expected type.
-        let emitted = self
-            .inner
+        self.inner
             .logs()
             .iter()
             .filter_map(|log| log.log_decode().ok())
             .map(|log| log.inner.data)
-            .any(|event| expected == event);
-
-        assert!(emitted, "Event {expected:?} not emitted");
+            .any(|event| expected == event)
     }
 }


### PR DESCRIPTION
Small refactor to enable checking an event does *not* get emitted.

I'm currently working on the e2e tests for `AccessControl` and had the need to check that an event was not emitted. However, with the current API of `receipt.emits`, the assertion occurs inside the `emits` function, which does not let me do something like `assert!(!receipt.emits(...));`.

This PR enables this by delegating the assertion to the caller.

This also makes the API more consistent with the Error e2e API.
