### PR TITLE
ref: add associated error types for contract traits

### DIFF
--- a/contracts/src/token/erc20/extensions/burnable.rs
+++ b/contracts/src/token/erc20/extensions/burnable.rs
@@ -9,7 +9,7 @@ use crate::token::erc20::{Erc20, Error};
 /// their own tokens and those that they have an allowance for,
 /// in a way that can be recognized off-chain (via event analysis).
 pub trait IErc20Burnable {
-    /// The error type associated with ERC-20 burnable contract.
+    /// The error type associated to this ERC-20 Burnable trait implementation.
     type Error: Into<alloc::vec::Vec<u8>>;
 
     /// Destroys a `value` amount of tokens from the caller. lowering the total

--- a/contracts/src/token/erc20/extensions/burnable.rs
+++ b/contracts/src/token/erc20/extensions/burnable.rs
@@ -9,6 +9,9 @@ use crate::token::erc20::{Erc20, Error};
 /// their own tokens and those that they have an allowance for,
 /// in a way that can be recognized off-chain (via event analysis).
 pub trait IErc20Burnable {
+    /// The error type associated with ERC-20 burnable contract.
+    type Error: Into<alloc::vec::Vec<u8>>;
+
     /// Destroys a `value` amount of tokens from the caller. lowering the total
     /// supply.
     ///
@@ -26,7 +29,7 @@ pub trait IErc20Burnable {
     /// # Events
     ///
     /// Emits a [`super::super::Transfer`] event.
-    fn burn(&mut self, value: U256) -> Result<(), Error>;
+    fn burn(&mut self, value: U256) -> Result<(), Self::Error>;
 
     /// Destroys a `value` amount of tokens from `account`, lowering the total
     /// supply.
@@ -50,12 +53,17 @@ pub trait IErc20Burnable {
     /// # Events
     ///
     /// Emits a [`super::super::Transfer`] event.
-    fn burn_from(&mut self, account: Address, value: U256)
-        -> Result<(), Error>;
+    fn burn_from(
+        &mut self,
+        account: Address,
+        value: U256,
+    ) -> Result<(), Self::Error>;
 }
 
 impl IErc20Burnable for Erc20 {
-    fn burn(&mut self, value: U256) -> Result<(), Error> {
+    type Error = Error;
+
+    fn burn(&mut self, value: U256) -> Result<(), Self::Error> {
         self._burn(msg::sender(), value)
     }
 
@@ -63,7 +71,7 @@ impl IErc20Burnable for Erc20 {
         &mut self,
         account: Address,
         value: U256,
-    ) -> Result<(), Error> {
+    ) -> Result<(), Self::Error> {
         self._spend_allowance(account, msg::sender(), value)?;
         self._burn(account, value)
     }

--- a/contracts/src/token/erc20/extensions/permit.rs
+++ b/contracts/src/token/erc20/extensions/permit.rs
@@ -12,7 +12,9 @@
 use alloy_primitives::{b256, keccak256, Address, B256, U256};
 use alloy_sol_types::{sol, SolType};
 use stylus_proc::{external, sol_storage, SolidityError};
-use stylus_sdk::{block, prelude::StorageType, storage::TopLevelStorage};
+use stylus_sdk::{
+    block, call::MethodError, prelude::StorageType, storage::TopLevelStorage,
+};
 
 use crate::{
     token::erc20::{self, Erc20, IErc20},

--- a/contracts/src/token/erc20/extensions/permit.rs
+++ b/contracts/src/token/erc20/extensions/permit.rs
@@ -12,9 +12,7 @@
 use alloy_primitives::{b256, keccak256, Address, B256, U256};
 use alloy_sol_types::{sol, SolType};
 use stylus_proc::{external, sol_storage, SolidityError};
-use stylus_sdk::{
-    block, call::MethodError, prelude::StorageType, storage::TopLevelStorage,
-};
+use stylus_sdk::{block, prelude::StorageType, storage::TopLevelStorage};
 
 use crate::{
     token::erc20::{self, Erc20, IErc20},

--- a/contracts/src/token/erc20/extensions/permit.rs
+++ b/contracts/src/token/erc20/extensions/permit.rs
@@ -60,18 +60,6 @@ pub enum Error {
     ECDSA(ecdsa::Error),
 }
 
-impl MethodError for erc20::Error {
-    fn encode(self) -> alloc::vec::Vec<u8> {
-        self.into()
-    }
-}
-
-impl MethodError for ecdsa::Error {
-    fn encode(self) -> alloc::vec::Vec<u8> {
-        self.into()
-    }
-}
-
 sol_storage! {
     /// State of a Permit Contract.
     pub struct Erc20Permit<T: IEip712 + StorageType>{

--- a/contracts/src/token/erc20/mod.rs
+++ b/contracts/src/token/erc20/mod.rs
@@ -8,11 +8,10 @@ use alloy_primitives::{Address, U256};
 use alloy_sol_types::sol;
 use stylus_proc::SolidityError;
 use stylus_sdk::{
+    call::MethodError,
     evm, msg,
     stylus_proc::{external, sol_storage},
 };
-
-use crate::impl_method_error;
 
 pub mod extensions;
 
@@ -93,7 +92,11 @@ pub enum Error {
     InvalidSpender(ERC20InvalidSpender),
 }
 
-impl_method_error!(Error);
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
+}
 
 sol_storage! {
     /// State of an `Erc20` token.

--- a/contracts/src/token/erc20/mod.rs
+++ b/contracts/src/token/erc20/mod.rs
@@ -13,8 +13,6 @@ use stylus_sdk::{
     stylus_proc::{external, sol_storage},
 };
 
-use crate::token::erc20;
-
 pub mod extensions;
 
 sol! {

--- a/contracts/src/token/erc20/mod.rs
+++ b/contracts/src/token/erc20/mod.rs
@@ -8,10 +8,11 @@ use alloy_primitives::{Address, U256};
 use alloy_sol_types::sol;
 use stylus_proc::SolidityError;
 use stylus_sdk::{
-    call::MethodError,
     evm, msg,
     stylus_proc::{external, sol_storage},
 };
+
+use crate::impl_method_error;
 
 pub mod extensions;
 
@@ -92,11 +93,7 @@ pub enum Error {
     InvalidSpender(ERC20InvalidSpender),
 }
 
-impl MethodError for Error {
-    fn encode(self) -> alloc::vec::Vec<u8> {
-        self.into()
-    }
-}
+impl_method_error!(Error);
 
 sol_storage! {
     /// State of an `Erc20` token.

--- a/contracts/src/token/erc20/mod.rs
+++ b/contracts/src/token/erc20/mod.rs
@@ -112,7 +112,7 @@ sol_storage! {
 
 /// Required interface of an [`Erc20`] compliant contract.
 pub trait IErc20 {
-    /// The error type associated with ERC-20 contract.
+    /// The error type associated to this ERC-20 trait implementation.
     type Error: Into<alloc::vec::Vec<u8>>;
 
     /// Returns the number of tokens in existence.

--- a/contracts/src/token/erc721/extensions/burnable.rs
+++ b/contracts/src/token/erc721/extensions/burnable.rs
@@ -7,7 +7,7 @@ use crate::token::erc721::{Erc721, Error};
 
 /// An [`Erc721`] token that can be burned (destroyed).
 pub trait IErc721Burnable {
-    /// The error type associated with ERC-721 burnable contract.
+    /// The error type associated to this ERC-721 burnable trait implementation.
     type Error: Into<alloc::vec::Vec<u8>>;
 
     /// Burns `token_id`.

--- a/contracts/src/token/erc721/extensions/burnable.rs
+++ b/contracts/src/token/erc721/extensions/burnable.rs
@@ -7,6 +7,9 @@ use crate::token::erc721::{Erc721, Error};
 
 /// An [`Erc721`] token that can be burned (destroyed).
 pub trait IErc721Burnable {
+    /// The error type associated with ERC-721 burnable contract.
+    type Error: Into<alloc::vec::Vec<u8>>;
+
     /// Burns `token_id`.
     ///
     /// The approval is cleared when the token is burned. Relies on the `_burn`
@@ -31,11 +34,13 @@ pub trait IErc721Burnable {
     /// # Events
     ///
     /// Emits a [`super::super::Transfer`] event.
-    fn burn(&mut self, token_id: U256) -> Result<(), Error>;
+    fn burn(&mut self, token_id: U256) -> Result<(), Self::Error>;
 }
 
 impl IErc721Burnable for Erc721 {
-    fn burn(&mut self, token_id: U256) -> Result<(), Error> {
+    type Error = Error;
+
+    fn burn(&mut self, token_id: U256) -> Result<(), Self::Error> {
         // Setting an "auth" arguments enables the
         // [`super::super::Erc721::_is_authorized`] check which verifies that
         // the token exists (from != `Address::ZERO`).

--- a/contracts/src/token/erc721/extensions/consecutive.rs
+++ b/contracts/src/token/erc721/extensions/consecutive.rs
@@ -130,18 +130,6 @@ pub enum Error {
 
 unsafe impl TopLevelStorage for Erc721Consecutive {}
 
-impl MethodError for erc721::Error {
-    fn encode(self) -> alloc::vec::Vec<u8> {
-        self.into()
-    }
-}
-
-impl MethodError for checkpoints::Error {
-    fn encode(self) -> alloc::vec::Vec<u8> {
-        self.into()
-    }
-}
-
 // ************** ERC-721 External **************
 
 #[external]

--- a/contracts/src/token/erc721/extensions/consecutive.rs
+++ b/contracts/src/token/erc721/extensions/consecutive.rs
@@ -27,9 +27,7 @@ use alloc::vec;
 use alloy_primitives::{uint, Address, U256};
 use alloy_sol_types::sol;
 use stylus_proc::{external, sol_storage, SolidityError};
-use stylus_sdk::{
-    abi::Bytes, call::MethodError, evm, msg, prelude::TopLevelStorage,
-};
+use stylus_sdk::{abi::Bytes, evm, msg, prelude::TopLevelStorage};
 
 use crate::{
     token::{

--- a/contracts/src/token/erc721/extensions/consecutive.rs
+++ b/contracts/src/token/erc721/extensions/consecutive.rs
@@ -27,7 +27,9 @@ use alloc::vec;
 use alloy_primitives::{uint, Address, U256};
 use alloy_sol_types::sol;
 use stylus_proc::{external, sol_storage, SolidityError};
-use stylus_sdk::{abi::Bytes, evm, msg, prelude::TopLevelStorage};
+use stylus_sdk::{
+    abi::Bytes, call::MethodError, evm, msg, prelude::TopLevelStorage,
+};
 
 use crate::{
     token::{

--- a/contracts/src/token/erc721/extensions/enumerable.rs
+++ b/contracts/src/token/erc721/extensions/enumerable.rs
@@ -64,7 +64,8 @@ sol_storage! {
 /// This is the interface of the optional `Enumerable` extension
 /// of the ERC-721 standard.
 pub trait IErc721Enumerable {
-    /// The error type associated with ERC-721 enumerable contract.
+    /// The error type associated to this ERC-721 enumerable trait
+    /// implementation.
     type Error: Into<alloc::vec::Vec<u8>>;
 
     // TODO: fn supports_interface (#33)

--- a/contracts/src/token/erc721/extensions/enumerable.rs
+++ b/contracts/src/token/erc721/extensions/enumerable.rs
@@ -64,6 +64,9 @@ sol_storage! {
 /// This is the interface of the optional `Enumerable` extension
 /// of the ERC-721 standard.
 pub trait IErc721Enumerable {
+    /// The error type associated with ERC-721 enumerable contract.
+    type Error: Into<alloc::vec::Vec<u8>>;
+
     // TODO: fn supports_interface (#33)
 
     /// Returns a token ID owned by `owner` at a given `index` of its token
@@ -84,7 +87,7 @@ pub trait IErc721Enumerable {
         &self,
         owner: Address,
         index: U256,
-    ) -> Result<U256, Error>;
+    ) -> Result<U256, Self::Error>;
 
     /// Returns the total amount of tokens stored by the contract.
     ///
@@ -107,16 +110,18 @@ pub trait IErc721Enumerable {
     ///
     /// * If an `owner`'s token query is out of bounds for `index`,
     /// then the error [`Error::OutOfBoundsIndex`] is returned.
-    fn token_by_index(&self, index: U256) -> Result<U256, Error>;
+    fn token_by_index(&self, index: U256) -> Result<U256, Self::Error>;
 }
 
 #[external]
 impl IErc721Enumerable for Erc721Enumerable {
+    type Error = Error;
+
     fn token_of_owner_by_index(
         &self,
         owner: Address,
         index: U256,
-    ) -> Result<U256, Error> {
+    ) -> Result<U256, Self::Error> {
         let token = self._owned_tokens.getter(owner).get(index);
 
         if token.is_zero() {
@@ -131,7 +136,7 @@ impl IErc721Enumerable for Erc721Enumerable {
         U256::from(tokens_length)
     }
 
-    fn token_by_index(&self, index: U256) -> Result<U256, Error> {
+    fn token_by_index(&self, index: U256) -> Result<U256, Self::Error> {
         self._all_tokens.get(index).ok_or(
             ERC721OutOfBoundsIndex { owner: Address::ZERO, index }.into(),
         )

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -199,7 +199,7 @@ unsafe impl TopLevelStorage for Erc721 {}
 
 /// Required interface of an [`Erc721`] compliant contract.
 pub trait IErc721 {
-    /// The error type associated with ERC-721 contract.
+    /// The error type associated to this ERC-721 trait implementation.
     type Error: Into<alloc::vec::Vec<u8>>;
 
     /// Returns the number of tokens in `owner`'s account.

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -10,10 +10,7 @@ use stylus_sdk::{
     prelude::*,
 };
 
-use crate::{
-    token::erc721,
-    utils::math::storage::{AddAssignUnchecked, SubAssignUnchecked},
-};
+use crate::utils::math::storage::{AddAssignUnchecked, SubAssignUnchecked};
 
 pub mod extensions;
 

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -5,15 +5,12 @@ use alloy_primitives::{fixed_bytes, uint, Address, FixedBytes, U128, U256};
 use stylus_sdk::{
     abi::Bytes,
     alloy_sol_types::sol,
-    call::{self, Call},
+    call::{self, Call, MethodError},
     evm, msg,
     prelude::*,
 };
 
-use crate::{
-    impl_method_error,
-    utils::math::storage::{AddAssignUnchecked, SubAssignUnchecked},
-};
+use crate::utils::math::storage::{AddAssignUnchecked, SubAssignUnchecked};
 
 pub mod extensions;
 
@@ -153,7 +150,11 @@ pub enum Error {
     InvalidOperator(ERC721InvalidOperator),
 }
 
-impl_method_error!(Error);
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
+}
 
 sol_interface! {
     /// [`Erc721`] token receiver interface.

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -5,12 +5,15 @@ use alloy_primitives::{fixed_bytes, uint, Address, FixedBytes, U128, U256};
 use stylus_sdk::{
     abi::Bytes,
     alloy_sol_types::sol,
-    call::{self, Call},
+    call::{self, Call, MethodError},
     evm, msg,
     prelude::*,
 };
 
-use crate::utils::math::storage::{AddAssignUnchecked, SubAssignUnchecked};
+use crate::{
+    token::erc721,
+    utils::math::storage::{AddAssignUnchecked, SubAssignUnchecked},
+};
 
 pub mod extensions;
 
@@ -150,6 +153,12 @@ pub enum Error {
     InvalidOperator(ERC721InvalidOperator),
 }
 
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
+}
+
 sol_interface! {
     /// [`Erc721`] token receiver interface.
     ///
@@ -193,8 +202,9 @@ unsafe impl TopLevelStorage for Erc721 {}
 
 /// Required interface of an [`Erc721`] compliant contract.
 pub trait IErc721 {
-    /// The error type associated to this ERC-721 trait implementation.
+    /// The error type associated with ERC-721 contract.
     type Error: Into<alloc::vec::Vec<u8>>;
+
     /// Returns the number of tokens in `owner`'s account.
     ///
     /// # Arguments

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -5,12 +5,15 @@ use alloy_primitives::{fixed_bytes, uint, Address, FixedBytes, U128, U256};
 use stylus_sdk::{
     abi::Bytes,
     alloy_sol_types::sol,
-    call::{self, Call, MethodError},
+    call::{self, Call},
     evm, msg,
     prelude::*,
 };
 
-use crate::utils::math::storage::{AddAssignUnchecked, SubAssignUnchecked};
+use crate::{
+    impl_method_error,
+    utils::math::storage::{AddAssignUnchecked, SubAssignUnchecked},
+};
 
 pub mod extensions;
 
@@ -150,11 +153,7 @@ pub enum Error {
     InvalidOperator(ERC721InvalidOperator),
 }
 
-impl MethodError for Error {
-    fn encode(self) -> alloc::vec::Vec<u8> {
-        self.into()
-    }
-}
+impl_method_error!(Error);
 
 sol_interface! {
     /// [`Erc721`] token receiver interface.

--- a/contracts/src/utils/cryptography/ecdsa.rs
+++ b/contracts/src/utils/cryptography/ecdsa.rs
@@ -8,9 +8,11 @@ use alloy_primitives::{address, uint, Address, B256, U256};
 use alloy_sol_types::{sol, SolType};
 use stylus_proc::SolidityError;
 use stylus_sdk::{
-    call::{self, Call},
+    call::{self, Call, MethodError},
     storage::TopLevelStorage,
 };
+
+use crate::utils::cryptography::ecdsa;
 
 /// Address of the `ecrecover` EVM precompile.
 pub const ECRECOVER_ADDR: Address =
@@ -52,6 +54,12 @@ pub enum Error {
     InvalidSignatureLength(ECDSAInvalidSignatureLength),
     /// The signature has an `S` value that is in the upper half order.
     InvalidSignatureS(ECDSAInvalidSignatureS),
+}
+
+impl MethodError for ecdsa::Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
 }
 
 sol! {

--- a/contracts/src/utils/cryptography/ecdsa.rs
+++ b/contracts/src/utils/cryptography/ecdsa.rs
@@ -8,11 +8,11 @@ use alloy_primitives::{address, uint, Address, B256, U256};
 use alloy_sol_types::{sol, SolType};
 use stylus_proc::SolidityError;
 use stylus_sdk::{
-    call::{self, Call},
+    call::{self, Call, MethodError},
     storage::TopLevelStorage,
 };
 
-use crate::impl_method_error;
+use crate::utils::cryptography::ecdsa;
 
 /// Address of the `ecrecover` EVM precompile.
 pub const ECRECOVER_ADDR: Address =
@@ -56,7 +56,11 @@ pub enum Error {
     InvalidSignatureS(ECDSAInvalidSignatureS),
 }
 
-impl_method_error!(Error);
+impl MethodError for ecdsa::Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
+}
 
 sol! {
     /// Struct with callable data to the `ecrecover` precompile.

--- a/contracts/src/utils/cryptography/ecdsa.rs
+++ b/contracts/src/utils/cryptography/ecdsa.rs
@@ -8,11 +8,11 @@ use alloy_primitives::{address, uint, Address, B256, U256};
 use alloy_sol_types::{sol, SolType};
 use stylus_proc::SolidityError;
 use stylus_sdk::{
-    call::{self, Call, MethodError},
+    call::{self, Call},
     storage::TopLevelStorage,
 };
 
-use crate::utils::cryptography::ecdsa;
+use crate::impl_method_error;
 
 /// Address of the `ecrecover` EVM precompile.
 pub const ECRECOVER_ADDR: Address =
@@ -56,11 +56,7 @@ pub enum Error {
     InvalidSignatureS(ECDSAInvalidSignatureS),
 }
 
-impl MethodError for ecdsa::Error {
-    fn encode(self) -> alloc::vec::Vec<u8> {
-        self.into()
-    }
-}
+impl_method_error!(Error);
 
 sol! {
     /// Struct with callable data to the `ecrecover` precompile.

--- a/contracts/src/utils/mod.rs
+++ b/contracts/src/utils/mod.rs
@@ -5,18 +5,6 @@ pub mod metadata;
 pub mod nonces;
 pub mod pausable;
 pub mod structs;
+
 pub use metadata::Metadata;
 pub use pausable::Pausable;
-
-/// Implement [`stylus_sdk::call::MethodError`] trait for the error type.
-/// Will make it possible to reuse error in the other contract.
-#[macro_export]
-macro_rules! impl_method_error {
-    ($error_ty:ty) => {
-        impl stylus_sdk::call::MethodError for $error_ty {
-            fn encode(self) -> alloc::vec::Vec<u8> {
-                self.into()
-            }
-        }
-    };
-}

--- a/contracts/src/utils/mod.rs
+++ b/contracts/src/utils/mod.rs
@@ -5,6 +5,18 @@ pub mod metadata;
 pub mod nonces;
 pub mod pausable;
 pub mod structs;
-
 pub use metadata::Metadata;
 pub use pausable::Pausable;
+
+/// Implement [`stylus_sdk::call::MethodError`] trait for the error type.
+/// Will make it possible to reuse error in the other contract.
+#[macro_export]
+macro_rules! impl_method_error {
+    ($error_ty:ty) => {
+        impl stylus_sdk::call::MethodError for $error_ty {
+            fn encode(self) -> alloc::vec::Vec<u8> {
+                self.into()
+            }
+        }
+    };
+}

--- a/contracts/src/utils/structs/checkpoints.rs
+++ b/contracts/src/utils/structs/checkpoints.rs
@@ -7,9 +7,12 @@
 use alloy_primitives::{uint, Uint, U256, U32};
 use alloy_sol_types::sol;
 use stylus_proc::{sol_storage, SolidityError};
-use stylus_sdk::storage::{StorageGuard, StorageGuardMut};
+use stylus_sdk::{
+    call::MethodError,
+    storage::{StorageGuard, StorageGuardMut},
+};
 
-use crate::utils::math::alloy::Math;
+use crate::utils::{math::alloy::Math, structs::checkpoints};
 
 // TODO: add generics for other pairs (uint32, uint224) and (uint48, uint208).
 // Logic should be the same.
@@ -27,6 +30,12 @@ sol! {
 pub enum Error {
     /// A value was attempted to be inserted into a past checkpoint.
     CheckpointUnorderedInsertion(CheckpointUnorderedInsertion),
+}
+
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
 }
 
 sol_storage! {

--- a/contracts/src/utils/structs/checkpoints.rs
+++ b/contracts/src/utils/structs/checkpoints.rs
@@ -7,12 +7,9 @@
 use alloy_primitives::{uint, Uint, U256, U32};
 use alloy_sol_types::sol;
 use stylus_proc::{sol_storage, SolidityError};
-use stylus_sdk::{
-    call::MethodError,
-    storage::{StorageGuard, StorageGuardMut},
-};
+use stylus_sdk::storage::{StorageGuard, StorageGuardMut};
 
-use crate::utils::math::alloy::Math;
+use crate::{impl_method_error, utils::math::alloy::Math};
 
 // TODO: add generics for other pairs (uint32, uint224) and (uint48, uint208).
 // Logic should be the same.
@@ -32,11 +29,7 @@ pub enum Error {
     CheckpointUnorderedInsertion(CheckpointUnorderedInsertion),
 }
 
-impl MethodError for Error {
-    fn encode(self) -> alloc::vec::Vec<u8> {
-        self.into()
-    }
-}
+impl_method_error!(Error);
 
 sol_storage! {
     /// State of the checkpoint library contract.

--- a/contracts/src/utils/structs/checkpoints.rs
+++ b/contracts/src/utils/structs/checkpoints.rs
@@ -7,9 +7,12 @@
 use alloy_primitives::{uint, Uint, U256, U32};
 use alloy_sol_types::sol;
 use stylus_proc::{sol_storage, SolidityError};
-use stylus_sdk::storage::{StorageGuard, StorageGuardMut};
+use stylus_sdk::{
+    call::MethodError,
+    storage::{StorageGuard, StorageGuardMut},
+};
 
-use crate::{impl_method_error, utils::math::alloy::Math};
+use crate::utils::math::alloy::Math;
 
 // TODO: add generics for other pairs (uint32, uint224) and (uint48, uint208).
 // Logic should be the same.
@@ -29,7 +32,11 @@ pub enum Error {
     CheckpointUnorderedInsertion(CheckpointUnorderedInsertion),
 }
 
-impl_method_error!(Error);
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
+}
 
 sol_storage! {
     /// State of the checkpoint library contract.

--- a/contracts/src/utils/structs/checkpoints.rs
+++ b/contracts/src/utils/structs/checkpoints.rs
@@ -12,7 +12,7 @@ use stylus_sdk::{
     storage::{StorageGuard, StorageGuardMut},
 };
 
-use crate::utils::{math::alloy::Math, structs::checkpoints};
+use crate::utils::math::alloy::Math;
 
 // TODO: add generics for other pairs (uint32, uint224) and (uint48, uint208).
 // Logic should be the same.


### PR DESCRIPTION
Allows to the library users to reuse our traits with their own error types.
And it is more "rusty" approach having associated error types for traits with fallible functions.
Adds new functional macro for the `MethodError` trait.