### PR TITLE
feat: cache contracts before benching

### DIFF
--- a/.github/workflows/gas-bench.yml
+++ b/.github/workflows/gas-bench.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           key: "gas-bench"
 
+      - name: install cargo-stylus
+        run: cargo install cargo-stylus@0.4.2 cargo-stylus-check@0.4.2
+
       - name: install solc
         run: |
           curl -LO https://github.com/ethereum/solidity/releases/download/v0.8.21/solc-static-linux

--- a/.github/workflows/gas-bench.yml
+++ b/.github/workflows/gas-bench.yml
@@ -32,7 +32,7 @@ jobs:
           key: "gas-bench"
 
       - name: install cargo-stylus
-        run: cargo install cargo-stylus@0.4.2 cargo-stylus-check@0.4.2
+        run: cargo install cargo-stylus@0.5.1
 
       - name: install solc
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,6 +822,7 @@ dependencies = [
  "alloy-primitives",
  "e2e",
  "eyre",
+ "futures",
  "keccak-const",
  "koba",
  "openzeppelin-stylus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ rand = "0.8.5"
 regex = "1.10.4"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 tokio = { version = "1.12.0", features = ["full"] }
+futures = "0.3.30"
 
 # procedural macros
 syn = { version = "2.0.58", features = ["full"] }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,6 +11,7 @@ openzeppelin-stylus = { path = "../contracts" }
 alloy-primitives = { workspace = true, features = ["tiny-keccak"] }
 alloy.workspace = true
 tokio.workspace = true
+futures.workspace = true
 eyre.workspace = true
 koba.workspace = true
 e2e = { path = "../lib/e2e" }

--- a/benches/src/access_control.rs
+++ b/benches/src/access_control.rs
@@ -50,7 +50,9 @@ pub async fn bench() -> eyre::Result<Report> {
         .wallet(EthereumWallet::from(bob.signer.clone()))
         .on_http(bob.url().parse()?);
 
-    let contract_addr = deploy(&alice).await;
+    let contract_addr = deploy(&alice).await?;
+    crate::cache_contract(&alice, contract_addr)?;
+
     let contract = AccessControl::new(contract_addr, &alice_wallet);
     let contract_bob = AccessControl::new(contract_addr, &bob_wallet);
 
@@ -72,7 +74,7 @@ pub async fn bench() -> eyre::Result<Report> {
     Ok(report)
 }
 
-async fn deploy(account: &Account) -> Address {
+async fn deploy(account: &Account) -> eyre::Result<Address> {
     let args = AccessControl::constructorCall {};
     let args = alloy::hex::encode(args.abi_encode());
     crate::deploy(account, "access-control", Some(args)).await

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -67,7 +67,7 @@ pub async fn bench() -> eyre::Result<Report> {
     // should have plenty of room to fill the cache (can hold ~4k contracts).
     let status = Command::new("cargo-stylus")
         .arg("cache")
-        .args(&["--e", &std::env::var("RPC_URL")?])
+        .args(&["-e", &std::env::var("RPC_URL")?])
         .args(&["--private-key", &format!("0x{}", alice.pk())])
         .args(&["--address", &format!("{}", contract_addr)])
         .status()

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -9,7 +9,10 @@ use alloy::{
 use alloy_primitives::U256;
 use e2e::{receipt, Account};
 
-use crate::report::Report;
+use crate::{
+    report::{ContractReport, FunctionReport},
+    CacheOpt,
+};
 
 sol!(
     #[sol(rpc)]
@@ -39,7 +42,23 @@ const TOKEN_NAME: &str = "Test Token";
 const TOKEN_SYMBOL: &str = "TTK";
 const CAP: U256 = uint!(1_000_000_U256);
 
-pub async fn bench() -> eyre::Result<Report> {
+pub async fn bench() -> eyre::Result<ContractReport> {
+    let reports = run_with(CacheOpt::None).await?;
+    let report = reports
+        .into_iter()
+        .try_fold(ContractReport::new("Erc20"), ContractReport::add)?;
+
+    let cached_reports = run_with(CacheOpt::Bid(0)).await?;
+    let report = cached_reports
+        .into_iter()
+        .try_fold(report, ContractReport::add_cached)?;
+
+    Ok(report)
+}
+
+pub async fn run_with(
+    cache_opt: CacheOpt,
+) -> eyre::Result<Vec<FunctionReport>> {
     let alice = Account::new().await?;
     let alice_addr = alice.address();
     let alice_wallet = ProviderBuilder::new()
@@ -56,8 +75,7 @@ pub async fn bench() -> eyre::Result<Report> {
         .wallet(EthereumWallet::from(bob.signer.clone()))
         .on_http(bob.url().parse()?);
 
-    let contract_addr = deploy(&alice).await?;
-    crate::cache_contract(&alice, contract_addr)?;
+    let contract_addr = deploy(&alice, cache_opt).await?;
 
     let contract = Erc20::new(contract_addr, &alice_wallet);
     let contract_bob = Erc20::new(contract_addr, &bob_wallet);
@@ -81,17 +99,21 @@ pub async fn bench() -> eyre::Result<Report> {
         (transferFromCall::SIGNATURE, receipt!(contract_bob.transferFrom(alice_addr, bob_addr, uint!(4_U256)))?),
     ];
 
-    let report =
-        receipts.into_iter().try_fold(Report::new("Erc20"), Report::add)?;
-    Ok(report)
+    receipts
+        .into_iter()
+        .map(FunctionReport::new)
+        .collect::<eyre::Result<Vec<_>>>()
 }
 
-async fn deploy(account: &Account) -> eyre::Result<Address> {
+async fn deploy(
+    account: &Account,
+    cache_opt: CacheOpt,
+) -> eyre::Result<Address> {
     let args = Erc20Example::constructorCall {
         name_: TOKEN_NAME.to_owned(),
         symbol_: TOKEN_SYMBOL.to_owned(),
         cap_: CAP,
     };
     let args = alloy::hex::encode(args.abi_encode());
-    crate::deploy(account, "erc20", Some(args)).await
+    crate::deploy(account, "erc20", Some(args), cache_opt).await
 }

--- a/benches/src/erc20.rs
+++ b/benches/src/erc20.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 use alloy::{
     network::{AnyNetwork, EthereumWallet},
     primitives::Address,
@@ -8,6 +10,7 @@ use alloy::{
 };
 use alloy_primitives::U256;
 use e2e::{receipt, Account};
+use eyre::{bail, Context};
 
 use crate::report::Report;
 
@@ -59,6 +62,19 @@ pub async fn bench() -> eyre::Result<Report> {
     let contract_addr = deploy(&alice).await;
     let contract = Erc20::new(contract_addr, &alice_wallet);
     let contract_bob = Erc20::new(contract_addr, &bob_wallet);
+
+    // Add contract to cache manager. We leave the bid unspecified, since we
+    // should have plenty of room to fill the cache (can hold ~4k contracts).
+    let status = Command::new("cargo-stylus")
+        .arg("cache")
+        .args(&["--e", &std::env::var("RPC_URL")?])
+        .args(&["--private-key", &format!("0x{}", alice.pk())])
+        .args(&["--address", &format!("{}", contract_addr)])
+        .status()
+        .with_context(|| "`cargo stylus cache` failed:")?;
+    if !status.success() {
+        bail!("Failed to cache Erc20 contract");
+    }
 
     // IMPORTANT: Order matters!
     use Erc20::*;

--- a/benches/src/erc721.rs
+++ b/benches/src/erc721.rs
@@ -41,7 +41,9 @@ pub async fn bench() -> eyre::Result<Report> {
     let bob = Account::new().await?;
     let bob_addr = bob.address();
 
-    let contract_addr = deploy(&alice).await;
+    let contract_addr = deploy(&alice).await?;
+    crate::cache_contract(&alice, contract_addr)?;
+
     let contract = Erc721::new(contract_addr, &alice_wallet);
 
     let token_1 = uint!(1_U256);
@@ -75,7 +77,7 @@ pub async fn bench() -> eyre::Result<Report> {
     Ok(report)
 }
 
-async fn deploy(account: &Account) -> Address {
+async fn deploy(account: &Account) -> eyre::Result<Address> {
     let args = Erc721Example::constructorCall {};
     let args = alloy::hex::encode(args.abi_encode());
     crate::deploy(account, "erc721", Some(args)).await

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -13,6 +13,7 @@ async fn main() -> eyre::Result<()> {
     let report =
         reports.into_iter().fold(Reports::default(), Reports::merge_with);
 
+    println!();
     println!("{report}");
 
     Ok(())

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -1,20 +1,19 @@
 use benches::{
     access_control, erc20, erc721, merkle_proofs, report::BenchmarkReport,
 };
+use futures::FutureExt;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let reports = tokio::join!(
-        access_control::bench(),
-        erc20::bench(),
-        erc721::bench(),
-        merkle_proofs::bench()
-    );
-
-    let reports = [reports.0?, reports.1?, reports.2?, reports.3?];
-    let report = reports
-        .into_iter()
-        .fold(BenchmarkReport::default(), BenchmarkReport::merge_with);
+    let report = futures::future::try_join_all([
+        access_control::bench().boxed(),
+        erc20::bench().boxed(),
+        erc721::bench().boxed(),
+        merkle_proofs::bench().boxed(),
+    ])
+    .await?
+    .into_iter()
+    .fold(BenchmarkReport::default(), BenchmarkReport::merge_with);
 
     println!();
     println!("{report}");

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -1,4 +1,6 @@
-use benches::{access_control, erc20, erc721, merkle_proofs, report::Reports};
+use benches::{
+    access_control, erc20, erc721, merkle_proofs, report::BenchmarkReport,
+};
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
@@ -10,8 +12,9 @@ async fn main() -> eyre::Result<()> {
     );
 
     let reports = [reports.0?, reports.1?, reports.2?, reports.3?];
-    let report =
-        reports.into_iter().fold(Reports::default(), Reports::merge_with);
+    let report = reports
+        .into_iter()
+        .fold(BenchmarkReport::default(), BenchmarkReport::merge_with);
 
     println!();
     println!("{report}");

--- a/benches/src/merkle_proofs.rs
+++ b/benches/src/merkle_proofs.rs
@@ -8,7 +8,10 @@ use alloy::{
 };
 use e2e::{receipt, Account};
 
-use crate::report::Report;
+use crate::{
+    report::{ContractReport, FunctionReport},
+    CacheOpt,
+};
 
 sol!(
     #[sol(rpc)]
@@ -57,7 +60,23 @@ const PROOF: [[u8; 32]; 16] = bytes_array! {
     "fd47b6c292f51911e8dfdc3e4f8bd127773b17f25b7a554beaa8741e99c41208",
 };
 
-pub async fn bench() -> eyre::Result<Report> {
+pub async fn bench() -> eyre::Result<ContractReport> {
+    let reports = run_with(CacheOpt::None).await?;
+    let report = reports
+        .into_iter()
+        .try_fold(ContractReport::new("MerkleProofs"), ContractReport::add)?;
+
+    let cached_reports = run_with(CacheOpt::Bid(0)).await?;
+    let report = cached_reports
+        .into_iter()
+        .try_fold(report, ContractReport::add_cached)?;
+
+    Ok(report)
+}
+
+pub async fn run_with(
+    cache_opt: CacheOpt,
+) -> eyre::Result<Vec<FunctionReport>> {
     let alice = Account::new().await?;
     let alice_wallet = ProviderBuilder::new()
         .network::<AnyNetwork>()
@@ -65,8 +84,7 @@ pub async fn bench() -> eyre::Result<Report> {
         .wallet(EthereumWallet::from(alice.signer.clone()))
         .on_http(alice.url().parse()?);
 
-    let contract_addr = deploy(&alice).await?;
-    crate::cache_contract(&alice, contract_addr)?;
+    let contract_addr = deploy(&alice, cache_opt).await?;
 
     let contract = Verifier::new(contract_addr, &alice_wallet);
 
@@ -77,12 +95,15 @@ pub async fn bench() -> eyre::Result<Report> {
         receipt!(contract.verify(proof, ROOT.into(), LEAF.into()))?,
     )];
 
-    let report = receipts
+    receipts
         .into_iter()
-        .try_fold(Report::new("MerkleProofs"), Report::add)?;
-    Ok(report)
+        .map(FunctionReport::new)
+        .collect::<eyre::Result<Vec<_>>>()
 }
 
-async fn deploy(account: &Account) -> eyre::Result<Address> {
-    crate::deploy(account, "merkle-proofs", None).await
+async fn deploy(
+    account: &Account,
+    cache_opt: CacheOpt,
+) -> eyre::Result<Address> {
+    crate::deploy(account, "merkle-proofs", None, cache_opt).await
 }

--- a/benches/src/merkle_proofs.rs
+++ b/benches/src/merkle_proofs.rs
@@ -65,7 +65,9 @@ pub async fn bench() -> eyre::Result<Report> {
         .wallet(EthereumWallet::from(alice.signer.clone()))
         .on_http(alice.url().parse()?);
 
-    let contract_addr = deploy(&alice).await;
+    let contract_addr = deploy(&alice).await?;
+    crate::cache_contract(&alice, contract_addr)?;
+
     let contract = Verifier::new(contract_addr, &alice_wallet);
 
     let proof = PROOF.map(|h| h.into()).to_vec();
@@ -81,6 +83,6 @@ pub async fn bench() -> eyre::Result<Report> {
     Ok(report)
 }
 
-async fn deploy(account: &Account) -> Address {
+async fn deploy(account: &Account) -> eyre::Result<Address> {
     crate::deploy(account, "merkle-proofs", None).await
 }

--- a/lib/e2e/src/account.rs
+++ b/lib/e2e/src/account.rs
@@ -13,6 +13,8 @@ use crate::{
     system::{fund_account, Wallet, RPC_URL_ENV_VAR_NAME},
 };
 
+const DEFAULT_FUNDING_ETH: u32 = 100;
+
 /// Type that corresponds to a test account.
 #[derive(Clone, Debug)]
 pub struct Account {
@@ -23,7 +25,7 @@ pub struct Account {
 }
 
 impl Account {
-    /// Create a new account.
+    /// Create a new account with default funding of 100 ETH.
     ///
     /// # Errors
     ///
@@ -103,7 +105,7 @@ impl AccountFactory {
 
         let signer = PrivateKeySigner::random();
         let addr = signer.address();
-        fund_account(addr, "100")?;
+        fund_account(addr, DEFAULT_FUNDING_ETH)?;
 
         let rpc_url = std::env::var(RPC_URL_ENV_VAR_NAME)
             .expect("failed to load RPC_URL var from env")

--- a/lib/e2e/src/account.rs
+++ b/lib/e2e/src/account.rs
@@ -25,7 +25,7 @@ pub struct Account {
 }
 
 impl Account {
-    /// Create a new account with default funding of 100 ETH.
+    /// Create a new account with a default funding of [`DEFAULT_FUNDING_ETH`].
     ///
     /// # Errors
     ///

--- a/lib/e2e/src/system.rs
+++ b/lib/e2e/src/system.rs
@@ -61,7 +61,7 @@ pub fn provider() -> Provider {
 }
 
 /// Send `amount` eth to `address` in the nitro-tesnode.
-pub fn fund_account(address: Address, amount: &str) -> eyre::Result<()> {
+pub fn fund_account(address: Address, amount: u32) -> eyre::Result<()> {
     let node_script = get_node_path()?.join("test-node.bash");
     if !node_script.exists() {
         bail!("Test nitro node wasn't setup properly. Try to setup it first with `./scripts/nitro-testnode.sh -i -d`")
@@ -73,7 +73,7 @@ pub fn fund_account(address: Address, amount: &str) -> eyre::Result<()> {
         .arg("--to")
         .arg(format!("address_{address}"))
         .arg("--ethamount")
-        .arg(amount)
+        .arg(amount.to_string())
         .output()?;
 
     if !output.status.success() {

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -10,9 +10,8 @@ cargo +"$NIGHTLY_TOOLCHAIN" build --release --target wasm32-unknown-unknown -Z b
 
 export RPC_URL=http://localhost:8547
 
-# No need to run benchmark infrastructure with release.
-# Just compilation will take longer.
-# Contracts already built with release.
+# No need to compile benchmarks with `--release`
+# since gas measurement happens on the contract side
 cargo run -p benches
 
 echo "Finished running benches!"

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -5,9 +5,14 @@ MYDIR=$(realpath "$(dirname "$0")")
 cd "$MYDIR"
 cd ..
 
-NIGHTLY_TOOLCHAIN=${NIGHTLY_TOOLCHAIN:-nightly}
+NIGHTLY_TOOLCHAIN=${NIGHTLY_TOOLCHAIN:-nightly-2024-01-01}
 cargo +"$NIGHTLY_TOOLCHAIN" build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 
 export RPC_URL=http://localhost:8547
-cargo run --release -p benches
+
+# No need to run benchmark infrastructure with release.
+# Just compilation will take longer.
+# Contracts already built with release.
+cargo run -p benches
+
 echo "Finished running benches!"

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -11,7 +11,7 @@ cargo +"$NIGHTLY_TOOLCHAIN" build --release --target wasm32-unknown-unknown -Z b
 export RPC_URL=http://localhost:8547
 
 # No need to compile benchmarks with `--release`
-# since gas measurement happens on the contract side
+# since this only runs the benchmarking code and the contracts have already been compiled with `--release`
 cargo run -p benches
 
 echo "NOTE: To measure non cached contract's gas usage correctly,

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -14,4 +14,7 @@ export RPC_URL=http://localhost:8547
 # since gas measurement happens on the contract side
 cargo run -p benches
 
+echo "NOTE: To measure non cached contract's gas usage correctly,
+ benchmarks should run on a clean instance of the nitro test node."
+echo
 echo "Finished running benches!"

--- a/scripts/nitro-testnode.sh
+++ b/scripts/nitro-testnode.sh
@@ -48,7 +48,7 @@ then
   cd "$MYDIR" || exit
   cd ..
 
-  git clone -b release --recurse-submodules https://github.com/OffchainLabs/nitro-testnode.git
+  git clone --recurse-submodules https://github.com/OffchainLabs/nitro-testnode.git
   cd ./nitro-testnode || exit
   git pull origin release --recurse-submodules
   git checkout 43861b001713db3526b74e905e383d41e9272760 || exit

--- a/scripts/nitro-testnode.sh
+++ b/scripts/nitro-testnode.sh
@@ -21,7 +21,7 @@ do
       NITRO_CONTAINERS=$(docker container ls -q --filter name=nitro-testnode)
 
       if [ -z "$NITRO_CONTAINERS" ]; then
-          echo "No running nitro test node containers"
+          echo "No nitro-testnode containers running"
       else
           docker container stop $NITRO_CONTAINERS || exit
       fi

--- a/scripts/nitro-testnode.sh
+++ b/scripts/nitro-testnode.sh
@@ -51,7 +51,7 @@ then
   git clone --recurse-submodules https://github.com/OffchainLabs/nitro-testnode.git
   cd ./nitro-testnode || exit
   git pull origin release --recurse-submodules
-  git checkout 43861b001713db3526b74e905e383d41e9272760 || exit
+  git checkout d4244cd5c2cb56ca3d11c23478ef9642f8ebf472 || exit
 
   ./test-node.bash --no-run --init || exit
 fi

--- a/scripts/nitro-testnode.sh
+++ b/scripts/nitro-testnode.sh
@@ -18,7 +18,14 @@ do
       shift
       ;;
     -q|--quit)
-      docker container stop $(docker container ls -q --filter name=nitro-testnode)
+      NITRO_CONTAINERS=$(docker container ls -q --filter name=nitro-testnode)
+
+      if [ -z "$NITRO_CONTAINERS" ]; then
+          echo "No running nitro test node containers"
+      else
+          docker container stop $NITRO_CONTAINERS || exit
+      fi
+
       exit 0
       ;;
     *)
@@ -41,10 +48,10 @@ then
   cd "$MYDIR" || exit
   cd ..
 
-  git clone --recurse-submodules https://github.com/OffchainLabs/nitro-testnode.git
+  git clone -b release --recurse-submodules https://github.com/OffchainLabs/nitro-testnode.git
   cd ./nitro-testnode || exit
-  # `release` branch.
-  git checkout 8cb6b84e31909157d431e7e4af9fb83799443e00 || exit
+  git pull origin release --recurse-submodules
+  git checkout 43861b001713db3526b74e905e383d41e9272760 || exit
 
   ./test-node.bash --no-run --init || exit
 fi


### PR DESCRIPTION
Use the `cargo stylus cache` to cache contracts in the `CacheManager` before running benches.
