### PR TITLE
Add rc tag to antora docs and improve security warning in docs

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,6 @@
 name: contracts-stylus
 title: Contracts for Stylus
 version: 0.1.0
+prerelease: '-rc' #we can remove this with the official release
 nav:
   - modules/ROOT/nav.adoc

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -4,6 +4,6 @@
 
 *A library for secure smart contract development* written in Rust for {stylus}.
 
-WARNING: This repo contains highly experimental code. *Use at your own risk.*
+WARNING: This repo contains highly experimental code. It has never been audited nor thoroughly reviewed for security vulnerabilities. *Use at your own risk.*
 
 NOTE: You can track our roadmap in our https://github.com/orgs/OpenZeppelin/projects/35[Github Project].


### PR DESCRIPTION
Add the rc tag to the docs so we can publish them before the audit. It should be shown as `0.1.0-rc` on the site. I also made clear in the warning that this hasn't been audited yet.