### PR TITLE
build: pin stylus-sdk version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,8 @@ all = "warn"
 
 [workspace.dependencies]
 # stylus-related
-stylus-sdk = { version = "0.5.0", default-features = false }
-stylus-proc = { version = "0.5.0", default-features = false }
+stylus-sdk = { version = "=0.5.0", default-features = false }
+stylus-proc = { version = "=0.5.0", default-features = false }
 mini-alloc = "0.4.2"
 
 alloy = { version = "0.1.1", features = [


### PR DESCRIPTION
Need to pin so that new installs don't use broken versions.