### PR TITLE
ref(e2e): use generic deploy function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -778,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.80"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.36",
@@ -1463,6 +1463,7 @@ name = "e2e"
 version = "0.1.0"
 dependencies = [
  "alloy",
+ "async-trait",
  "e2e-proc",
  "eyre",
  "koba",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,7 +1463,6 @@ name = "e2e"
 version = "0.1.0"
 dependencies = [
  "alloy",
- "async-trait",
  "e2e-proc",
  "eyre",
  "koba",

--- a/examples/access-control/tests/access_control.rs
+++ b/examples/access-control/tests/access_control.rs
@@ -4,14 +4,9 @@ use abi::AccessControl::{
     self, AccessControlBadConfirmation, AccessControlUnauthorizedAccount,
     RoleAdminChanged, RoleGranted, RoleRevoked,
 };
-use alloy::{hex, network::ReceiptResponse, sol_types::SolConstructor};
-use e2e::{
-    receipt, send, watch, Account, ContractDeployer, EventExt, ReceiptExt,
-    Revert,
-};
-use eyre::{ContextCompat, Result};
-
-use crate::abi::AccessControl::constructorCall;
+use alloy::hex;
+use e2e::{receipt, send, watch, Account, EventExt, ReceiptExt, Revert};
+use eyre::Result;
 
 mod abi;
 
@@ -21,10 +16,6 @@ const ROLE: [u8; 32] = access_control_example::TRANSFER_ROLE;
 const NEW_ADMIN_ROLE: [u8; 32] =
     hex!("879ce0d4bfd332649ca3552efe772a38d64a315eb70ab69689fd309c735946b5");
 
-fn ctr() -> constructorCall {
-    constructorCall {}
-}
-
 // ============================================================================
 // Integration Tests: AccessControl
 // ============================================================================
@@ -32,7 +23,7 @@ fn ctr() -> constructorCall {
 #[e2e::test]
 async fn constructs(alice: Account) -> Result<()> {
     let alice_addr = alice.address();
-    let receipt = alice.as_deployer().with_constructor(ctr()).deploy().await?;
+    let receipt = alice.as_deployer().deploy().await?;
     let contract = AccessControl::new(receipt.address()?, &alice.wallet);
 
     assert!(receipt.emits(RoleGranted {
@@ -52,12 +43,7 @@ async fn constructs(alice: Account) -> Result<()> {
 async fn other_roles_admin_is_the_default_admin_role(
     alice: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let AccessControl::getRoleAdminReturn { role } =
@@ -69,12 +55,7 @@ async fn other_roles_admin_is_the_default_admin_role(
 
 #[e2e::test]
 async fn default_role_is_default_admin(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let AccessControl::getRoleAdminReturn { role } =
@@ -93,12 +74,7 @@ async fn error_when_non_admin_grants_role(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &bob.wallet);
 
     let err = send!(contract.grantRole(ROLE.into(), alice.address()))
@@ -118,12 +94,7 @@ async fn accounts_can_be_granted_roles_multiple_times(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -148,12 +119,7 @@ async fn accounts_can_be_granted_roles_multiple_times(
 #[e2e::test]
 async fn not_granted_roles_can_be_revoked(alice: Account) -> Result<()> {
     let alice_addr = alice.address();
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let AccessControl::hasRoleReturn { hasRole } =
@@ -172,12 +138,7 @@ async fn not_granted_roles_can_be_revoked(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn admin_can_revoke_role(alice: Account, bob: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -200,12 +161,7 @@ async fn error_when_non_admin_revokes_role(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -229,12 +185,7 @@ async fn roles_can_be_revoked_multiple_times(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -254,12 +205,7 @@ async fn roles_can_be_revoked_multiple_times(
 #[e2e::test]
 async fn not_granted_roles_can_be_renounced(alice: Account) -> Result<()> {
     let alice_addr = alice.address();
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let receipt = receipt!(contract.renounceRole(ROLE.into(), alice_addr))?;
@@ -275,12 +221,7 @@ async fn not_granted_roles_can_be_renounced(alice: Account) -> Result<()> {
 #[e2e::test]
 async fn bearer_can_renounce_role(alice: Account, bob: Account) -> Result<()> {
     let bob_addr = bob.address();
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let _ = watch!(contract.grantRole(ROLE.into(), bob_addr))?;
@@ -301,12 +242,7 @@ async fn error_when_the_one_renouncing_is_not_the_sender(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -325,12 +261,7 @@ async fn error_when_the_one_renouncing_is_not_the_sender(
 #[e2e::test]
 async fn roles_can_be_renounced_multiple_times(alice: Account) -> Result<()> {
     let alice_addr = alice.address();
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let _ = watch!(contract.renounceRole(ROLE.into(), alice_addr))?;
@@ -346,12 +277,7 @@ async fn roles_can_be_renounced_multiple_times(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn a_roles_admin_role_can_change(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let receipt =
@@ -374,12 +300,7 @@ async fn the_new_admin_can_grant_roles(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -411,12 +332,7 @@ async fn the_new_admin_can_revoke_roles(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -449,12 +365,7 @@ async fn error_when_previous_admin_grants_roles(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -483,12 +394,7 @@ async fn error_when_previous_admin_revokes_roles(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();

--- a/examples/access-control/tests/access_control.rs
+++ b/examples/access-control/tests/access_control.rs
@@ -6,8 +6,8 @@ use abi::AccessControl::{
 };
 use alloy::{hex, network::ReceiptResponse, sol_types::SolConstructor};
 use e2e::{
-    deploy, receipt, send, watch, Account, ContractDeployer, EventExt,
-    ReceiptExt, Revert,
+    receipt, send, watch, Account, ContractDeployer, EventExt, ReceiptExt,
+    Revert,
 };
 use eyre::{ContextCompat, Result};
 
@@ -21,8 +21,8 @@ const ROLE: [u8; 32] = access_control_example::TRANSFER_ROLE;
 const NEW_ADMIN_ROLE: [u8; 32] =
     hex!("879ce0d4bfd332649ca3552efe772a38d64a315eb70ab69689fd309c735946b5");
 
-fn constructor() -> Option<constructorCall> {
-    Some(constructorCall {})
+fn ctr() -> constructorCall {
+    constructorCall {}
 }
 
 // ============================================================================
@@ -32,7 +32,7 @@ fn constructor() -> Option<constructorCall> {
 #[e2e::test]
 async fn constructs(alice: Account) -> Result<()> {
     let alice_addr = alice.address();
-    let receipt = deploy(&alice, constructor()).await?;
+    let receipt = alice.as_deployer().with_constructor(ctr()).deploy().await?;
     let contract = AccessControl::new(receipt.address()?, &alice.wallet);
 
     assert!(receipt.emits(RoleGranted {
@@ -52,7 +52,12 @@ async fn constructs(alice: Account) -> Result<()> {
 async fn other_roles_admin_is_the_default_admin_role(
     alice: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let AccessControl::getRoleAdminReturn { role } =
@@ -64,7 +69,12 @@ async fn other_roles_admin_is_the_default_admin_role(
 
 #[e2e::test]
 async fn default_role_is_default_admin(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let AccessControl::getRoleAdminReturn { role } =
@@ -83,7 +93,12 @@ async fn error_when_non_admin_grants_role(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &bob.wallet);
 
     let err = send!(contract.grantRole(ROLE.into(), alice.address()))
@@ -103,7 +118,12 @@ async fn accounts_can_be_granted_roles_multiple_times(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -128,7 +148,12 @@ async fn accounts_can_be_granted_roles_multiple_times(
 #[e2e::test]
 async fn not_granted_roles_can_be_revoked(alice: Account) -> Result<()> {
     let alice_addr = alice.address();
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let AccessControl::hasRoleReturn { hasRole } =
@@ -147,7 +172,12 @@ async fn not_granted_roles_can_be_revoked(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn admin_can_revoke_role(alice: Account, bob: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -170,7 +200,12 @@ async fn error_when_non_admin_revokes_role(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -194,7 +229,12 @@ async fn roles_can_be_revoked_multiple_times(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -214,7 +254,12 @@ async fn roles_can_be_revoked_multiple_times(
 #[e2e::test]
 async fn not_granted_roles_can_be_renounced(alice: Account) -> Result<()> {
     let alice_addr = alice.address();
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let receipt = receipt!(contract.renounceRole(ROLE.into(), alice_addr))?;
@@ -230,7 +275,12 @@ async fn not_granted_roles_can_be_renounced(alice: Account) -> Result<()> {
 #[e2e::test]
 async fn bearer_can_renounce_role(alice: Account, bob: Account) -> Result<()> {
     let bob_addr = bob.address();
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let _ = watch!(contract.grantRole(ROLE.into(), bob_addr))?;
@@ -251,7 +301,12 @@ async fn error_when_the_one_renouncing_is_not_the_sender(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -270,7 +325,12 @@ async fn error_when_the_one_renouncing_is_not_the_sender(
 #[e2e::test]
 async fn roles_can_be_renounced_multiple_times(alice: Account) -> Result<()> {
     let alice_addr = alice.address();
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let _ = watch!(contract.renounceRole(ROLE.into(), alice_addr))?;
@@ -286,7 +346,12 @@ async fn roles_can_be_renounced_multiple_times(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn a_roles_admin_role_can_change(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let receipt =
@@ -309,7 +374,12 @@ async fn the_new_admin_can_grant_roles(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -341,7 +411,12 @@ async fn the_new_admin_can_revoke_roles(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -374,7 +449,12 @@ async fn error_when_previous_admin_grants_roles(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -403,7 +483,12 @@ async fn error_when_previous_admin_revokes_roles(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = AccessControl::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();

--- a/examples/access-control/tests/access_control.rs
+++ b/examples/access-control/tests/access_control.rs
@@ -4,10 +4,7 @@ use abi::AccessControl::{
     self, AccessControlBadConfirmation, AccessControlUnauthorizedAccount,
     RoleAdminChanged, RoleGranted, RoleRevoked,
 };
-use alloy::{
-    hex, network::ReceiptResponse, primitives::Address,
-    rpc::types::TransactionReceipt, sol_types::SolConstructor,
-};
+use alloy::{hex, network::ReceiptResponse, sol_types::SolConstructor};
 use e2e::{
     deploy, receipt, send, watch, Account, EventExt, ReceiptExt, Revert,
 };

--- a/examples/ecdsa/tests/ecdsa.rs
+++ b/examples/ecdsa/tests/ecdsa.rs
@@ -3,21 +3,22 @@
 use abi::ECDSA;
 use alloy::{
     primitives::{address, b256, uint, Address, B256},
+    rpc::types::TransactionReceipt,
     sol,
     sol_types::SolConstructor,
 };
-use e2e::{Account, ReceiptExt, Revert};
+use e2e::{deploy, Account, ReceiptExt, Revert};
 use eyre::Result;
 use openzeppelin_stylus::utils::cryptography::ecdsa::SIGNATURE_S_UPPER_BOUND;
+
+use crate::ECDSAExample::constructorCall;
 
 mod abi;
 
 sol!("src/constructor.sol");
 
-async fn deploy(account: &Account) -> eyre::Result<Address> {
-    let args = ECDSAExample::constructorCall {};
-    let args = alloy::hex::encode(args.abi_encode());
-    e2e::deploy(account.url(), &account.pk(), Some(args)).await?.address()
+fn constructor() -> Option<constructorCall> {
+    Some(constructorCall {})
 }
 
 const HASH: B256 =
@@ -37,7 +38,7 @@ const ADDRESS: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
 #[e2e::test]
 async fn ecrecover_works(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice).await?;
+    let contract_addr = deploy(&alice, constructor()).await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let ECDSA::recoverReturn { recovered } =
@@ -52,7 +53,7 @@ async fn ecrecover_works(alice: Account) -> Result<()> {
 async fn different_hash_recovers_different_address(
     alice: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice).await?;
+    let contract_addr = deploy(&alice, constructor()).await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let hash = b256!(
@@ -68,7 +69,7 @@ async fn different_hash_recovers_different_address(
 
 #[e2e::test]
 async fn different_v_recovers_different_address(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice).await?;
+    let contract_addr = deploy(&alice, constructor()).await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let v = 27;
@@ -83,7 +84,7 @@ async fn different_v_recovers_different_address(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn different_r_recovers_different_address(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice).await?;
+    let contract_addr = deploy(&alice, constructor()).await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let r = b256!(
@@ -100,7 +101,7 @@ async fn different_r_recovers_different_address(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn different_s_recovers_different_address(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice).await?;
+    let contract_addr = deploy(&alice, constructor()).await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let s = b256!(
@@ -116,7 +117,7 @@ async fn different_s_recovers_different_address(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn recovers_from_v_r_s(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice).await?;
+    let contract_addr = deploy(&alice, constructor()).await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let signature = alice.sign_hash(&HASH).await;
@@ -141,7 +142,7 @@ async fn recovers_from_v_r_s(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn rejects_v0_with_invalid_signature_error(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice).await?;
+    let contract_addr = deploy(&alice, constructor()).await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let wrong_v = 0;
@@ -158,7 +159,7 @@ async fn rejects_v0_with_invalid_signature_error(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn rejects_v1_with_invalid_signature_error(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice).await?;
+    let contract_addr = deploy(&alice, constructor()).await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let wrong_v = 0;
@@ -175,7 +176,7 @@ async fn rejects_v1_with_invalid_signature_error(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn error_when_higher_s(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice).await?;
+    let contract_addr = deploy(&alice, constructor()).await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let higher_s = SIGNATURE_S_UPPER_BOUND + uint!(1_U256);

--- a/examples/ecdsa/tests/ecdsa.rs
+++ b/examples/ecdsa/tests/ecdsa.rs
@@ -3,7 +3,6 @@
 use abi::ECDSA;
 use alloy::{
     primitives::{address, b256, uint, Address, B256},
-    rpc::types::TransactionReceipt,
     sol,
     sol_types::SolConstructor,
 };

--- a/examples/ecdsa/tests/ecdsa.rs
+++ b/examples/ecdsa/tests/ecdsa.rs
@@ -6,7 +6,7 @@ use alloy::{
     sol,
     sol_types::SolConstructor,
 };
-use e2e::{deploy, Account, ReceiptExt, Revert};
+use e2e::{Account, ContractDeployer, ReceiptExt, Revert};
 use eyre::Result;
 use openzeppelin_stylus::utils::cryptography::ecdsa::SIGNATURE_S_UPPER_BOUND;
 
@@ -16,8 +16,8 @@ mod abi;
 
 sol!("src/constructor.sol");
 
-fn constructor() -> Option<constructorCall> {
-    Some(constructorCall {})
+fn ctr() -> constructorCall {
+    constructorCall {}
 }
 
 const HASH: B256 =
@@ -37,7 +37,12 @@ const ADDRESS: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
 #[e2e::test]
 async fn ecrecover_works(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let ECDSA::recoverReturn { recovered } =
@@ -52,7 +57,12 @@ async fn ecrecover_works(alice: Account) -> Result<()> {
 async fn different_hash_recovers_different_address(
     alice: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let hash = b256!(
@@ -68,7 +78,12 @@ async fn different_hash_recovers_different_address(
 
 #[e2e::test]
 async fn different_v_recovers_different_address(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let v = 27;
@@ -83,7 +98,12 @@ async fn different_v_recovers_different_address(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn different_r_recovers_different_address(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let r = b256!(
@@ -100,7 +120,12 @@ async fn different_r_recovers_different_address(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn different_s_recovers_different_address(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let s = b256!(
@@ -116,7 +141,12 @@ async fn different_s_recovers_different_address(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn recovers_from_v_r_s(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let signature = alice.sign_hash(&HASH).await;
@@ -141,7 +171,12 @@ async fn recovers_from_v_r_s(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn rejects_v0_with_invalid_signature_error(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let wrong_v = 0;
@@ -158,7 +193,12 @@ async fn rejects_v0_with_invalid_signature_error(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn rejects_v1_with_invalid_signature_error(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let wrong_v = 0;
@@ -175,7 +215,12 @@ async fn rejects_v1_with_invalid_signature_error(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn error_when_higher_s(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let higher_s = SIGNATURE_S_UPPER_BOUND + uint!(1_U256);

--- a/examples/ecdsa/tests/ecdsa.rs
+++ b/examples/ecdsa/tests/ecdsa.rs
@@ -1,24 +1,12 @@
 #![cfg(feature = "e2e")]
 
 use abi::ECDSA;
-use alloy::{
-    primitives::{address, b256, uint, Address, B256},
-    sol,
-    sol_types::SolConstructor,
-};
-use e2e::{Account, ContractDeployer, ReceiptExt, Revert};
+use alloy::primitives::{address, b256, uint, Address, B256};
+use e2e::{Account, ReceiptExt, Revert};
 use eyre::Result;
 use openzeppelin_stylus::utils::cryptography::ecdsa::SIGNATURE_S_UPPER_BOUND;
 
-use crate::ECDSAExample::constructorCall;
-
 mod abi;
-
-sol!("src/constructor.sol");
-
-fn ctr() -> constructorCall {
-    constructorCall {}
-}
 
 const HASH: B256 =
     b256!("a1de988600a42c4b4ab089b619297c17d53cffae5d5120d82d8a92d0bb3b78f2");
@@ -37,12 +25,7 @@ const ADDRESS: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
 
 #[e2e::test]
 async fn ecrecover_works(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let ECDSA::recoverReturn { recovered } =
@@ -57,12 +40,7 @@ async fn ecrecover_works(alice: Account) -> Result<()> {
 async fn different_hash_recovers_different_address(
     alice: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let hash = b256!(
@@ -78,12 +56,7 @@ async fn different_hash_recovers_different_address(
 
 #[e2e::test]
 async fn different_v_recovers_different_address(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let v = 27;
@@ -98,12 +71,7 @@ async fn different_v_recovers_different_address(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn different_r_recovers_different_address(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let r = b256!(
@@ -120,12 +88,7 @@ async fn different_r_recovers_different_address(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn different_s_recovers_different_address(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let s = b256!(
@@ -141,12 +104,7 @@ async fn different_s_recovers_different_address(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn recovers_from_v_r_s(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let signature = alice.sign_hash(&HASH).await;
@@ -171,12 +129,7 @@ async fn recovers_from_v_r_s(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn rejects_v0_with_invalid_signature_error(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let wrong_v = 0;
@@ -193,12 +146,7 @@ async fn rejects_v0_with_invalid_signature_error(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn rejects_v1_with_invalid_signature_error(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let wrong_v = 0;
@@ -215,12 +163,7 @@ async fn rejects_v1_with_invalid_signature_error(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn error_when_higher_s(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = ECDSA::new(contract_addr, &alice.wallet);
 
     let higher_s = SIGNATURE_S_UPPER_BOUND + uint!(1_U256);

--- a/examples/erc20-permit/tests/erc20permit.rs
+++ b/examples/erc20-permit/tests/erc20permit.rs
@@ -4,20 +4,13 @@ use abi::Erc20Permit;
 use alloy::{
     primitives::{b256, keccak256, Address, B256, U256},
     sol,
-    sol_types::{SolConstructor, SolType},
+    sol_types::SolType,
 };
 use alloy_primitives::uint;
-use e2e::{
-    receipt, send, watch, Account, ContractDeployer, EventExt, ReceiptExt,
-    Revert,
-};
+use e2e::{receipt, send, watch, Account, EventExt, ReceiptExt, Revert};
 use eyre::Result;
 
-use crate::Erc20PermitExample::constructorCall;
-
 mod abi;
-
-sol!("src/constructor.sol");
 
 // Saturday, 1 January 2000 00:00:00
 const EXPIRED_DEADLINE: U256 = uint!(946_684_800_U256);
@@ -43,10 +36,6 @@ macro_rules! domain_separator {
             .expect("should return `DOMAIN_SEPARATOR`");
         B256::from_slice(domainSeparator.as_slice())
     }};
-}
-
-fn ctr() -> constructorCall {
-    constructorCall {}
 }
 
 fn to_typed_data_hash(domain_separator: B256, struct_hash: B256) -> B256 {
@@ -85,12 +74,7 @@ async fn error_when_expired_deadline_for_permit(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let bob_addr = bob.address();
@@ -133,12 +117,7 @@ async fn error_when_expired_deadline_for_permit(
 
 #[e2e::test]
 async fn permit_works(alice: Account, bob: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let bob_addr = bob.address();
@@ -229,12 +208,7 @@ async fn permit_rejects_reused_signature(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let bob_addr = bob.address();
@@ -309,12 +283,7 @@ async fn permit_rejects_invalid_signature(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let bob_addr = bob.address();
@@ -363,12 +332,7 @@ async fn permit_rejects_invalid_signature(
 
 #[e2e::test]
 async fn constructs(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc20Permit::new(contract_addr, &alice.wallet);
 
     let Erc20Permit::totalSupplyReturn { totalSupply: total_supply } =
@@ -380,12 +344,7 @@ async fn constructs(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn mints(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
 
@@ -417,12 +376,7 @@ async fn mints(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn mints_rejects_invalid_receiver(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc20Permit::new(contract_addr, &alice.wallet);
     let invalid_receiver = Address::ZERO;
 
@@ -450,12 +404,7 @@ async fn mints_rejects_invalid_receiver(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn transfers(alice: Account, bob: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let bob_addr = bob.address();
@@ -499,12 +448,7 @@ async fn transfer_rejects_insufficient_balance(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let bob_addr = bob.address();
@@ -545,12 +489,7 @@ async fn transfer_rejects_insufficient_balance(
 
 #[e2e::test]
 async fn transfer_rejects_invalid_receiver(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let invalid_receiver = Address::ZERO;
@@ -589,12 +528,7 @@ async fn transfer_rejects_invalid_receiver(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn approves(alice: Account, bob: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let bob_addr = bob.address();
@@ -661,12 +595,7 @@ async fn approves(alice: Account, bob: Account) -> Result<()> {
 
 #[e2e::test]
 async fn approve_rejects_invalid_spender(alice: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let invalid_spender = Address::ZERO;
@@ -718,12 +647,7 @@ async fn approve_rejects_invalid_spender(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn transfers_from(alice: Account, bob: Account) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let contract_bob = Erc20Permit::new(contract_addr, &bob.wallet);
 
@@ -778,12 +702,7 @@ async fn transfer_from_reverts_insufficient_balance(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let contract_bob = Erc20Permit::new(contract_addr, &bob.wallet);
 
@@ -838,12 +757,7 @@ async fn transfer_from_rejects_insufficient_allowance(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let contract_bob = Erc20Permit::new(contract_addr, &bob.wallet);
 
@@ -898,12 +812,7 @@ async fn transfer_from_rejects_invalid_receiver(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let contract_bob = Erc20Permit::new(contract_addr, &bob.wallet);
 

--- a/examples/erc20-permit/tests/erc20permit.rs
+++ b/examples/erc20-permit/tests/erc20permit.rs
@@ -3,13 +3,13 @@
 use abi::Erc20Permit;
 use alloy::{
     primitives::{b256, keccak256, Address, B256, U256},
-    rpc::types::TransactionReceipt,
     sol,
     sol_types::{SolConstructor, SolType},
 };
 use alloy_primitives::uint;
 use e2e::{
-    deploy, receipt, send, watch, Account, EventExt, ReceiptExt, Revert,
+    receipt, send, watch, Account, ContractDeployer, EventExt, ReceiptExt,
+    Revert,
 };
 use eyre::Result;
 
@@ -45,8 +45,8 @@ macro_rules! domain_separator {
     }};
 }
 
-fn constructor() -> Option<constructorCall> {
-    Some(constructorCall {})
+fn ctr() -> constructorCall {
+    constructorCall {}
 }
 
 fn to_typed_data_hash(domain_separator: B256, struct_hash: B256) -> B256 {
@@ -85,7 +85,12 @@ async fn error_when_expired_deadline_for_permit(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let bob_addr = bob.address();
@@ -128,7 +133,12 @@ async fn error_when_expired_deadline_for_permit(
 
 #[e2e::test]
 async fn permit_works(alice: Account, bob: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let bob_addr = bob.address();
@@ -219,7 +229,12 @@ async fn permit_rejects_reused_signature(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let bob_addr = bob.address();
@@ -294,7 +309,12 @@ async fn permit_rejects_invalid_signature(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let bob_addr = bob.address();
@@ -343,7 +363,12 @@ async fn permit_rejects_invalid_signature(
 
 #[e2e::test]
 async fn constructs(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc20Permit::new(contract_addr, &alice.wallet);
 
     let Erc20Permit::totalSupplyReturn { totalSupply: total_supply } =
@@ -355,7 +380,12 @@ async fn constructs(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn mints(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
 
@@ -387,7 +417,12 @@ async fn mints(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn mints_rejects_invalid_receiver(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc20Permit::new(contract_addr, &alice.wallet);
     let invalid_receiver = Address::ZERO;
 
@@ -415,7 +450,12 @@ async fn mints_rejects_invalid_receiver(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn transfers(alice: Account, bob: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let bob_addr = bob.address();
@@ -459,7 +499,12 @@ async fn transfer_rejects_insufficient_balance(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let bob_addr = bob.address();
@@ -500,7 +545,12 @@ async fn transfer_rejects_insufficient_balance(
 
 #[e2e::test]
 async fn transfer_rejects_invalid_receiver(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let invalid_receiver = Address::ZERO;
@@ -539,7 +589,12 @@ async fn transfer_rejects_invalid_receiver(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn approves(alice: Account, bob: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let bob_addr = bob.address();
@@ -606,7 +661,12 @@ async fn approves(alice: Account, bob: Account) -> Result<()> {
 
 #[e2e::test]
 async fn approve_rejects_invalid_spender(alice: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc20Permit::new(contract_addr, &alice.wallet);
     let alice_addr = alice.address();
     let invalid_spender = Address::ZERO;
@@ -658,7 +718,12 @@ async fn approve_rejects_invalid_spender(alice: Account) -> Result<()> {
 
 #[e2e::test]
 async fn transfers_from(alice: Account, bob: Account) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let contract_bob = Erc20Permit::new(contract_addr, &bob.wallet);
 
@@ -713,7 +778,12 @@ async fn transfer_from_reverts_insufficient_balance(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let contract_bob = Erc20Permit::new(contract_addr, &bob.wallet);
 
@@ -768,7 +838,12 @@ async fn transfer_from_rejects_insufficient_allowance(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let contract_bob = Erc20Permit::new(contract_addr, &bob.wallet);
 
@@ -823,7 +898,12 @@ async fn transfer_from_rejects_invalid_receiver(
     alice: Account,
     bob: Account,
 ) -> Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc20Permit::new(contract_addr, &alice.wallet);
     let contract_bob = Erc20Permit::new(contract_addr, &bob.wallet);
 

--- a/examples/erc20/tests/erc20.rs
+++ b/examples/erc20/tests/erc20.rs
@@ -2,17 +2,15 @@
 
 use abi::Erc20;
 use alloy::{
-    network::ReceiptResponse,
     primitives::{Address, U256},
     sol,
-    sol_types::{SolConstructor, SolError},
 };
 use alloy_primitives::uint;
 use e2e::{
-    receipt, send, watch, Account, ContractDeployer, EventExt, Panic,
-    PanicCode, ReceiptExt, Revert,
+    receipt, send, watch, Account, EventExt, Panic, PanicCode, ReceiptExt,
+    Revert,
 };
-use eyre::{ContextCompat, Result};
+use eyre::Result;
 
 use crate::Erc20Example::constructorCall;
 
@@ -24,11 +22,21 @@ const TOKEN_NAME: &str = "Test Token";
 const TOKEN_SYMBOL: &str = "TTK";
 const CAP: U256 = uint!(1_000_000_U256);
 
-fn ctr(cap: Option<U256>) -> constructorCall {
+impl Default for constructorCall {
+    fn default() -> Self {
+        constructorCall {
+            name_: TOKEN_NAME.to_owned(),
+            symbol_: TOKEN_SYMBOL.to_owned(),
+            cap_: CAP,
+        }
+    }
+}
+
+fn ctr(cap: U256) -> constructorCall {
     Erc20Example::constructorCall {
         name_: TOKEN_NAME.to_owned(),
         symbol_: TOKEN_SYMBOL.to_owned(),
-        cap_: cap.unwrap_or(CAP),
+        cap_: cap,
     }
 }
 
@@ -40,7 +48,7 @@ fn ctr(cap: Option<U256>) -> constructorCall {
 async fn constructs(alice: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -65,7 +73,7 @@ async fn constructs(alice: Account) -> Result<()> {
 async fn mints(alice: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -102,7 +110,7 @@ async fn mints(alice: Account) -> Result<()> {
 async fn mints_rejects_invalid_receiver(alice: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -137,7 +145,7 @@ async fn mints_rejects_overflow(alice: Account) -> Result<()> {
 
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(Some(max_cap)))
+        .with_constructor(ctr(max_cap))
         .deploy()
         .await?
         .address()?;
@@ -175,7 +183,7 @@ async fn mints_rejects_overflow(alice: Account) -> Result<()> {
 async fn transfers(alice: Account, bob: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -224,7 +232,7 @@ async fn transfer_rejects_insufficient_balance(
 ) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -270,7 +278,7 @@ async fn transfer_rejects_insufficient_balance(
 async fn transfer_rejects_invalid_receiver(alice: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -314,7 +322,7 @@ async fn transfer_rejects_invalid_receiver(alice: Account) -> Result<()> {
 async fn approves(alice: Account, bob: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -386,7 +394,7 @@ async fn approves(alice: Account, bob: Account) -> Result<()> {
 async fn approve_rejects_invalid_spender(alice: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -441,7 +449,7 @@ async fn approve_rejects_invalid_spender(alice: Account) -> Result<()> {
 async fn transfers_from(alice: Account, bob: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -501,7 +509,7 @@ async fn transfer_from_reverts_insufficient_balance(
 ) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -561,7 +569,7 @@ async fn transfer_from_rejects_insufficient_allowance(
 ) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -621,7 +629,7 @@ async fn transfer_from_rejects_invalid_receiver(
 ) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -682,7 +690,7 @@ async fn transfer_from_rejects_invalid_receiver(
 async fn burns(alice: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -722,7 +730,7 @@ async fn burns(alice: Account) -> Result<()> {
 async fn burn_rejects_insufficient_balance(alice: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -762,7 +770,7 @@ async fn burn_rejects_insufficient_balance(alice: Account) -> Result<()> {
 async fn burns_from(alice: Account, bob: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -821,7 +829,7 @@ async fn burn_from_reverts_insufficient_balance(
 ) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -881,7 +889,7 @@ async fn burn_from_rejects_insufficient_allowance(
 ) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -942,7 +950,7 @@ async fn burn_from_rejects_insufficient_allowance(
 async fn mint_rejects_exceeding_cap(alice: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -983,7 +991,7 @@ async fn mint_rejects_exceeding_cap(alice: Account) -> Result<()> {
 async fn mint_rejects_when_cap_reached(alice: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -1026,7 +1034,7 @@ async fn should_not_deploy_capped_with_invalid_cap(
     let invalid_cap = U256::ZERO;
     let err = alice
         .as_deployer()
-        .with_constructor(ctr(Some(invalid_cap)))
+        .with_constructor(ctr(invalid_cap))
         .deploy()
         .await
         .expect_err("should not deploy due to `ERC20InvalidCap`");
@@ -1044,7 +1052,7 @@ async fn should_not_deploy_capped_with_invalid_cap(
 async fn pauses(alice: Account) -> eyre::Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -1077,7 +1085,7 @@ async fn pauses(alice: Account) -> eyre::Result<()> {
 async fn unpauses(alice: Account) -> eyre::Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -1112,7 +1120,7 @@ async fn unpauses(alice: Account) -> eyre::Result<()> {
 async fn error_when_burn_in_paused_state(alice: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -1153,7 +1161,7 @@ async fn error_when_burn_from_in_paused_state(
 ) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -1207,7 +1215,7 @@ async fn error_when_burn_from_in_paused_state(
 async fn error_when_mint_in_paused_state(alice: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -1245,7 +1253,7 @@ async fn error_when_transfer_in_paused_state(
 ) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;
@@ -1288,7 +1296,7 @@ async fn error_when_transfer_in_paused_state(
 async fn error_when_transfer_from(alice: Account, bob: Account) -> Result<()> {
     let contract_addr = alice
         .as_deployer()
-        .with_constructor(ctr(None))
+        .with_default_constructor::<constructorCall>()
         .deploy()
         .await?
         .address()?;

--- a/examples/erc20/tests/erc20.rs
+++ b/examples/erc20/tests/erc20.rs
@@ -930,25 +930,7 @@ async fn should_not_deploy_capped_with_invalid_cap(
         .await
         .expect_err("should not deploy due to `ERC20InvalidCap`");
 
-    // TODO#q: Improve error check for contract deployments.
-    // Issue: https://github.com/OpenZeppelin/rust-contracts-stylus/issues/128
-    // Requires strange casting
-    //  ErrorResp(
-    //      ErrorPayload {
-    //          code: 3,
-    //          message: \"execution reverted\",
-    //          data: Some(
-    //              RawValue(
-    //                  \"0x...\",
-    //              ),
-    //          ),
-    //      },
-    //  )
-    let err_string = format!("{:#?}", err);
-    let expected = Erc20::ERC20InvalidCap { cap: invalid_cap };
-    let expected = alloy::hex::encode(expected.abi_encode());
-
-    assert!(err_string.contains(&expected));
+    assert!(err.reverted_with(Erc20::ERC20InvalidCap { cap: invalid_cap }));
     Ok(())
 }
 

--- a/examples/erc20/tests/erc20.rs
+++ b/examples/erc20/tests/erc20.rs
@@ -24,11 +24,7 @@ const CAP: U256 = uint!(1_000_000_U256);
 
 impl Default for constructorCall {
     fn default() -> Self {
-        constructorCall {
-            name_: TOKEN_NAME.to_owned(),
-            symbol_: TOKEN_SYMBOL.to_owned(),
-            cap_: CAP,
-        }
+        ctr(CAP)
     }
 }
 

--- a/examples/erc20/tests/erc20.rs
+++ b/examples/erc20/tests/erc20.rs
@@ -4,7 +4,6 @@ use abi::Erc20;
 use alloy::{
     network::ReceiptResponse,
     primitives::{Address, U256},
-    rpc::types::TransactionReceipt,
     sol,
     sol_types::{SolConstructor, SolError},
 };

--- a/examples/erc721-consecutive/tests/erc721-consecutive.rs
+++ b/examples/erc721-consecutive/tests/erc721-consecutive.rs
@@ -7,7 +7,7 @@ use alloy::{
     sol_types::SolConstructor,
 };
 use alloy_primitives::uint;
-use e2e::{receipt, watch, Account, EventExt, ReceiptExt, Revert};
+use e2e::{deploy, receipt, watch, Account, EventExt, ReceiptExt, Revert};
 
 use crate::{abi::Erc721, Erc721ConsecutiveExample::constructorCall};
 
@@ -23,21 +23,16 @@ fn random_token_id() -> U256 {
     U256::from(num)
 }
 
-async fn deploy<C: SolConstructor>(
-    account: &Account,
-    constructor: C,
-) -> eyre::Result<TransactionReceipt> {
-    let args = alloy::hex::encode(constructor.abi_encode());
-    e2e::deploy(account.url(), &account.pk(), Some(args)).await
-}
-
-fn constructor(receivers: Vec<Address>, amounts: Vec<u128>) -> constructorCall {
-    constructorCall {
+fn constructor(
+    receivers: Vec<Address>,
+    amounts: Vec<u128>,
+) -> Option<constructorCall> {
+    Some(constructorCall {
         receivers,
         amounts,
         firstConsecutiveId: FIRST_CONSECUTIVE_ID,
         maxBatchSize: MAX_BATCH_SIZE,
-    }
+    })
 }
 
 #[e2e::test]

--- a/examples/erc721-consecutive/tests/erc721-consecutive.rs
+++ b/examples/erc721-consecutive/tests/erc721-consecutive.rs
@@ -2,7 +2,6 @@
 
 use alloy::{
     primitives::{Address, U256},
-    rpc::types::TransactionReceipt,
     sol,
     sol_types::SolConstructor,
 };

--- a/examples/erc721-consecutive/tests/erc721-consecutive.rs
+++ b/examples/erc721-consecutive/tests/erc721-consecutive.rs
@@ -6,9 +6,7 @@ use alloy::{
     sol_types::SolConstructor,
 };
 use alloy_primitives::uint;
-use e2e::{
-    receipt, watch, Account, ContractDeployer, EventExt, ReceiptExt, Revert,
-};
+use e2e::{receipt, watch, Account, EventExt, ReceiptExt, Revert};
 
 use crate::{abi::Erc721, Erc721ConsecutiveExample::constructorCall};
 

--- a/examples/erc721-metadata/tests/erc721.rs
+++ b/examples/erc721-metadata/tests/erc721.rs
@@ -7,7 +7,10 @@ use alloy::{
     sol,
     sol_types::SolConstructor,
 };
-use e2e::{deploy, receipt, watch, Account, EventExt, ReceiptExt, Revert};
+use e2e::{
+    deploy, receipt, watch, Account, ContractDeployer, EventExt, ReceiptExt,
+    Revert,
+};
 use eyre::ContextCompat;
 
 use crate::Erc721MetadataExample::constructorCall;

--- a/examples/erc721-metadata/tests/erc721.rs
+++ b/examples/erc721-metadata/tests/erc721.rs
@@ -7,9 +7,7 @@ use alloy::{
     sol,
     sol_types::SolConstructor,
 };
-use e2e::{
-    receipt, watch, Account, ContractDeployer, EventExt, ReceiptExt, Revert,
-};
+use e2e::{receipt, watch, Account, EventExt, ReceiptExt, Revert};
 use eyre::ContextCompat;
 
 use crate::Erc721MetadataExample::constructorCall;

--- a/examples/erc721-metadata/tests/erc721.rs
+++ b/examples/erc721-metadata/tests/erc721.rs
@@ -8,8 +8,7 @@ use alloy::{
     sol_types::SolConstructor,
 };
 use e2e::{
-    deploy, receipt, watch, Account, ContractDeployer, EventExt, ReceiptExt,
-    Revert,
+    receipt, watch, Account, ContractDeployer, EventExt, ReceiptExt, Revert,
 };
 use eyre::ContextCompat;
 
@@ -27,12 +26,12 @@ fn random_token_id() -> U256 {
     U256::from(num)
 }
 
-fn constructor(base_uri: &str) -> Option<constructorCall> {
-    Some(constructorCall {
+fn ctr(base_uri: &str) -> constructorCall {
+    constructorCall {
         name_: TOKEN_NAME.to_owned(),
         symbol_: TOKEN_SYMBOL.to_owned(),
         baseUri_: base_uri.to_owned(),
-    })
+    }
 }
 
 // ============================================================================
@@ -43,8 +42,12 @@ fn constructor(base_uri: &str) -> Option<constructorCall> {
 async fn constructs(alice: Account) -> eyre::Result<()> {
     let base_uri = "";
 
-    let contract_addr =
-        deploy(&alice, constructor(base_uri)).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr(base_uri))
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let Erc721::nameReturn { name } = contract.name().call().await?;
@@ -62,8 +65,12 @@ async fn constructs(alice: Account) -> eyre::Result<()> {
 async fn constructs_with_base_uri(alice: Account) -> eyre::Result<()> {
     let base_uri = "https://github.com/OpenZeppelin/rust-contracts-stylus";
 
-    let contract_addr =
-        deploy(&alice, constructor(base_uri)).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr(base_uri))
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let Erc721::baseUriReturn { baseURI } = contract.baseUri().call().await?;
@@ -81,7 +88,12 @@ async fn constructs_with_base_uri(alice: Account) -> eyre::Result<()> {
 async fn error_when_checking_token_uri_for_nonexistent_token(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor("")).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr(""))
+        .deploy()
+        .await?
+        .address()?;
 
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
@@ -103,7 +115,12 @@ async fn error_when_checking_token_uri_for_nonexistent_token(
 async fn return_empty_token_uri_when_without_base_uri_and_token_uri(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor("")).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr(""))
+        .deploy()
+        .await?
+        .address()?;
 
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
@@ -125,8 +142,12 @@ async fn return_token_uri_with_base_uri_and_without_token_uri(
 ) -> eyre::Result<()> {
     let base_uri = "https://github.com/OpenZeppelin/rust-contracts-stylus/";
 
-    let contract_addr =
-        deploy(&alice, constructor(base_uri)).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr(base_uri))
+        .deploy()
+        .await?
+        .address()?;
 
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
@@ -147,8 +168,12 @@ async fn return_token_uri_with_base_uri_and_token_uri(
 ) -> eyre::Result<()> {
     let base_uri = "https://github.com/OpenZeppelin/rust-contracts-stylus/";
 
-    let contract_addr =
-        deploy(&alice, constructor(base_uri)).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr(base_uri))
+        .deploy()
+        .await?
+        .address()?;
 
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
@@ -176,8 +201,12 @@ async fn return_token_uri_with_base_uri_and_token_uri(
 async fn set_token_uri_before_mint(alice: Account) -> eyre::Result<()> {
     let base_uri = "https://github.com/OpenZeppelin/rust-contracts-stylus/";
 
-    let contract_addr =
-        deploy(&alice, constructor(base_uri)).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr(base_uri))
+        .deploy()
+        .await?
+        .address()?;
 
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
@@ -219,8 +248,12 @@ async fn return_token_uri_after_burn_and_remint(
 
     let alice_addr = alice.address();
 
-    let contract_addr =
-        deploy(&alice, constructor(base_uri)).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr(base_uri))
+        .deploy()
+        .await?
+        .address()?;
 
     let contract = Erc721::new(contract_addr, &alice.wallet);
 

--- a/examples/erc721-metadata/tests/erc721.rs
+++ b/examples/erc721-metadata/tests/erc721.rs
@@ -4,7 +4,6 @@ use abi::Erc721;
 use alloy::{
     network::ReceiptResponse,
     primitives::{Address, U256},
-    rpc::types::TransactionReceipt,
     sol,
     sol_types::SolConstructor,
 };

--- a/examples/erc721/tests/erc721.rs
+++ b/examples/erc721/tests/erc721.rs
@@ -3,7 +3,6 @@
 use abi::Erc721;
 use alloy::{
     primitives::{fixed_bytes, Address, Bytes, U256},
-    rpc::types::TransactionReceipt,
     sol,
     sol_types::SolConstructor,
 };

--- a/examples/erc721/tests/erc721.rs
+++ b/examples/erc721/tests/erc721.rs
@@ -8,7 +8,8 @@ use alloy::{
 };
 use alloy_primitives::uint;
 use e2e::{
-    deploy, receipt, send, watch, Account, EventExt, ReceiptExt, Revert,
+    receipt, send, watch, Account, ContractDeployer, EventExt, ReceiptExt,
+    Revert,
 };
 use mock::{receiver, receiver::ERC721ReceiverMock};
 
@@ -24,8 +25,8 @@ fn random_token_id() -> U256 {
     U256::from(num)
 }
 
-fn constructor() -> Option<constructorCall> {
-    Some(constructorCall {})
+fn ctr() -> constructorCall {
+    constructorCall {}
 }
 
 // ============================================================================
@@ -34,7 +35,12 @@ fn constructor() -> Option<constructorCall> {
 
 #[e2e::test]
 async fn constructs(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let Erc721::pausedReturn { paused } = contract.paused().call().await?;
@@ -48,7 +54,12 @@ async fn constructs(alice: Account) -> eyre::Result<()> {
 async fn error_when_checking_balance_of_invalid_owner(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
     let invalid_owner = Address::ZERO;
 
@@ -66,7 +77,12 @@ async fn error_when_checking_balance_of_invalid_owner(
 
 #[e2e::test]
 async fn balance_of_zero_balance(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let Erc721::balanceOfReturn { balance } =
@@ -80,7 +96,12 @@ async fn balance_of_zero_balance(alice: Account) -> eyre::Result<()> {
 async fn error_when_checking_owner_of_nonexistent_token(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
     let token_id = random_token_id();
 
@@ -99,7 +120,12 @@ async fn error_when_checking_owner_of_nonexistent_token(
 
 #[e2e::test]
 async fn mints(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -125,7 +151,12 @@ async fn mints(alice: Account) -> eyre::Result<()> {
 
 #[e2e::test]
 async fn error_when_minting_token_id_twice(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -144,7 +175,12 @@ async fn error_when_minting_token_id_twice(alice: Account) -> eyre::Result<()> {
 async fn error_when_minting_token_to_invalid_receiver(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let token_id = random_token_id();
@@ -161,7 +197,12 @@ async fn error_when_minting_token_to_invalid_receiver(
 
 #[e2e::test]
 async fn transfers_from(alice: Account, bob: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -206,7 +247,12 @@ async fn transfers_from_approved_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -254,7 +300,12 @@ async fn transfers_from_approved_for_all(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -301,7 +352,12 @@ async fn transfers_from_approved_for_all(
 async fn error_when_transfer_to_invalid_receiver(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -330,7 +386,12 @@ async fn error_when_transfer_from_incorrect_owner(
     bob: Account,
     dave: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -362,7 +423,12 @@ async fn error_when_transfer_with_insufficient_approval(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -391,7 +457,12 @@ async fn error_when_transfer_nonexistent_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -418,7 +489,12 @@ async fn error_when_transfer_nonexistent_token(
 
 #[e2e::test]
 async fn safe_transfers_from(alice: Account, bob: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -462,7 +538,12 @@ async fn safe_transfers_from(alice: Account, bob: Account) -> eyre::Result<()> {
 async fn safe_transfers_to_receiver_contract(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let receiver_address =
@@ -521,7 +602,12 @@ async fn safe_transfers_from_approved_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -570,7 +656,12 @@ async fn safe_transfers_from_approved_for_all(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -618,7 +709,12 @@ async fn safe_transfers_from_approved_for_all(
 async fn error_when_safe_transfer_to_invalid_receiver(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -650,7 +746,12 @@ async fn error_when_safe_transfer_from_incorrect_owner(
     bob: Account,
     dave: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -682,7 +783,12 @@ async fn error_when_safe_transfer_with_insufficient_approval(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -713,7 +819,12 @@ async fn error_when_safe_transfer_nonexistent_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -744,7 +855,12 @@ async fn safe_transfers_from_with_data(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -792,7 +908,12 @@ async fn safe_transfers_from_with_data(
 async fn safe_transfers_with_data_to_receiver_contract(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let receiver_address =
@@ -853,7 +974,12 @@ async fn safe_transfers_from_with_data_approved_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -905,7 +1031,12 @@ async fn safe_transfers_from_with_data_approved_for_all(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -956,7 +1087,12 @@ async fn safe_transfers_from_with_data_approved_for_all(
 async fn error_when_safe_transfer_with_data_to_invalid_receiver(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -989,7 +1125,12 @@ async fn error_when_safe_transfer_with_data_from_incorrect_owner(
     bob: Account,
     dave: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1026,7 +1167,12 @@ async fn error_when_safe_transfer_with_data_with_insufficient_approval(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1061,7 +1207,12 @@ async fn error_when_safe_transfer_with_data_nonexistent_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1098,7 +1249,12 @@ async fn error_when_safe_transfer_with_data_nonexistent_token(
 async fn errors_when_receiver_reverts_with_reason(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let receiver_address = receiver::deploy(
@@ -1129,7 +1285,12 @@ async fn errors_when_receiver_reverts_with_reason(
 async fn errors_when_receiver_reverts_without_reason(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let receiver_address = receiver::deploy(
@@ -1162,7 +1323,12 @@ async fn errors_when_receiver_reverts_without_reason(
 #[e2e::test]
 #[ignore]
 async fn errors_when_receiver_panics(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let receiver_address =
@@ -1190,7 +1356,12 @@ async fn errors_when_receiver_panics(alice: Account) -> eyre::Result<()> {
 
 #[e2e::test]
 async fn approves(alice: Account, bob: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1223,7 +1394,12 @@ async fn error_when_approve_for_nonexistent_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let bob_addr = bob.address();
@@ -1244,7 +1420,12 @@ async fn error_when_approve_by_invalid_approver(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -1272,7 +1453,12 @@ async fn error_when_approve_by_invalid_approver(
 async fn error_when_checking_approved_of_nonexistent_token(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let token_id = random_token_id();
@@ -1294,7 +1480,12 @@ async fn sets_approval_for_all(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1335,7 +1526,12 @@ async fn sets_approval_for_all(
 async fn error_when_set_approval_for_all_by_invalid_operator(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let invalid_operator = Address::ZERO;
@@ -1354,7 +1550,12 @@ async fn error_when_set_approval_for_all_by_invalid_operator(
 async fn is_approved_for_all_invalid_operator(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let invalid_operator = Address::ZERO;
@@ -1375,7 +1576,12 @@ async fn is_approved_for_all_invalid_operator(
 
 #[e2e::test]
 async fn pauses(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let receipt = receipt!(contract.pause())?;
@@ -1403,7 +1609,12 @@ async fn pauses(alice: Account) -> eyre::Result<()> {
 
 #[e2e::test]
 async fn unpauses(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let _ = watch!(contract.pause())?;
@@ -1433,7 +1644,12 @@ async fn unpauses(alice: Account) -> eyre::Result<()> {
 
 #[e2e::test]
 async fn error_when_burn_in_paused_state(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1464,7 +1680,12 @@ async fn error_when_burn_in_paused_state(alice: Account) -> eyre::Result<()> {
 
 #[e2e::test]
 async fn error_when_mint_in_paused_state(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1498,7 +1719,12 @@ async fn error_when_transfer_in_paused_state(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1539,7 +1765,12 @@ async fn error_when_safe_transfer_in_paused_state(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1581,7 +1812,12 @@ async fn error_when_safe_transfer_with_data_in_paused_state(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1628,7 +1864,12 @@ async fn error_when_safe_transfer_with_data_in_paused_state(
 
 #[e2e::test]
 async fn burns(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1669,7 +1910,12 @@ async fn burns_approved_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -1714,7 +1960,12 @@ async fn burns_approved_for_all(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -1759,7 +2010,12 @@ async fn error_when_burn_with_insufficient_approval(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1789,7 +2045,12 @@ async fn error_when_burn_with_insufficient_approval(
 
 #[e2e::test]
 async fn error_when_burn_nonexistent_token(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let token_id = random_token_id();
@@ -1808,7 +2069,12 @@ async fn error_when_burn_nonexistent_token(alice: Account) -> eyre::Result<()> {
 
 #[e2e::test]
 async fn totally_supply_works(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1831,7 +2097,12 @@ async fn totally_supply_works(alice: Account) -> eyre::Result<()> {
 async fn error_when_checking_token_of_owner_by_index_out_of_bound(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1859,7 +2130,12 @@ async fn error_when_checking_token_of_owner_by_index_out_of_bound(
 async fn error_when_checking_token_of_owner_by_index_account_has_no_tokens(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1882,7 +2158,12 @@ async fn error_when_checking_token_of_owner_by_index_account_has_no_tokens(
 
 #[e2e::test]
 async fn token_of_owner_by_index_works(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1909,7 +2190,12 @@ async fn token_of_owner_by_index_after_transfer_to_another_account(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1965,7 +2251,12 @@ async fn token_of_owner_by_index_after_transfer_to_another_account(
 async fn error_when_checking_token_by_index_account_has_no_tokens(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let index = uint!(0_U256);
@@ -1988,7 +2279,12 @@ async fn error_when_checking_token_by_index_account_has_no_tokens(
 async fn error_when_checking_token_by_index_out_of_bound(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -2014,7 +2310,12 @@ async fn error_when_checking_token_by_index_out_of_bound(
 
 #[e2e::test]
 async fn token_by_index_works(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -2038,7 +2339,12 @@ async fn token_by_index_works(alice: Account) -> eyre::Result<()> {
 
 #[e2e::test]
 async fn token_by_index_after_burn(alice: Account) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -2079,7 +2385,12 @@ async fn token_by_index_after_burn(alice: Account) -> eyre::Result<()> {
 async fn token_by_index_after_burn_and_some_mints(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = deploy(&alice, constructor()).await?.address()?;
+    let contract_addr = alice
+        .as_deployer()
+        .with_constructor(ctr())
+        .deploy()
+        .await?
+        .address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();

--- a/examples/erc721/tests/erc721.rs
+++ b/examples/erc721/tests/erc721.rs
@@ -1,32 +1,17 @@
 #![cfg(feature = "e2e")]
 
 use abi::Erc721;
-use alloy::{
-    primitives::{fixed_bytes, Address, Bytes, U256},
-    sol,
-    sol_types::SolConstructor,
-};
+use alloy::primitives::{fixed_bytes, Address, Bytes, U256};
 use alloy_primitives::uint;
-use e2e::{
-    receipt, send, watch, Account, ContractDeployer, EventExt, ReceiptExt,
-    Revert,
-};
+use e2e::{receipt, send, watch, Account, EventExt, ReceiptExt, Revert};
 use mock::{receiver, receiver::ERC721ReceiverMock};
-
-use crate::Erc721Example::constructorCall;
 
 mod abi;
 mod mock;
 
-sol!("src/constructor.sol");
-
 fn random_token_id() -> U256 {
     let num: u32 = rand::random();
     U256::from(num)
-}
-
-fn ctr() -> constructorCall {
-    constructorCall {}
 }
 
 // ============================================================================
@@ -35,12 +20,7 @@ fn ctr() -> constructorCall {
 
 #[e2e::test]
 async fn constructs(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let Erc721::pausedReturn { paused } = contract.paused().call().await?;
@@ -54,12 +34,7 @@ async fn constructs(alice: Account) -> eyre::Result<()> {
 async fn error_when_checking_balance_of_invalid_owner(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
     let invalid_owner = Address::ZERO;
 
@@ -77,12 +52,7 @@ async fn error_when_checking_balance_of_invalid_owner(
 
 #[e2e::test]
 async fn balance_of_zero_balance(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let Erc721::balanceOfReturn { balance } =
@@ -96,12 +66,7 @@ async fn balance_of_zero_balance(alice: Account) -> eyre::Result<()> {
 async fn error_when_checking_owner_of_nonexistent_token(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
     let token_id = random_token_id();
 
@@ -120,12 +85,7 @@ async fn error_when_checking_owner_of_nonexistent_token(
 
 #[e2e::test]
 async fn mints(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -151,12 +111,7 @@ async fn mints(alice: Account) -> eyre::Result<()> {
 
 #[e2e::test]
 async fn error_when_minting_token_id_twice(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -175,12 +130,7 @@ async fn error_when_minting_token_id_twice(alice: Account) -> eyre::Result<()> {
 async fn error_when_minting_token_to_invalid_receiver(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let token_id = random_token_id();
@@ -197,12 +147,7 @@ async fn error_when_minting_token_to_invalid_receiver(
 
 #[e2e::test]
 async fn transfers_from(alice: Account, bob: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -247,12 +192,7 @@ async fn transfers_from_approved_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -300,12 +240,7 @@ async fn transfers_from_approved_for_all(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -352,12 +287,7 @@ async fn transfers_from_approved_for_all(
 async fn error_when_transfer_to_invalid_receiver(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -386,12 +316,7 @@ async fn error_when_transfer_from_incorrect_owner(
     bob: Account,
     dave: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -423,12 +348,7 @@ async fn error_when_transfer_with_insufficient_approval(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -457,12 +377,7 @@ async fn error_when_transfer_nonexistent_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -489,12 +404,7 @@ async fn error_when_transfer_nonexistent_token(
 
 #[e2e::test]
 async fn safe_transfers_from(alice: Account, bob: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -538,12 +448,7 @@ async fn safe_transfers_from(alice: Account, bob: Account) -> eyre::Result<()> {
 async fn safe_transfers_to_receiver_contract(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let receiver_address =
@@ -602,12 +507,7 @@ async fn safe_transfers_from_approved_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -656,12 +556,7 @@ async fn safe_transfers_from_approved_for_all(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -709,12 +604,7 @@ async fn safe_transfers_from_approved_for_all(
 async fn error_when_safe_transfer_to_invalid_receiver(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -746,12 +636,7 @@ async fn error_when_safe_transfer_from_incorrect_owner(
     bob: Account,
     dave: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -783,12 +668,7 @@ async fn error_when_safe_transfer_with_insufficient_approval(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -819,12 +699,7 @@ async fn error_when_safe_transfer_nonexistent_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -855,12 +730,7 @@ async fn safe_transfers_from_with_data(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -908,12 +778,7 @@ async fn safe_transfers_from_with_data(
 async fn safe_transfers_with_data_to_receiver_contract(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let receiver_address =
@@ -974,12 +839,7 @@ async fn safe_transfers_from_with_data_approved_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -1031,12 +891,7 @@ async fn safe_transfers_from_with_data_approved_for_all(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -1087,12 +942,7 @@ async fn safe_transfers_from_with_data_approved_for_all(
 async fn error_when_safe_transfer_with_data_to_invalid_receiver(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1125,12 +975,7 @@ async fn error_when_safe_transfer_with_data_from_incorrect_owner(
     bob: Account,
     dave: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1167,12 +1012,7 @@ async fn error_when_safe_transfer_with_data_with_insufficient_approval(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1207,12 +1047,7 @@ async fn error_when_safe_transfer_with_data_nonexistent_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1249,12 +1084,7 @@ async fn error_when_safe_transfer_with_data_nonexistent_token(
 async fn errors_when_receiver_reverts_with_reason(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let receiver_address = receiver::deploy(
@@ -1285,12 +1115,7 @@ async fn errors_when_receiver_reverts_with_reason(
 async fn errors_when_receiver_reverts_without_reason(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let receiver_address = receiver::deploy(
@@ -1323,12 +1148,7 @@ async fn errors_when_receiver_reverts_without_reason(
 #[e2e::test]
 #[ignore]
 async fn errors_when_receiver_panics(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let receiver_address =
@@ -1356,12 +1176,7 @@ async fn errors_when_receiver_panics(alice: Account) -> eyre::Result<()> {
 
 #[e2e::test]
 async fn approves(alice: Account, bob: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1394,12 +1209,7 @@ async fn error_when_approve_for_nonexistent_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let bob_addr = bob.address();
@@ -1420,12 +1230,7 @@ async fn error_when_approve_by_invalid_approver(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -1453,12 +1258,7 @@ async fn error_when_approve_by_invalid_approver(
 async fn error_when_checking_approved_of_nonexistent_token(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let token_id = random_token_id();
@@ -1480,12 +1280,7 @@ async fn sets_approval_for_all(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1526,12 +1321,7 @@ async fn sets_approval_for_all(
 async fn error_when_set_approval_for_all_by_invalid_operator(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let invalid_operator = Address::ZERO;
@@ -1550,12 +1340,7 @@ async fn error_when_set_approval_for_all_by_invalid_operator(
 async fn is_approved_for_all_invalid_operator(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let invalid_operator = Address::ZERO;
@@ -1576,12 +1361,7 @@ async fn is_approved_for_all_invalid_operator(
 
 #[e2e::test]
 async fn pauses(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let receipt = receipt!(contract.pause())?;
@@ -1609,12 +1389,7 @@ async fn pauses(alice: Account) -> eyre::Result<()> {
 
 #[e2e::test]
 async fn unpauses(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let _ = watch!(contract.pause())?;
@@ -1644,12 +1419,7 @@ async fn unpauses(alice: Account) -> eyre::Result<()> {
 
 #[e2e::test]
 async fn error_when_burn_in_paused_state(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1680,12 +1450,7 @@ async fn error_when_burn_in_paused_state(alice: Account) -> eyre::Result<()> {
 
 #[e2e::test]
 async fn error_when_mint_in_paused_state(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1719,12 +1484,7 @@ async fn error_when_transfer_in_paused_state(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1765,12 +1525,7 @@ async fn error_when_safe_transfer_in_paused_state(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1812,12 +1567,7 @@ async fn error_when_safe_transfer_with_data_in_paused_state(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1864,12 +1614,7 @@ async fn error_when_safe_transfer_with_data_in_paused_state(
 
 #[e2e::test]
 async fn burns(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -1910,12 +1655,7 @@ async fn burns_approved_token(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -1960,12 +1700,7 @@ async fn burns_approved_for_all(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract_alice = Erc721::new(contract_addr, &alice.wallet);
     let contract_bob = Erc721::new(contract_addr, &bob.wallet);
 
@@ -2010,12 +1745,7 @@ async fn error_when_burn_with_insufficient_approval(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -2045,12 +1775,7 @@ async fn error_when_burn_with_insufficient_approval(
 
 #[e2e::test]
 async fn error_when_burn_nonexistent_token(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let token_id = random_token_id();
@@ -2069,12 +1794,7 @@ async fn error_when_burn_nonexistent_token(alice: Account) -> eyre::Result<()> {
 
 #[e2e::test]
 async fn totally_supply_works(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -2097,12 +1817,7 @@ async fn totally_supply_works(alice: Account) -> eyre::Result<()> {
 async fn error_when_checking_token_of_owner_by_index_out_of_bound(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -2130,12 +1845,7 @@ async fn error_when_checking_token_of_owner_by_index_out_of_bound(
 async fn error_when_checking_token_of_owner_by_index_account_has_no_tokens(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -2158,12 +1868,7 @@ async fn error_when_checking_token_of_owner_by_index_account_has_no_tokens(
 
 #[e2e::test]
 async fn token_of_owner_by_index_works(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -2190,12 +1895,7 @@ async fn token_of_owner_by_index_after_transfer_to_another_account(
     alice: Account,
     bob: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -2251,12 +1951,7 @@ async fn token_of_owner_by_index_after_transfer_to_another_account(
 async fn error_when_checking_token_by_index_account_has_no_tokens(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let index = uint!(0_U256);
@@ -2279,12 +1974,7 @@ async fn error_when_checking_token_by_index_account_has_no_tokens(
 async fn error_when_checking_token_by_index_out_of_bound(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -2310,12 +2000,7 @@ async fn error_when_checking_token_by_index_out_of_bound(
 
 #[e2e::test]
 async fn token_by_index_works(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -2339,12 +2024,7 @@ async fn token_by_index_works(alice: Account) -> eyre::Result<()> {
 
 #[e2e::test]
 async fn token_by_index_after_burn(alice: Account) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();
@@ -2385,12 +2065,7 @@ async fn token_by_index_after_burn(alice: Account) -> eyre::Result<()> {
 async fn token_by_index_after_burn_and_some_mints(
     alice: Account,
 ) -> eyre::Result<()> {
-    let contract_addr = alice
-        .as_deployer()
-        .with_constructor(ctr())
-        .deploy()
-        .await?
-        .address()?;
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
     let contract = Erc721::new(contract_addr, &alice.wallet);
 
     let alice_addr = alice.address();

--- a/examples/ownable/tests/ownable.rs
+++ b/examples/ownable/tests/ownable.rs
@@ -5,7 +5,6 @@ use alloy::{
     network::ReceiptResponse,
     primitives::Address,
     providers::Provider,
-    rpc::types::{BlockNumberOrTag, Filter, TransactionReceipt},
     sol,
     sol_types::{SolConstructor, SolError, SolEvent},
 };

--- a/examples/ownable/tests/ownable.rs
+++ b/examples/ownable/tests/ownable.rs
@@ -1,17 +1,9 @@
 #![cfg(feature = "e2e")]
 
 use abi::{Ownable, Ownable::OwnershipTransferred};
-use alloy::{
-    network::ReceiptResponse,
-    primitives::Address,
-    providers::Provider,
-    sol,
-    sol_types::{SolConstructor, SolError, SolEvent},
-};
-use e2e::{
-    receipt, send, Account, ContractDeployer, EventExt, ReceiptExt, Revert,
-};
-use eyre::{ContextCompat, Result};
+use alloy::{primitives::Address, sol};
+use e2e::{receipt, send, Account, EventExt, ReceiptExt, Revert};
+use eyre::Result;
 
 use crate::OwnableExample::constructorCall;
 

--- a/examples/ownable/tests/ownable.rs
+++ b/examples/ownable/tests/ownable.rs
@@ -41,7 +41,6 @@ async fn constructs(alice: Account) -> Result<()> {
     Ok(())
 }
 
-
 #[e2e::test]
 async fn rejects_zero_address_initial_owner(alice: Account) -> Result<()> {
     let err = deploy(&alice, constructor(Address::ZERO))

--- a/examples/ownable/tests/ownable.rs
+++ b/examples/ownable/tests/ownable.rs
@@ -5,21 +5,21 @@ use alloy::{
     network::ReceiptResponse,
     primitives::Address,
     providers::Provider,
-    rpc::types::{BlockNumberOrTag, Filter},
+    rpc::types::{BlockNumberOrTag, Filter, TransactionReceipt},
     sol,
     sol_types::{SolConstructor, SolError, SolEvent},
 };
-use e2e::{receipt, send, Account, EventExt, ReceiptExt, Revert};
+use e2e::{deploy, receipt, send, Account, EventExt, ReceiptExt, Revert};
 use eyre::{ContextCompat, Result};
+
+use crate::OwnableExample::constructorCall;
 
 mod abi;
 
 sol!("src/constructor.sol");
 
-async fn deploy(account: &Account, owner: Address) -> eyre::Result<Address> {
-    let args = OwnableExample::constructorCall { initialOwner: owner };
-    let args = alloy::hex::encode(args.abi_encode());
-    e2e::deploy(account.url(), &account.pk(), Some(args)).await?.address()
+fn constructor(owner: Address) -> Option<constructorCall> {
+    Some(constructorCall { initialOwner: owner })
 }
 
 // ============================================================================
@@ -29,7 +29,8 @@ async fn deploy(account: &Account, owner: Address) -> eyre::Result<Address> {
 #[e2e::test]
 async fn constructs(alice: Account) -> Result<()> {
     let alice_addr = alice.address();
-    let contract_addr = deploy(&alice, alice_addr).await?;
+    let contract_addr =
+        deploy(&alice, constructor(alice_addr)).await?.address()?;
     let contract = Ownable::new(contract_addr, &alice.wallet);
 
     let Ownable::ownerReturn { owner } = contract.owner().call().await?;
@@ -44,7 +45,9 @@ async fn emits_ownership_transfer_during_construction(
 ) -> Result<()> {
     let alice_addr = alice.address();
 
-    deploy(&alice, alice_addr).await?;
+    deploy(&alice, constructor(alice_addr)).await?.address()?;
+    
+    // TODO#q: check for event
 
     let block = alice.wallet.get_block_number().await?;
     let filter = Filter::new()
@@ -64,11 +67,11 @@ async fn emits_ownership_transfer_during_construction(
 
 #[e2e::test]
 async fn rejects_zero_address_initial_owner(alice: Account) -> Result<()> {
-    let err = deploy(&alice, Address::ZERO)
+    let err = deploy(&alice, constructor(Address::ZERO))
         .await
         .expect_err("should not deploy due to `OwnableInvalidOwner`");
 
-    // TODO: Improve error check for contract deployments.
+    // TODO#q: Improve error check for contract deployments.
     // Issue: https://github.com/OpenZeppelin/rust-contracts-stylus/issues/128
     let err_string = format!("{:#?}", err);
     let expected = Ownable::OwnableInvalidOwner { owner: Address::ZERO };
@@ -84,7 +87,8 @@ async fn transfers_ownership(alice: Account, bob: Account) -> Result<()> {
     let alice_addr = alice.address();
     let bob_addr = bob.address();
 
-    let contract_addr = deploy(&alice, alice_addr).await?;
+    let contract_addr =
+        deploy(&alice, constructor(alice_addr)).await?.address()?;
     let contract = Ownable::new(contract_addr, &alice.wallet);
 
     let receipt = receipt!(contract.transferOwnership(bob_addr))?;
@@ -107,7 +111,8 @@ async fn prevents_non_owners_from_transferring(
     let alice_addr = alice.address();
     let bob_addr = bob.address();
 
-    let contract_addr = deploy(&alice, bob_addr).await?;
+    let contract_addr =
+        deploy(&alice, constructor(bob_addr)).await?.address()?;
     let contract = Ownable::new(contract_addr, &alice.wallet);
 
     let err = send!(contract.transferOwnership(bob_addr))
@@ -122,7 +127,8 @@ async fn prevents_non_owners_from_transferring(
 #[e2e::test]
 async fn guards_against_stuck_state(alice: Account) -> Result<()> {
     let alice_addr = alice.address();
-    let contract_addr = deploy(&alice, alice_addr).await?;
+    let contract_addr =
+        deploy(&alice, constructor(alice_addr)).await?.address()?;
     let contract = Ownable::new(contract_addr, &alice.wallet);
 
     let err = send!(contract.transferOwnership(Address::ZERO))
@@ -138,7 +144,8 @@ async fn guards_against_stuck_state(alice: Account) -> Result<()> {
 #[e2e::test]
 async fn loses_ownership_after_renouncement(alice: Account) -> Result<()> {
     let alice_addr = alice.address();
-    let contract_addr = deploy(&alice, alice_addr).await?;
+    let contract_addr =
+        deploy(&alice, constructor(alice_addr)).await?.address()?;
     let contract = Ownable::new(contract_addr, &alice.wallet);
 
     let receipt = receipt!(contract.renounceOwnership())?;
@@ -161,7 +168,8 @@ async fn prevents_non_owners_from_renouncement(
     let alice_addr = alice.address();
     let bob_addr = bob.address();
 
-    let contract_addr = deploy(&alice, alice_addr).await?;
+    let contract_addr =
+        deploy(&alice, constructor(alice_addr)).await?.address()?;
     let contract = Ownable::new(contract_addr, &bob.wallet);
 
     let err = send!(contract.renounceOwnership())

--- a/lib/e2e/Cargo.toml
+++ b/lib/e2e/Cargo.toml
@@ -17,7 +17,6 @@ once_cell.workspace = true
 koba.workspace = true
 e2e-proc = { path = "../e2e-proc" }
 toml = "0.8.13"
-async-trait = "0.1.81"
 
 [lints]
 workspace = true

--- a/lib/e2e/Cargo.toml
+++ b/lib/e2e/Cargo.toml
@@ -17,6 +17,7 @@ once_cell.workspace = true
 koba.workspace = true
 e2e-proc = { path = "../e2e-proc" }
 toml = "0.8.13"
+async-trait = "0.1.81"
 
 [lints]
 workspace = true

--- a/lib/e2e/src/account.rs
+++ b/lib/e2e/src/account.rs
@@ -8,7 +8,10 @@ use eyre::Result;
 use once_cell::sync::Lazy;
 use tokio::sync::{Mutex, MutexGuard};
 
-use crate::system::{fund_account, Wallet, RPC_URL_ENV_VAR_NAME};
+use crate::{
+    deploy::Deployer,
+    system::{fund_account, Wallet, RPC_URL_ENV_VAR_NAME},
+};
 
 /// Type that corresponds to a test account.
 #[derive(Clone, Debug)]
@@ -65,6 +68,11 @@ impl Account {
     /// happen.
     pub async fn sign_message(&self, message: &[u8]) -> Signature {
         self.signer.sign_message(message).await.expect("should sign a message")
+    }
+
+    /// Create a configurable smart contract deployer on behalf of this account.
+    pub fn as_deployer(&self) -> Deployer {
+        Deployer::new(self.url().to_string(), self.pk())
     }
 }
 

--- a/lib/e2e/src/deploy.rs
+++ b/lib/e2e/src/deploy.rs
@@ -1,7 +1,7 @@
-use alloy::{
-    primitives::Address, rpc::types::TransactionReceipt,
-    sol_types::SolConstructor,
-};
+use std::path::PathBuf;
+
+use alloy::{rpc::types::TransactionReceipt, sol_types::SolConstructor};
+use async_trait::async_trait;
 use koba::config::Deploy;
 
 use crate::{project::Crate, Account};
@@ -19,52 +19,128 @@ pub async fn deploy<C: SolConstructor>(
     account: &Account,
     constructor: Option<C>,
 ) -> eyre::Result<TransactionReceipt> {
+    let has_constructor = constructor.is_some();
+    let pkg = Crate::new()?;
+    let wasm_path = pkg.wasm;
+
     deploy_inner(
-        account.url(),
-        &account.pk(),
+        account.url().to_owned(),
+        account.pk().clone(),
+        wasm_path,
         constructor.map(|c| alloy::hex::encode(c.abi_encode())),
+        if has_constructor {
+            Some(pkg.manifest_dir.join("src/constructor.sol"))
+        } else {
+            None
+        },
     )
     .await
 }
 
 /// Deploy and activate the contract implemented as `#[entrypoint]` in the
-/// current crate using `rpc_url`, `private_key` and the ABI-encoded constructor
-/// `args`.
+/// current crate.
 ///
-/// # Errors
-///
-/// May error if:
-///
-/// - Unable to collect information about the crate required for deployment.
-/// - `koba::deploy` errors.
+/// # Arguments
+/// * `rpc_url` - The RPC URL of the network to deploy to.
+/// * `private_key` - The private key of the account to deploy from.
+/// * `wasm_path` - The path to the contract's wasm file.
+/// * `ctr_args` - Optional ABI-encoded constructor arguments.
+/// * `sol_path` - Optional path to the contract's solidity constructor.
 async fn deploy_inner(
-    rpc_url: &str,
-    private_key: &str,
-    args: Option<String>,
+    rpc_url: String,
+    private_key: String,
+    wasm_path: PathBuf,
+    ctr_args: Option<String>,
+    sol_path: Option<PathBuf>,
 ) -> eyre::Result<TransactionReceipt> {
-    let pkg = Crate::new()?;
-    let sol_path = pkg.manifest_dir.join("src/constructor.sol");
-    let wasm_path = pkg.wasm;
-    let has_constructor = args.is_some();
-
     let config = Deploy {
         generate_config: koba::config::Generate {
             wasm: wasm_path.clone(),
-            sol: if has_constructor { Some(sol_path) } else { None },
-            args,
+            sol: sol_path,
+            args: ctr_args,
             legacy: false,
         },
         auth: koba::config::PrivateKey {
             private_key_path: None,
-            private_key: Some(private_key.to_owned()),
+            private_key: Some(private_key),
             keystore_path: None,
             keystore_password_path: None,
         },
-        endpoint: rpc_url.to_owned(),
+        endpoint: rpc_url,
         deploy_only: false,
         quiet: false,
     };
 
     let receipt = koba::deploy(&config).await?;
     Ok(receipt)
+}
+
+/// Abstraction for configured deployer.
+#[async_trait]
+pub trait ContractDeployer {
+    /// Deploy and activate the contract implemented as `#[entrypoint]` in the
+    /// current crate.
+    /// Consumes currently configured deployer.
+    ///
+    /// # Errors
+    ///
+    /// May error if:
+    ///
+    /// - Unable to collect information about the crate required for deployment.
+    /// - [`koba::deploy`] errors.
+    async fn deploy(self) -> eyre::Result<TransactionReceipt>;
+}
+
+/// A basic smart contract deployer.
+pub struct Deployer {
+    rpc_url: String,
+    private_key: String,
+}
+
+impl Deployer {
+    pub fn new(rpc_url: String, private_key: String) -> Self {
+        Self { rpc_url, private_key }
+    }
+
+    /// Add solidity constructor to the deployer.
+    pub fn with_constructor<C: SolConstructor + Send>(
+        self,
+        constructor: C,
+    ) -> DeployerWithConstructor<C> {
+        DeployerWithConstructor { deployer: self, constructor }
+    }
+}
+
+#[async_trait]
+impl ContractDeployer for Deployer {
+    async fn deploy(self) -> eyre::Result<TransactionReceipt> {
+        let pkg = Crate::new()?;
+        let wasm_path = pkg.wasm;
+        deploy_inner(self.rpc_url, self.private_key, wasm_path, None, None)
+            .await
+    }
+}
+
+/// A smart contract deployer with solidity constructor compiled with `koba`.
+pub struct DeployerWithConstructor<C: SolConstructor + Send> {
+    deployer: Deployer,
+    constructor: C,
+}
+
+#[async_trait]
+impl<C: SolConstructor + Send> ContractDeployer for DeployerWithConstructor<C> {
+    async fn deploy(self) -> eyre::Result<TransactionReceipt> {
+        let pkg = Crate::new()?;
+        let wasm_path = pkg.wasm;
+        let args = alloy::hex::encode(self.constructor.abi_encode());
+        let sol_path = pkg.manifest_dir.join("src/constructor.sol");
+        deploy_inner(
+            self.deployer.rpc_url,
+            self.deployer.private_key,
+            wasm_path,
+            Some(args),
+            Some(sol_path),
+        )
+        .await
+    }
 }

--- a/lib/e2e/src/deploy.rs
+++ b/lib/e2e/src/deploy.rs
@@ -4,38 +4,7 @@ use alloy::{rpc::types::TransactionReceipt, sol_types::SolConstructor};
 use async_trait::async_trait;
 use koba::config::Deploy;
 
-use crate::{project::Crate, Account};
-
-/// Deploy and activate the contract implemented as `#[entrypoint]` in the
-/// current crate using `account` and optional `constructor` parameter.
-///
-/// # Errors
-///
-/// May error if:
-///
-/// - Unable to collect information about the crate required for deployment.
-/// - `koba::deploy` errors.
-pub async fn deploy<C: SolConstructor>(
-    account: &Account,
-    constructor: Option<C>,
-) -> eyre::Result<TransactionReceipt> {
-    let has_constructor = constructor.is_some();
-    let pkg = Crate::new()?;
-    let wasm_path = pkg.wasm;
-
-    deploy_inner(
-        account.url().to_owned(),
-        account.pk().clone(),
-        wasm_path,
-        constructor.map(|c| alloy::hex::encode(c.abi_encode())),
-        if has_constructor {
-            Some(pkg.manifest_dir.join("src/constructor.sol"))
-        } else {
-            None
-        },
-    )
-    .await
-}
+use crate::project::Crate;
 
 /// Deploy and activate the contract implemented as `#[entrypoint]` in the
 /// current crate.

--- a/lib/e2e/src/deploy.rs
+++ b/lib/e2e/src/deploy.rs
@@ -14,7 +14,7 @@ use crate::project::Crate;
 /// * `wasm_path` - The path to the contract's wasm file.
 /// * `ctr_args` - Optional ABI-encoded constructor arguments.
 /// * `sol_path` - Optional path to the contract's solidity constructor.
-async fn deploy_inner(
+async fn deploy(
     rpc_url: String,
     private_key: String,
     wasm_path: PathBuf,
@@ -84,17 +84,14 @@ impl Deployer {
     pub async fn deploy(self) -> eyre::Result<TransactionReceipt> {
         let pkg = Crate::new()?;
         let wasm_path = pkg.wasm;
-        let sol_path = if self.ctr_args.is_some() {
-            Some(pkg.manifest_dir.join("src/constructor.sol"))
-        } else {
-            None
-        };
-        deploy_inner(
+        let sol_path = pkg.manifest_dir.join("src/constructor.sol");
+
+        deploy(
             self.rpc_url,
             self.private_key,
             wasm_path,
             self.ctr_args,
-            sol_path,
+            Some(sol_path),
         )
         .await
     }

--- a/lib/e2e/src/lib.rs
+++ b/lib/e2e/src/lib.rs
@@ -9,7 +9,6 @@ mod receipt;
 mod system;
 
 pub use account::Account;
-pub use deploy::ContractDeployer;
 pub use e2e_proc::test;
 pub use error::{Panic, PanicCode, Revert};
 pub use event::EventExt;

--- a/lib/e2e/src/lib.rs
+++ b/lib/e2e/src/lib.rs
@@ -9,7 +9,7 @@ mod receipt;
 mod system;
 
 pub use account::Account;
-pub use deploy::deploy;
+pub use deploy::{deploy, ContractDeployer};
 pub use e2e_proc::test;
 pub use error::{Panic, PanicCode, Revert};
 pub use event::EventExt;

--- a/lib/e2e/src/lib.rs
+++ b/lib/e2e/src/lib.rs
@@ -9,7 +9,7 @@ mod receipt;
 mod system;
 
 pub use account::Account;
-pub use deploy::{deploy, ContractDeployer};
+pub use deploy::ContractDeployer;
 pub use e2e_proc::test;
 pub use error::{Panic, PanicCode, Revert};
 pub use event::EventExt;

--- a/lib/e2e/src/lib.rs
+++ b/lib/e2e/src/lib.rs
@@ -25,7 +25,7 @@ pub use system::{fund_account, provider, Provider, Wallet};
 /// ```rust,ignore
 /// #[e2e::test]
 /// async fn foo(alice: Account) -> eyre::Result<()> {
-///     let contract_addr = deploy(alice.url(), &alice.pk()).await?;
+///     let contract_addr = alice.as_deployer().deploy().await?.address()?;
 ///     let contract = Erc721::new(contract_addr, &alice.wallet);
 ///
 ///     let alice_addr = alice.address();
@@ -50,7 +50,7 @@ macro_rules! send {
 /// ```rust,ignore
 /// #[e2e::test]
 /// async fn foo(alice: Account) -> eyre::Result<()> {
-///     let contract_addr = deploy(alice.url(), &alice.pk()).await?;
+///     let contract_addr = alice.as_deployer().deploy().await?.address()?;
 ///     let contract = Erc721::new(contract_addr, &alice.wallet);
 ///
 ///     let alice_addr = alice.address();
@@ -76,7 +76,7 @@ macro_rules! watch {
 /// ```rust,ignore
 /// #[e2e::test]
 /// async fn foo(alice: Account) -> eyre::Result<()> {
-///     let contract_addr = deploy(alice.url(), &alice.pk()).await?;
+///     let contract_addr = alice.as_deployer().deploy().await?.address()?;
 ///     let contract = Erc721::new(contract_addr, &alice.wallet);
 ///
 ///     let alice_addr = alice.address();


### PR DESCRIPTION
Adds `Account::as_deployer()` function that let's to configure contract (with/without constructor) for e2e tests. And deploy it.
Includes all necessary migrations of e2e tests to the new api.
