### PR TITLE
feat: rename crypto crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,7 +2359,7 @@ dependencies = [
  "alloy-primitives 0.3.3",
  "alloy-sol-types 0.3.1",
  "mini-alloc",
- "openzeppelin-crypto-rs",
+ "openzeppelin-crypto",
  "stylus-proc",
  "stylus-sdk",
 ]
@@ -2567,7 +2567,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "openzeppelin-crypto-rs"
+name = "openzeppelin-crypto"
 version = "0.1.0"
 dependencies = [
  "hex-literal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,16 +1284,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto"
-version = "0.1.0"
-dependencies = [
- "hex-literal",
- "mini-alloc",
- "rand",
- "tiny-keccak",
-]
-
-[[package]]
 name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2368,8 +2358,8 @@ version = "0.0.0"
 dependencies = [
  "alloy-primitives 0.3.3",
  "alloy-sol-types 0.3.1",
- "crypto",
  "mini-alloc",
+ "openzeppelin-crypto-rs",
  "stylus-proc",
  "stylus-sdk",
 ]
@@ -2574,6 +2564,16 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "openzeppelin-crypto-rs"
+version = "0.1.0"
+dependencies = [
+ "hex-literal",
+ "mini-alloc",
+ "rand",
+ "tiny-keccak",
 ]
 
 [[package]]

--- a/examples/merkle-proofs/Cargo.toml
+++ b/examples/merkle-proofs/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 version = "0.0.0"
 
 [dependencies]
-crypto = { path = "../../lib/crypto" }
+openzeppelin-crypto-rs = { path = "../../lib/crypto" }
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 stylus-sdk.workspace = true

--- a/examples/merkle-proofs/Cargo.toml
+++ b/examples/merkle-proofs/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 version = "0.0.0"
 
 [dependencies]
-openzeppelin-crypto-rs = { path = "../../lib/crypto" }
+openzeppelin-crypto = { path = "../../lib/crypto" }
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 stylus-sdk.workspace = true

--- a/examples/merkle-proofs/src/lib.rs
+++ b/examples/merkle-proofs/src/lib.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use alloy_primitives::B256;
-use openzeppelin_crypto_rs::{
+use openzeppelin_crypto::{
     merkle::{self, Verifier},
     KeccakBuilder,
 };

--- a/examples/merkle-proofs/src/lib.rs
+++ b/examples/merkle-proofs/src/lib.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use alloy_primitives::B256;
-use crypto::{
+use openzeppelin_crypto_rs::{
     merkle::{self, Verifier},
     KeccakBuilder,
 };

--- a/lib/crypto/Cargo.toml
+++ b/lib/crypto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "crypto"
+name = "openzeppelin-crypto-rs"
 categories = ["cryptography", "algorithms", "no-std", "wasm"]
 description = "Cryptography Utilities"
 edition.workspace = true

--- a/lib/crypto/Cargo.toml
+++ b/lib/crypto/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "openzeppelin-crypto-rs"
+name = "openzeppelin-crypto"
 categories = ["cryptography", "algorithms", "no-std", "wasm"]
 description = "Cryptography Utilities"
 edition.workspace = true

--- a/lib/crypto/src/hash.rs
+++ b/lib/crypto/src/hash.rs
@@ -51,8 +51,8 @@ pub trait Hasher {
 /// # Examples
 ///
 /// ```rust
-/// use openzeppelin_crypto_rs::KeccakBuilder;
-/// use openzeppelin_crypto_rs::hash::{BuildHasher, Hash, Hasher};
+/// use openzeppelin_crypto::KeccakBuilder;
+/// use openzeppelin_crypto::hash::{BuildHasher, Hash, Hasher};
 ///
 /// let b = KeccakBuilder;
 /// let mut hasher_1 = b.build_hasher();
@@ -78,8 +78,8 @@ pub trait BuildHasher {
     /// # Examples
     ///
     /// ```rust
-    /// use openzeppelin_crypto_rs::KeccakBuilder;
-    /// use openzeppelin_crypto_rs::hash::BuildHasher;
+    /// use openzeppelin_crypto::KeccakBuilder;
+    /// use openzeppelin_crypto::hash::BuildHasher;
     ///
     /// let b = KeccakBuilder;
     /// let hasher = b.build_hasher();
@@ -100,8 +100,8 @@ pub trait BuildHasher {
     /// # Examples
     ///
     /// ```rust
-    /// use openzeppelin_crypto_rs::KeccakBuilder;
-    /// use openzeppelin_crypto_rs::hash::{BuildHasher, Hash};
+    /// use openzeppelin_crypto::KeccakBuilder;
+    /// use openzeppelin_crypto::hash::{BuildHasher, Hash};
     ///
     /// let b = KeccakBuilder;
     /// let hash_1 = b.hash_one([0u8; 32]);

--- a/lib/crypto/src/hash.rs
+++ b/lib/crypto/src/hash.rs
@@ -51,8 +51,8 @@ pub trait Hasher {
 /// # Examples
 ///
 /// ```rust
-/// use crypto::KeccakBuilder;
-/// use crypto::hash::{BuildHasher, Hash, Hasher};
+/// use openzeppelin_crypto_rs::KeccakBuilder;
+/// use openzeppelin_crypto_rs::hash::{BuildHasher, Hash, Hasher};
 ///
 /// let b = KeccakBuilder;
 /// let mut hasher_1 = b.build_hasher();
@@ -78,8 +78,8 @@ pub trait BuildHasher {
     /// # Examples
     ///
     /// ```rust
-    /// use crypto::KeccakBuilder;
-    /// use crypto::hash::BuildHasher;
+    /// use openzeppelin_crypto_rs::KeccakBuilder;
+    /// use openzeppelin_crypto_rs::hash::BuildHasher;
     ///
     /// let b = KeccakBuilder;
     /// let hasher = b.build_hasher();
@@ -100,8 +100,8 @@ pub trait BuildHasher {
     /// # Examples
     ///
     /// ```rust
-    /// use crypto::KeccakBuilder;
-    /// use crypto::hash::{BuildHasher, Hash};
+    /// use openzeppelin_crypto_rs::KeccakBuilder;
+    /// use openzeppelin_crypto_rs::hash::{BuildHasher, Hash};
     ///
     /// let b = KeccakBuilder;
     /// let hash_1 = b.hash_one([0u8; 32]);

--- a/lib/crypto/src/merkle.rs
+++ b/lib/crypto/src/merkle.rs
@@ -46,7 +46,7 @@ impl Verifier<KeccakBuilder> {
     /// # Examples
     ///
     /// ```
-    /// use crypto::merkle::Verifier;
+    /// use openzeppelin_crypto_rs::merkle::Verifier;
     /// use hex_literal::hex;
     ///
     /// let root  = hex!("0000000000000000000000000000000000000000000000000000000000000000");
@@ -110,7 +110,7 @@ impl Verifier<KeccakBuilder> {
     /// # Examples
     ///
     /// ```rust
-    /// use crypto::merkle::Verifier;
+    /// use openzeppelin_crypto_rs::merkle::Verifier;
     /// use hex_literal::hex;
     ///
     /// let root   =  hex!("6deb52b5da8fd108f79fab00341f38d2587896634c646ee52e49f845680a70c8");
@@ -166,7 +166,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use crypto::{merkle::Verifier, KeccakBuilder};
+    /// use openzeppelin_crypto_rs::{merkle::Verifier, KeccakBuilder};
     /// use hex_literal::hex;
     ///
     /// let root  = hex!("0000000000000000000000000000000000000000000000000000000000000000");
@@ -240,7 +240,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use crypto::{merkle::Verifier, KeccakBuilder};
+    /// use openzeppelin_crypto_rs::{merkle::Verifier, KeccakBuilder};
     /// use hex_literal::hex;
     ///
     /// let root   =  hex!("6deb52b5da8fd108f79fab00341f38d2587896634c646ee52e49f845680a70c8");

--- a/lib/crypto/src/merkle.rs
+++ b/lib/crypto/src/merkle.rs
@@ -46,7 +46,7 @@ impl Verifier<KeccakBuilder> {
     /// # Examples
     ///
     /// ```
-    /// use openzeppelin_crypto_rs::merkle::Verifier;
+    /// use openzeppelin_crypto::merkle::Verifier;
     /// use hex_literal::hex;
     ///
     /// let root  = hex!("0000000000000000000000000000000000000000000000000000000000000000");
@@ -110,7 +110,7 @@ impl Verifier<KeccakBuilder> {
     /// # Examples
     ///
     /// ```rust
-    /// use openzeppelin_crypto_rs::merkle::Verifier;
+    /// use openzeppelin_crypto::merkle::Verifier;
     /// use hex_literal::hex;
     ///
     /// let root   =  hex!("6deb52b5da8fd108f79fab00341f38d2587896634c646ee52e49f845680a70c8");
@@ -166,7 +166,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use openzeppelin_crypto_rs::{merkle::Verifier, KeccakBuilder};
+    /// use openzeppelin_crypto::{merkle::Verifier, KeccakBuilder};
     /// use hex_literal::hex;
     ///
     /// let root  = hex!("0000000000000000000000000000000000000000000000000000000000000000");
@@ -240,7 +240,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use openzeppelin_crypto_rs::{merkle::Verifier, KeccakBuilder};
+    /// use openzeppelin_crypto::{merkle::Verifier, KeccakBuilder};
     /// use hex_literal::hex;
     ///
     /// let root   =  hex!("6deb52b5da8fd108f79fab00341f38d2587896634c646ee52e49f845680a70c8");


### PR DESCRIPTION
Decided to go for `openzeppelin-crypto-rs`, but obv open to something different.

UPDATE: In the end went for `openzeppelin-crypto`.