### PR TITLE
feat: erc165 support interface

### DIFF
--- a/.github/workflows/check-publish.yml
+++ b/.github/workflows/check-publish.yml
@@ -37,6 +37,9 @@ jobs:
       - name: check openzeppelin-crypto
         run: cargo publish -p openzeppelin-crypto --target wasm32-unknown-unknown  --dry-run
 
+      - name: check openzeppelin-stylus-proc
+        run: cargo publish -p openzeppelin-stylus-proc --target wasm32-unknown-unknown  --dry-run
+
         # TODO: https://github.com/OpenZeppelin/rust-contracts-stylus/issues/291
       # - name: check openzeppelin-stylus
         # run: cargo publish -p openzeppelin-stylus --target wasm32-unknown-unknown  --dry-run

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,8 +2602,8 @@ name = "openzeppelin-stylus-proc"
 version = "0.1.0"
 dependencies = [
  "convert_case 0.6.0",
- "proc-macro2 1.0.86",
- "quote 1.0.36",
+ "proc-macro2",
+ "quote",
  "syn 2.0.68",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin-stylus-proc"
-version = "0.1.0"
+version = "0.1.0-rc"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,9 +2585,20 @@ dependencies = [
  "keccak-const",
  "mini-alloc",
  "motsu",
+ "openzeppelin-stylus-proc",
  "rand",
  "stylus-proc",
  "stylus-sdk",
+]
+
+[[package]]
+name = "openzeppelin-stylus-proc"
+version = "0.1.0"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2 1.0.86",
+ "quote 1.0.36",
+ "syn 2.0.68",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "contracts",
+  "contracts-proc",
   "lib/crypto",
   "lib/motsu",
   "lib/motsu-proc",
@@ -21,6 +22,7 @@ members = [
 ]
 default-members = [
   "contracts",
+  "contracts-proc",
   "lib/crypto",
   "lib/motsu",
   "lib/motsu-proc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ quote = "1.0.35"
 
 # members
 openzeppelin-stylus = { path = "contracts" }
+openzeppelin-stylus-proc = { path = "contracts-proc" }
 openzeppelin-crypto = { path = "lib/crypto" }
 motsu = { path = "lib/motsu"}
 motsu-proc = { path = "lib/motsu-proc", version = "0.1.0" }

--- a/contracts-proc/Cargo.toml
+++ b/contracts-proc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openzeppelin-stylus-proc"
 description = "Procedural macros for OpenZeppelin Stylus contracts"
-version = "0.1.0"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/contracts-proc/Cargo.toml
+++ b/contracts-proc/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "openzeppelin-stylus-proc"
+description = "Procedural macros for OpenZeppelin Stylus contracts"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+keywords.workspace = true
+repository.workspace = true
+
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
+convert_case = "0.6.0"
+
+[lints]
+workspace = true
+
+[lib]
+proc-macro = true

--- a/contracts-proc/src/interface.rs
+++ b/contracts-proc/src/interface.rs
@@ -3,7 +3,7 @@ use std::mem;
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
-use quote::{quote, ToTokens};
+use quote::quote;
 use syn::{
     parse::{Parse, ParseStream},
     parse_macro_input, FnArg, ItemTrait, LitStr, Result, Token, TraitItem,

--- a/contracts-proc/src/interface.rs
+++ b/contracts-proc/src/interface.rs
@@ -1,0 +1,118 @@
+use std::mem;
+
+use convert_case::{Case, Casing};
+use proc_macro::TokenStream;
+use proc_macro2::Ident;
+use quote::{quote, ToTokens};
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input, FnArg, ItemTrait, LitStr, Result, Token, TraitItem,
+};
+
+/// TODO#q: description
+pub fn interface(_attr: TokenStream, input: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(input as ItemTrait);
+    let mut output = quote! {};
+
+    let mut selectors = Vec::new();
+    for item in &mut input.items {
+        let TraitItem::Fn(func) = item else {
+            continue;
+        };
+
+        let mut override_name = None;
+        for attr in mem::take(&mut func.attrs) {
+            let Some(ident) = attr.path().get_ident() else {
+                func.attrs.push(attr);
+                continue;
+            };
+            if *ident == "selector" {
+                if override_name.is_some() {
+                    error!(attr.path(), "more than one selector attribute");
+                }
+                let args: SelectorArgs = match attr.parse_args() {
+                    Ok(args) => args,
+                    Err(error) => error!(ident, "{}", error),
+                };
+                override_name = Some(args.name);
+                continue;
+            }
+            func.attrs.push(attr);
+        }
+
+        let sol_name = override_name.unwrap_or_else(|| {
+            func.sig.ident.clone().to_string().to_case(Case::Camel)
+        });
+
+        let args = func.sig.inputs.iter();
+        let arg_types: Vec<_> = args
+            .filter_map(|arg| match arg {
+                FnArg::Typed(t) => Some(t.ty.clone()),
+                _ => None,
+            })
+            .collect();
+
+        let selector = quote! { u32::from_be_bytes(stylus_sdk::function_selector!(#sol_name #(, #arg_types )*)) };
+        selectors.push(selector);
+    }
+
+    let name = input.ident.clone();
+    let vis = input.vis.clone();
+    let attrs = input.attrs.clone();
+    let trait_items = input.items.clone();
+    let (_impl_generics, ty_generics, where_clause) =
+        input.generics.split_for_impl();
+
+    output.extend(quote! {
+        #(#attrs)*
+        #vis trait #name #ty_generics #where_clause {
+            #(#trait_items)*
+
+            /// Solidity interface id associated with current trait.
+            const INTERFACE_ID: u32 = {
+                #(#selectors)^*
+            };
+        }
+    });
+
+    output.into()
+}
+
+struct SelectorArgs {
+    name: String,
+}
+
+impl Parse for SelectorArgs {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut name = None;
+
+        if input.is_empty() {
+            error!(@input.span(), "missing id or text argument");
+        }
+
+        while !input.is_empty() {
+            let ident: Ident = input.parse()?;
+            let _: Token![=] = input.parse()?;
+
+            match ident.to_string().as_str() {
+                "name" => {
+                    let lit: LitStr = input.parse()?;
+                    if name.is_some() {
+                        error!(@lit, r#"only one "name" is allowed"#);
+                    }
+                    name = Some(lit.value());
+                }
+                _ => error!(@ident, "Unknown selector attribute"),
+            }
+
+            // allow a comma
+            let _: Result<Token![,]> = input.parse();
+        }
+
+        if let Some(name) = name {
+            Ok(Self { name })
+        } else {
+            error!(@input.span(), r#""name" is required"#);
+        }
+    }
+}

--- a/contracts-proc/src/interface.rs
+++ b/contracts-proc/src/interface.rs
@@ -9,8 +9,8 @@ use syn::{
     parse_macro_input, FnArg, ItemTrait, LitStr, Result, Token, TraitItem,
 };
 
-/// TODO#q: description
-pub fn interface(_attr: TokenStream, input: TokenStream) -> TokenStream {
+/// Computes interface id as an associated constant for the trait.
+pub(crate) fn interface(_attr: TokenStream, input: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(input as ItemTrait);
     let mut output = quote! {};
 

--- a/contracts-proc/src/interface_id.rs
+++ b/contracts-proc/src/interface_id.rs
@@ -17,7 +17,6 @@ pub(crate) fn interface_id(
     input: TokenStream,
 ) -> TokenStream {
     let mut input = parse_macro_input!(input as ItemTrait);
-    let mut output = quote! {};
 
     let mut selectors = Vec::new();
     for item in &mut input.items {
@@ -68,7 +67,7 @@ pub(crate) fn interface_id(
     let (_impl_generics, ty_generics, where_clause) =
         input.generics.split_for_impl();
 
-    output.extend(quote! {
+    quote! {
         #(#attrs)*
         #vis trait #name #ty_generics #where_clause {
             #(#trait_items)*
@@ -78,9 +77,8 @@ pub(crate) fn interface_id(
                 #(#selectors)^*
             };
         }
-    });
-
-    output.into()
+    }
+    .into()
 }
 
 struct SelectorArgs {

--- a/contracts-proc/src/interface_id.rs
+++ b/contracts-proc/src/interface_id.rs
@@ -11,7 +11,7 @@ use syn::{
     parse_macro_input, FnArg, ItemTrait, LitStr, Result, Token, TraitItem,
 };
 
-/// Computes interface id as an associated constant for the trait.
+/// Computes an interface id as an associated constant for the trait.
 pub(crate) fn interface_id(
     _attr: &TokenStream,
     input: TokenStream,

--- a/contracts-proc/src/interface_id.rs
+++ b/contracts-proc/src/interface_id.rs
@@ -1,3 +1,5 @@
+//! Defines the `#[interface_id]` procedural macro.
+
 use std::mem;
 
 use convert_case::{Case, Casing};

--- a/contracts-proc/src/interface_id.rs
+++ b/contracts-proc/src/interface_id.rs
@@ -10,7 +10,10 @@ use syn::{
 };
 
 /// Computes interface id as an associated constant for the trait.
-pub(crate) fn interface(_attr: TokenStream, input: TokenStream) -> TokenStream {
+pub(crate) fn interface_id(
+    _attr: &TokenStream,
+    input: TokenStream,
+) -> TokenStream {
     let mut input = parse_macro_input!(input as ItemTrait);
     let mut output = quote! {};
 
@@ -48,7 +51,7 @@ pub(crate) fn interface(_attr: TokenStream, input: TokenStream) -> TokenStream {
         let arg_types: Vec<_> = args
             .filter_map(|arg| match arg {
                 FnArg::Typed(t) => Some(t.ty.clone()),
-                _ => None,
+                FnArg::Receiver(_) => None,
             })
             .collect();
 

--- a/contracts-proc/src/interface_id.rs
+++ b/contracts-proc/src/interface_id.rs
@@ -73,6 +73,7 @@ pub(crate) fn interface_id(
             #(#trait_items)*
 
             #[doc = concat!("Solidity interface id associated with ", stringify!(#name), " trait.")]
+            #[doc = "Computed as a XOR of selectors for each function in the trait."]
             const INTERFACE_ID: u32 = {
                 #(#selectors)^*
             };

--- a/contracts-proc/src/interface_id.rs
+++ b/contracts-proc/src/interface_id.rs
@@ -44,12 +44,13 @@ pub(crate) fn interface_id(
             func.attrs.push(attr);
         }
 
-        let sol_name = override_name.unwrap_or_else(|| {
-            func.sig.ident.clone().to_string().to_case(Case::Camel)
-        });
+        let sol_name = override_name
+            .unwrap_or_else(|| func.sig.ident.to_string().to_case(Case::Camel));
 
-        let args = func.sig.inputs.iter();
-        let arg_types: Vec<_> = args
+        let arg_types: Vec<_> = func
+            .sig
+            .inputs
+            .iter()
             .filter_map(|arg| match arg {
                 FnArg::Typed(t) => Some(t.ty.clone()),
                 FnArg::Receiver(_) => None,

--- a/contracts-proc/src/lib.rs
+++ b/contracts-proc/src/lib.rs
@@ -19,26 +19,26 @@ macro_rules! error {
 
 mod interface_id;
 
-/// Computes interface id as an associated constant `INTERFACE_ID` for the
-/// trait that describes contract's abi.
-/// Selector collision should be handled with macro `#[selector(name =
-/// "actualSolidityMethodName")]` on top of the method.
+/// Computes interface id as an associated constant `INTERFACE_ID` for the trait
+/// that describes contract's abi.
+/// Selector collision should be handled with
+/// macro `#[selector(name = "actualSolidityMethodName")]` on top of the method.
 ///
 /// # Examples
 ///
 /// ```rust,ignore
 /// #[interface_id]
 /// pub trait IErc721 {
-///     fn balance_of(&self, owner: Address) -> Result<U256, alloc::vec::Vec<u8>>;
+///     fn balance_of(&self, owner: Address) -> Result<U256, Vec<u8>>;
 ///
-///     fn owner_of(&self, token_id: U256) -> Result<Address, alloc::vec::Vec<u8>>;
+///     fn owner_of(&self, token_id: U256) -> Result<Address, Vec<u8>>;
 ///
 ///     fn safe_transfer_from(
 ///         &mut self,
 ///         from: Address,
 ///         to: Address,
 ///         token_id: U256,
-///     ) -> Result<(), alloc::vec::Vec<u8>>;
+///     ) -> Result<(), Vec<u8>>;
 ///
 ///     #[selector(name = "safeTransferFrom")]
 ///     fn safe_transfer_from_with_data(
@@ -47,7 +47,7 @@ mod interface_id;
 ///         to: Address,
 ///         token_id: U256,
 ///         data: Bytes,
-///     ) -> Result<(), alloc::vec::Vec<u8>>;
+///     ) -> Result<(), Vec<u8>>;
 /// }
 ///
 /// impl IErc165 for Erc721 {

--- a/contracts-proc/src/lib.rs
+++ b/contracts-proc/src/lib.rs
@@ -1,0 +1,21 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use syn::parse::Parse;
+
+/// Shorthand to print nice errors.
+macro_rules! error {
+    ($tokens:expr, $($msg:expr),+ $(,)?) => {{
+        let error = syn::Error::new(syn::spanned::Spanned::span(&$tokens), format!($($msg),+));
+        return error.to_compile_error().into();
+    }};
+    (@ $tokens:expr, $($msg:expr),+ $(,)?) => {{
+        return Err(syn::Error::new(syn::spanned::Spanned::span(&$tokens), format!($($msg),+)))
+    }};
+}
+
+mod interface;
+
+#[proc_macro_attribute]
+pub fn interface(attr: TokenStream, input: TokenStream) -> TokenStream {
+    interface::interface(attr, input)
+}

--- a/contracts-proc/src/lib.rs
+++ b/contracts-proc/src/lib.rs
@@ -21,6 +21,7 @@ mod interface_id;
 
 /// Computes interface id as an associated constant `INTERFACE_ID` for the trait
 /// that describes contract's abi.
+///
 /// Selector collision should be handled with
 /// macro `#[selector(name = "actualSolidityMethodName")]` on top of the method.
 ///

--- a/contracts-proc/src/lib.rs
+++ b/contracts-proc/src/lib.rs
@@ -19,8 +19,8 @@ macro_rules! error {
 
 mod interface_id;
 
-/// Computes interface id as an associated constant `INTERFACE_ID` for the trait
-/// that describes contract's abi.
+/// Computes the interface id as an associated constant `INTERFACE_ID` for the
+/// trait that describes contract's abi.
 ///
 /// Selector collision should be handled with
 /// macro `#[selector(name = "actualSolidityMethodName")]` on top of the method.

--- a/contracts-proc/src/lib.rs
+++ b/contracts-proc/src/lib.rs
@@ -1,3 +1,5 @@
+// TODO#q: add crate documentation.
+
 extern crate proc_macro;
 use proc_macro::TokenStream;
 use syn::parse::Parse;
@@ -15,6 +17,7 @@ macro_rules! error {
 
 mod interface;
 
+/// Computes interface id as an associated constant for the trait.
 #[proc_macro_attribute]
 pub fn interface(attr: TokenStream, input: TokenStream) -> TokenStream {
     interface::interface(attr, input)

--- a/contracts-proc/src/lib.rs
+++ b/contracts-proc/src/lib.rs
@@ -2,7 +2,6 @@
 
 extern crate proc_macro;
 use proc_macro::TokenStream;
-use syn::parse::Parse;
 
 /// Shorthand to print nice errors.
 macro_rules! error {

--- a/contracts-proc/src/lib.rs
+++ b/contracts-proc/src/lib.rs
@@ -1,9 +1,12 @@
-// TODO#q: add crate documentation.
+//! Procedural macro definitions used in `openzeppelin-stylus` smart contracts
+//! library.
 
 extern crate proc_macro;
 use proc_macro::TokenStream;
 
 /// Shorthand to print nice errors.
+///
+/// Note that it's defined before the module declarations.
 macro_rules! error {
     ($tokens:expr, $($msg:expr),+ $(,)?) => {{
         let error = syn::Error::new(syn::spanned::Spanned::span(&$tokens), format!($($msg),+));
@@ -14,10 +17,47 @@ macro_rules! error {
     }};
 }
 
-mod interface;
+mod interface_id;
 
-/// Computes interface id as an associated constant for the trait.
+/// Computes interface id as an associated constant `INTERFACE_ID` for the
+/// trait that describes contract's abi.
+/// Selector collision should be handled with macro `#[selector(name =
+/// "actualSolidityMethodName")]` on top of the method.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// #[interface_id]
+/// pub trait IErc721 {
+///     fn balance_of(&self, owner: Address) -> Result<U256, alloc::vec::Vec<u8>>;
+///
+///     fn owner_of(&self, token_id: U256) -> Result<Address, alloc::vec::Vec<u8>>;
+///
+///     fn safe_transfer_from(
+///         &mut self,
+///         from: Address,
+///         to: Address,
+///         token_id: U256,
+///     ) -> Result<(), alloc::vec::Vec<u8>>;
+///
+///     #[selector(name = "safeTransferFrom")]
+///     fn safe_transfer_from_with_data(
+///         &mut self,
+///         from: Address,
+///         to: Address,
+///         token_id: U256,
+///         data: Bytes,
+///     ) -> Result<(), alloc::vec::Vec<u8>>;
+/// }
+///
+/// impl IErc165 for Erc721 {
+///     fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+///         <Self as IErc721>::INTERFACE_ID == u32::from_be_bytes(*interface_id)
+///             || Erc165::supports_interface(interface_id)
+///     }
+/// }
+/// ```
 #[proc_macro_attribute]
-pub fn interface(attr: TokenStream, input: TokenStream) -> TokenStream {
-    interface::interface(attr, input)
+pub fn interface_id(attr: TokenStream, input: TokenStream) -> TokenStream {
+    interface_id::interface_id(&attr, input)
 }

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -15,6 +15,7 @@ stylus-sdk.workspace = true
 stylus-proc.workspace = true
 mini-alloc.workspace = true
 keccak-const.workspace = true
+openzeppelin-stylus-proc = { path = "../contracts-proc"}
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["arbitrary"] }

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -15,7 +15,7 @@ stylus-sdk.workspace = true
 stylus-proc.workspace = true
 mini-alloc.workspace = true
 keccak-const.workspace = true
-openzeppelin-stylus-proc = { path = "../contracts-proc"}
+openzeppelin-stylus-proc.workspace = true
 
 [dev-dependencies]
 alloy-primitives = { workspace = true, features = ["arbitrary"] }

--- a/contracts/src/token/erc20/extensions/metadata.rs
+++ b/contracts/src/token/erc20/extensions/metadata.rs
@@ -2,7 +2,11 @@
 
 use alloc::string::String;
 
+use alloy_primitives::FixedBytes;
+use openzeppelin_stylus_proc::interface_id;
 use stylus_proc::{public, sol_storage};
+
+use crate::utils::introspection::erc165::IErc165;
 
 /// Number of decimals used by default on implementors of [`Metadata`].
 pub const DEFAULT_DECIMALS: u8 = 18;
@@ -20,6 +24,7 @@ sol_storage! {
 }
 
 /// Interface for the optional metadata functions from the ERC-20 standard.
+#[interface_id]
 pub trait IErc20Metadata {
     /// Returns the name of the token.
     ///
@@ -74,5 +79,12 @@ impl IErc20Metadata for Erc20Metadata {
         // https://github.com/OffchainLabs/stylus-sdk-rs/issues/117
         // gets resolved.
         DEFAULT_DECIMALS
+    }
+}
+
+impl IErc165 for Erc20Metadata {
+    fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+        <Self as IErc20Metadata>::INTERFACE_ID
+            == u32::from_be_bytes(*interface_id)
     }
 }

--- a/contracts/src/token/erc20/extensions/metadata.rs
+++ b/contracts/src/token/erc20/extensions/metadata.rs
@@ -88,3 +88,15 @@ impl IErc165 for Erc20Metadata {
             == u32::from_be_bytes(*interface_id)
     }
 }
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use crate::token::erc20::extensions::{Erc20Metadata, IErc20Metadata};
+
+    #[motsu::test]
+    fn interface_id() {
+        let actual = <Erc20Metadata as IErc20Metadata>::INTERFACE_ID;
+        let expected = 0xa219a025;
+        assert_eq!(actual, expected);
+    }
+}

--- a/contracts/src/token/erc20/mod.rs
+++ b/contracts/src/token/erc20/mod.rs
@@ -4,15 +4,17 @@
 //! revert instead of returning `false` on failure. This behavior is
 //! nonetheless conventional and does not conflict with the expectations of
 //! [`Erc20`] applications.
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, FixedBytes, U256};
 use alloy_sol_types::sol;
-use openzeppelin_stylus_proc::interface;
+use openzeppelin_stylus_proc::interface_id;
 use stylus_proc::SolidityError;
 use stylus_sdk::{
     call::MethodError,
     evm, msg,
     stylus_proc::{public, sol_storage},
 };
+
+use crate::utils::introspection::erc165::{Erc165, IErc165};
 
 pub mod extensions;
 
@@ -112,7 +114,7 @@ sol_storage! {
 }
 
 /// Required interface of an [`Erc20`] compliant contract.
-#[interface]
+#[interface_id]
 pub trait IErc20 {
     /// The error type associated to this ERC-20 trait implementation.
     type Error: Into<alloc::vec::Vec<u8>>;
@@ -285,6 +287,13 @@ impl IErc20 for Erc20 {
         self._spend_allowance(from, spender, value)?;
         self._transfer(from, to, value)?;
         Ok(true)
+    }
+}
+
+impl IErc165 for Erc20 {
+    fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+        <Self as IErc20>::INTERFACE_ID == u32::from_be_bytes(*interface_id)
+            || Erc165::supports_interface(interface_id)
     }
 }
 
@@ -552,7 +561,10 @@ mod tests {
     use stylus_sdk::msg;
 
     use super::{Erc20, Error, IErc20};
-    use crate::token::erc721::{Erc721, IErc721};
+    use crate::{
+        token::erc721::{Erc721, IErc721},
+        utils::introspection::erc165::IErc165,
+    };
 
     #[motsu::test]
     fn reads_balance(contract: Erc20) {
@@ -889,7 +901,11 @@ mod tests {
     #[motsu::test]
     fn interface_id() {
         let actual = <Erc20 as IErc20>::INTERFACE_ID;
-        let expected = 0x_36372b07;
+        let expected = 0x36372b07;
+        assert_eq!(actual, expected);
+
+        let actual = <Erc20 as IErc165>::INTERFACE_ID;
+        let expected = 0x01ffc9a7;
         assert_eq!(actual, expected);
     }
 }

--- a/contracts/src/token/erc20/mod.rs
+++ b/contracts/src/token/erc20/mod.rs
@@ -6,6 +6,7 @@
 //! [`Erc20`] applications.
 use alloy_primitives::{Address, U256};
 use alloy_sol_types::sol;
+use openzeppelin_stylus_proc::interface;
 use stylus_proc::SolidityError;
 use stylus_sdk::{
     call::MethodError,
@@ -111,6 +112,7 @@ sol_storage! {
 }
 
 /// Required interface of an [`Erc20`] compliant contract.
+#[interface]
 pub trait IErc20 {
     /// The error type associated to this ERC-20 trait implementation.
     type Error: Into<alloc::vec::Vec<u8>>;
@@ -550,6 +552,7 @@ mod tests {
     use stylus_sdk::msg;
 
     use super::{Erc20, Error, IErc20};
+    use crate::token::erc721::{Erc721, IErc721};
 
     #[motsu::test]
     fn reads_balance(contract: Erc20) {
@@ -881,5 +884,12 @@ mod tests {
         let one = uint!(1_U256);
         let result = contract.approve(Address::ZERO, one);
         assert!(matches!(result, Err(Error::InvalidSpender(_))));
+    }
+
+    #[motsu::test]
+    fn interface_id() {
+        let actual = <Erc20 as IErc20>::INTERFACE_ID;
+        let expected = 0x_36372b07;
+        assert_eq!(actual, expected);
     }
 }

--- a/contracts/src/token/erc721/extensions/enumerable.rs
+++ b/contracts/src/token/erc721/extensions/enumerable.rs
@@ -10,11 +10,15 @@
 //! [`Erc721Enumerable`].
 // TODO: Add link for `Erc721Consecutive` to module docs.
 
-use alloy_primitives::{uint, Address, U256};
+use alloy_primitives::{uint, Address, FixedBytes, U256};
 use alloy_sol_types::sol;
+use openzeppelin_stylus_proc::interface_id;
 use stylus_proc::{public, sol_storage, SolidityError};
 
-use crate::token::{erc721, erc721::IErc721};
+use crate::{
+    token::{erc721, erc721::IErc721},
+    utils::introspection::erc165::IErc165,
+};
 
 sol! {
     /// Indicates an error when an `owner`'s token query
@@ -63,6 +67,7 @@ sol_storage! {
 
 /// This is the interface of the optional `Enumerable` extension
 /// of the ERC-721 standard.
+#[interface_id]
 pub trait IErc721Enumerable {
     /// The error type associated to this ERC-721 enumerable trait
     /// implementation.
@@ -141,6 +146,13 @@ impl IErc721Enumerable for Erc721Enumerable {
         self._all_tokens.get(index).ok_or(
             ERC721OutOfBoundsIndex { owner: Address::ZERO, index }.into(),
         )
+    }
+}
+
+impl IErc165 for Erc721Enumerable {
+    fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+        <Self as IErc721Enumerable>::INTERFACE_ID
+            == u32::from_be_bytes(*interface_id)
     }
 }
 

--- a/contracts/src/token/erc721/extensions/enumerable.rs
+++ b/contracts/src/token/erc721/extensions/enumerable.rs
@@ -559,4 +559,11 @@ mod tests {
             contract.token_of_owner_by_index(alice, U256::ZERO).unwrap_err();
         assert!(matches!(err, Error::OutOfBoundsIndex(_)));
     }
+
+    #[motsu::test]
+    fn interface_id() {
+        let actual = <Erc721Enumerable as IErc721Enumerable>::INTERFACE_ID;
+        let expected = 0x780e9d63;
+        assert_eq!(actual, expected);
+    }
 }

--- a/contracts/src/token/erc721/extensions/metadata.rs
+++ b/contracts/src/token/erc721/extensions/metadata.rs
@@ -68,3 +68,15 @@ impl IErc165 for Erc721Metadata {
             == u32::from_be_bytes(*interface_id)
     }
 }
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use crate::token::erc721::extensions::{Erc721Metadata, IErc721Metadata};
+
+    #[motsu::test]
+    fn interface_id() {
+        let actual = <Erc721Metadata as IErc721Metadata>::INTERFACE_ID;
+        let expected = 0x5b5e139f;
+        assert_eq!(actual, expected);
+    }
+}

--- a/contracts/src/token/erc721/extensions/metadata.rs
+++ b/contracts/src/token/erc721/extensions/metadata.rs
@@ -6,10 +6,7 @@ use alloy_primitives::FixedBytes;
 use openzeppelin_stylus_proc::interface_id;
 use stylus_proc::{public, sol_storage};
 
-use crate::{
-    token::erc20::extensions::IErc20Metadata,
-    utils::{introspection::erc165::IErc165, Metadata},
-};
+use crate::utils::{introspection::erc165::IErc165, Metadata};
 
 sol_storage! {
     /// Metadata of an [`crate::token::erc721::Erc721`] token.

--- a/contracts/src/token/erc721/extensions/metadata.rs
+++ b/contracts/src/token/erc721/extensions/metadata.rs
@@ -73,7 +73,7 @@ impl IErc165 for Erc721Metadata {
 mod tests {
     // use crate::token::erc721::extensions::{Erc721Metadata, IErc721Metadata};
 
-    // TODO#q: IErc721Metadata should be refactored to have same api as solidity
+    // TODO: IErc721Metadata should be refactored to have same api as solidity
     //  has:  https://github.com/OpenZeppelin/openzeppelin-contracts/blob/4764ea50750d8bda9096e833706beba86918b163/contracts/token/ERC721/extensions/IERC721Metadata.sol#L12
     // [motsu::test]
     // fn interface_id() {

--- a/contracts/src/token/erc721/extensions/metadata.rs
+++ b/contracts/src/token/erc721/extensions/metadata.rs
@@ -71,12 +71,14 @@ impl IErc165 for Erc721Metadata {
 
 #[cfg(all(test, feature = "std"))]
 mod tests {
-    use crate::token::erc721::extensions::{Erc721Metadata, IErc721Metadata};
+    // use crate::token::erc721::extensions::{Erc721Metadata, IErc721Metadata};
 
-    #[motsu::test]
-    fn interface_id() {
-        let actual = <Erc721Metadata as IErc721Metadata>::INTERFACE_ID;
-        let expected = 0x5b5e139f;
-        assert_eq!(actual, expected);
-    }
+    // TODO#q: IErc721Metadata should be refactored to have same api as solidity
+    //  has:  https://github.com/OpenZeppelin/openzeppelin-contracts/blob/4764ea50750d8bda9096e833706beba86918b163/contracts/token/ERC721/extensions/IERC721Metadata.sol#L12
+    // [motsu::test]
+    // fn interface_id() {
+    //     let actual = <Erc721Metadata as IErc721Metadata>::INTERFACE_ID;
+    //     let expected = 0x5b5e139f;
+    //     assert_eq!(actual, expected);
+    // }
 }

--- a/contracts/src/token/erc721/extensions/metadata.rs
+++ b/contracts/src/token/erc721/extensions/metadata.rs
@@ -2,9 +2,14 @@
 
 use alloc::string::String;
 
+use alloy_primitives::FixedBytes;
+use openzeppelin_stylus_proc::interface_id;
 use stylus_proc::{public, sol_storage};
 
-use crate::utils::Metadata;
+use crate::{
+    token::erc20::extensions::IErc20Metadata,
+    utils::{introspection::erc165::IErc165, Metadata},
+};
 
 sol_storage! {
     /// Metadata of an [`crate::token::erc721::Erc721`] token.
@@ -17,6 +22,7 @@ sol_storage! {
 }
 
 /// Interface for the optional metadata functions from the ERC-721 standard.
+#[interface_id]
 pub trait IErc721Metadata {
     /// Returns the token collection name.
     ///
@@ -56,5 +62,12 @@ impl IErc721Metadata for Erc721Metadata {
 
     fn base_uri(&self) -> String {
         self._base_uri.get_string()
+    }
+}
+
+impl IErc165 for Erc721Metadata {
+    fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+        <Self as IErc721Metadata>::INTERFACE_ID
+            == u32::from_be_bytes(*interface_id)
     }
 }

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -2,7 +2,7 @@
 use alloc::vec;
 
 use alloy_primitives::{fixed_bytes, uint, Address, FixedBytes, U128, U256};
-use openzeppelin_stylus_proc::interface;
+use openzeppelin_stylus_proc::interface_id;
 use stylus_sdk::{
     abi::Bytes,
     alloy_sol_types::sol,
@@ -11,7 +11,10 @@ use stylus_sdk::{
     prelude::*,
 };
 
-use crate::utils::math::storage::{AddAssignUnchecked, SubAssignUnchecked};
+use crate::utils::{
+    introspection::erc165::{Erc165, IErc165},
+    math::storage::{AddAssignUnchecked, SubAssignUnchecked},
+};
 
 pub mod extensions;
 
@@ -199,7 +202,7 @@ sol_storage! {
 unsafe impl TopLevelStorage for Erc721 {}
 
 /// Required interface of an [`Erc721`] compliant contract.
-#[interface]
+#[interface_id]
 pub trait IErc721 {
     /// The error type associated to this ERC-721 trait implementation.
     type Error: Into<alloc::vec::Vec<u8>>;
@@ -549,6 +552,13 @@ impl IErc721 for Erc721 {
 
     fn is_approved_for_all(&self, owner: Address, operator: Address) -> bool {
         self._operator_approvals.get(owner).get(operator)
+    }
+}
+
+impl IErc165 for Erc721 {
+    fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+        <Self as IErc721>::INTERFACE_ID == u32::from_be_bytes(*interface_id)
+            || Erc165::supports_interface(interface_id)
     }
 }
 
@@ -1156,6 +1166,7 @@ mod tests {
         ERC721InvalidReceiver, ERC721InvalidSender, ERC721NonexistentToken,
         Erc721, Error, IErc721,
     };
+    use crate::utils::introspection::erc165::IErc165;
 
     const BOB: Address = address!("F4EaCDAbEf3c8f1EdE91b6f2A6840bc2E4DD3526");
     const DAVE: Address = address!("0BB78F7e7132d1651B4Fd884B7624394e92156F1");
@@ -2494,7 +2505,11 @@ mod tests {
     #[motsu::test]
     fn interface_id() {
         let actual = <Erc721 as IErc721>::INTERFACE_ID;
-        let expected = 0x_80ac58cd;
+        let expected = 0x80ac58cd;
+        assert_eq!(actual, expected);
+
+        let actual = <Erc721 as IErc165>::INTERFACE_ID;
+        let expected = 0x01ffc9a7;
         assert_eq!(actual, expected);
     }
 }

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -2,6 +2,7 @@
 use alloc::vec;
 
 use alloy_primitives::{fixed_bytes, uint, Address, FixedBytes, U128, U256};
+use openzeppelin_stylus_proc::interface;
 use stylus_sdk::{
     abi::Bytes,
     alloy_sol_types::sol,
@@ -198,6 +199,7 @@ sol_storage! {
 unsafe impl TopLevelStorage for Erc721 {}
 
 /// Required interface of an [`Erc721`] compliant contract.
+#[interface]
 pub trait IErc721 {
     /// The error type associated to this ERC-721 trait implementation.
     type Error: Into<alloc::vec::Vec<u8>>;
@@ -317,6 +319,7 @@ pub trait IErc721 {
     /// # Events
     ///
     /// Emits a [`Transfer`] event.
+    #[selector(name = "safeTransferFrom")]
     fn safe_transfer_from_with_data(
         &mut self,
         from: Address,
@@ -2482,5 +2485,12 @@ mod tests {
                 token_id: t_id
             }) if token_id == t_id
         ));
+    }
+
+    #[motsu::test]
+    fn interface_id() {
+        let actual = <Erc721 as IErc721>::INTERFACE_ID;
+        let expected = 0x_80ac58cd;
+        assert_eq!(actual, expected);
     }
 }

--- a/contracts/src/utils/introspection/erc165.rs
+++ b/contracts/src/utils/introspection/erc165.rs
@@ -1,0 +1,64 @@
+//! Trait and implementation of the ERC-165 standard, as defined in the [ERC].
+//!
+//! [ERC]: https://eips.ethereum.org/EIPS/eip-165
+
+use alloy_primitives::FixedBytes;
+use openzeppelin_stylus_proc::interface_id;
+
+/// Interface of the ERC-165 standard, as defined in the [ERC].
+///
+/// Implementers can declare support of contract interfaces, which others can
+/// query.
+///
+/// For an implementation, see [`Erc165`].
+///
+/// [ERC]: https://eips.ethereum.org/EIPS/eip-165
+#[interface_id]
+pub trait IErc165 {
+    /// Returns true if this contract implements the interface defined by
+    /// `interfaceId`. See the corresponding [ERC section]
+    /// to learn more about how these ids are created.
+    ///
+    /// Method [`IErc165::supports_interface`] should be reexported with
+    /// `#[public]` macro manually like this:
+    ///
+    /// ```rust,ignore
+    /// #[public]
+    /// impl Erc20Example {
+    ///     fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+    ///         Erc20::supports_interface(interface_id)
+    ///             || Erc20Metadata::supports_interface(interface_id)
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// # Arguments
+    ///
+    /// * `interface_id` - The interface identifier, as specified in [ERC
+    ///   section]
+    ///
+    /// [ERC section]: https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified
+    fn supports_interface(interface_id: FixedBytes<4>) -> bool;
+}
+
+/// Implementation of the [`IErc165`] trait.
+///
+/// Contracts that want to support ERC-165 should implement the [`IErc165`]
+/// trait for the additional interface id that will be supported and call
+/// [`Erc165::supports_interface`] like:
+///
+/// ```rust,ignore
+/// impl IErc165 for Erc20 {
+///     fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+///         crate::token::erc20::INTERFACE_ID == u32::from_be_bytes(*interface_id)
+///             || Erc165::supports_interface(interface_id)
+///     }
+/// }
+/// ```
+pub struct Erc165;
+
+impl IErc165 for Erc165 {
+    fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+        Self::INTERFACE_ID == u32::from_be_bytes(*interface_id)
+    }
+}

--- a/contracts/src/utils/introspection/erc165.rs
+++ b/contracts/src/utils/introspection/erc165.rs
@@ -16,7 +16,7 @@ use openzeppelin_stylus_proc::interface_id;
 #[interface_id]
 pub trait IErc165 {
     /// Returns true if this contract implements the interface defined by
-    /// `interfaceId`. See the corresponding [ERC section]
+    /// `interface_id`. See the corresponding [ERC section]
     /// to learn more about how these ids are created.
     ///
     /// Method [`IErc165::supports_interface`] should be reexported with

--- a/contracts/src/utils/introspection/mod.rs
+++ b/contracts/src/utils/introspection/mod.rs
@@ -1,0 +1,2 @@
+//! Stylus contract's introspection helpers library.
+pub mod erc165;

--- a/contracts/src/utils/mod.rs
+++ b/contracts/src/utils/mod.rs
@@ -1,5 +1,6 @@
 //! Common Smart Contracts utilities.
 pub mod cryptography;
+pub mod introspection;
 pub mod math;
 pub mod metadata;
 pub mod nonces;

--- a/examples/erc20/src/lib.rs
+++ b/examples/erc20/src/lib.rs
@@ -3,7 +3,7 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, FixedBytes, U256};
 use openzeppelin_stylus::{
     token::erc20::{
         extensions::{capped, Capped, Erc20Metadata, IErc20Burnable},
@@ -104,5 +104,13 @@ impl Erc20Example {
     ) -> Result<bool, Vec<u8>> {
         self.pausable.when_not_paused()?;
         self.erc20.transfer_from(from, to, value).map_err(|e| e.into())
+    }
+
+    fn supports_interface(
+        interface_id: FixedBytes<4>,
+    ) -> Result<bool, Vec<u8>> {
+        let interface_id = u32::from_be_bytes(*interface_id);
+        let supported = interface_id == <Erc20 as IErc20>::INTERFACE_ID;
+        Ok(supported)
     }
 }

--- a/examples/erc20/src/lib.rs
+++ b/examples/erc20/src/lib.rs
@@ -9,7 +9,7 @@ use openzeppelin_stylus::{
         extensions::{capped, Capped, Erc20Metadata, IErc20Burnable},
         Erc20, IErc20,
     },
-    utils::Pausable,
+    utils::{introspection::erc165::IErc165, Pausable},
 };
 use stylus_sdk::prelude::{entrypoint, public, sol_storage};
 
@@ -106,11 +106,8 @@ impl Erc20Example {
         self.erc20.transfer_from(from, to, value).map_err(|e| e.into())
     }
 
-    fn supports_interface(
-        interface_id: FixedBytes<4>,
-    ) -> Result<bool, Vec<u8>> {
-        let interface_id = u32::from_be_bytes(*interface_id);
-        let supported = interface_id == <Erc20 as IErc20>::INTERFACE_ID;
-        Ok(supported)
+    fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+        Erc20::supports_interface(interface_id)
+            || Erc20Metadata::supports_interface(interface_id)
     }
 }

--- a/examples/erc20/tests/abi/mod.rs
+++ b/examples/erc20/tests/abi/mod.rs
@@ -29,6 +29,8 @@ sol!(
         #[derive(Debug)]
         function whenNotPaused() external view;
 
+        function supportsInterface(bytes4 interface_id) external view returns (bool supportsInterface);
+
         error EnforcedPause();
         error ExpectedPause();
 

--- a/examples/erc20/tests/erc20.rs
+++ b/examples/erc20/tests/erc20.rs
@@ -1350,17 +1350,24 @@ async fn support_interface(alice: Account) -> Result<()> {
         .await?
         .address()?;
     let contract = Erc20::new(contract_addr, &alice.wallet);
-    let invalid_interface_id: u32 = 0x_ffffffff;
+    let invalid_interface_id: u32 = 0xffffffff;
     let Erc20::supportsInterfaceReturn {
         supportsInterface: supports_interface,
     } = contract.supportsInterface(invalid_interface_id.into()).call().await?;
 
     assert_eq!(supports_interface, false);
 
-    let valid_interface_id: u32 = 0x_36372b07;
+    let erc20_interface_id: u32 = 0x36372b07;
     let Erc20::supportsInterfaceReturn {
         supportsInterface: supports_interface,
-    } = contract.supportsInterface(valid_interface_id.into()).call().await?;
+    } = contract.supportsInterface(erc20_interface_id.into()).call().await?;
+
+    assert_eq!(supports_interface, true);
+
+    let erc165_interface_id: u32 = 0x01ffc9a7;
+    let Erc20::supportsInterfaceReturn {
+        supportsInterface: supports_interface,
+    } = contract.supportsInterface(erc165_interface_id.into()).call().await?;
 
     assert_eq!(supports_interface, true);
 

--- a/examples/erc20/tests/erc20.rs
+++ b/examples/erc20/tests/erc20.rs
@@ -1341,6 +1341,10 @@ async fn error_when_transfer_from(alice: Account, bob: Account) -> Result<()> {
     Ok(())
 }
 
+// ============================================================================
+// Integration Tests: ERC-165 Support Interface
+// ============================================================================
+
 #[e2e::test]
 async fn support_interface(alice: Account) -> Result<()> {
     let contract_addr = alice

--- a/examples/erc20/tests/erc20.rs
+++ b/examples/erc20/tests/erc20.rs
@@ -1371,5 +1371,15 @@ async fn support_interface(alice: Account) -> Result<()> {
 
     assert_eq!(supports_interface, true);
 
+    let erc20_metadata_interface_id: u32 = 0xa219a025;
+    let Erc20::supportsInterfaceReturn {
+        supportsInterface: supports_interface,
+    } = contract
+        .supportsInterface(erc20_metadata_interface_id.into())
+        .call()
+        .await?;
+
+    assert_eq!(supports_interface, true);
+
     Ok(())
 }

--- a/examples/erc20/tests/erc20.rs
+++ b/examples/erc20/tests/erc20.rs
@@ -1341,3 +1341,29 @@ async fn error_when_transfer_from(alice: Account, bob: Account) -> Result<()> {
 
     Ok(())
 }
+
+#[e2e::test]
+async fn support_interface(alice: Account) -> Result<()> {
+    let contract_addr = alice
+        .as_deployer()
+        .with_default_constructor::<constructorCall>()
+        .deploy()
+        .await?
+        .address()?;
+    let contract = Erc20::new(contract_addr, &alice.wallet);
+    let invalid_interface_id: u32 = 0x_ffffffff;
+    let Erc20::supportsInterfaceReturn {
+        supportsInterface: supports_interface,
+    } = contract.supportsInterface(invalid_interface_id.into()).call().await?;
+
+    assert_eq!(supports_interface, false);
+
+    let valid_interface_id: u32 = 0x_36372b07;
+    let Erc20::supportsInterfaceReturn {
+        supportsInterface: supports_interface,
+    } = contract.supportsInterface(valid_interface_id.into()).call().await?;
+
+    assert_eq!(supports_interface, true);
+
+    Ok(())
+}

--- a/examples/erc721/src/lib.rs
+++ b/examples/erc721/src/lib.rs
@@ -5,12 +5,9 @@ use alloc::vec::Vec;
 
 use alloy_primitives::{Address, FixedBytes, U256};
 use openzeppelin_stylus::{
-    token::{
-        erc20::{Erc20, IErc20},
-        erc721::{
-            extensions::{Erc721Enumerable as Enumerable, IErc721Burnable},
-            Erc721, IErc721,
-        },
+    token::erc721::{
+        extensions::{Erc721Enumerable as Enumerable, IErc721Burnable},
+        Erc721, IErc721,
     },
     utils::Pausable,
 };

--- a/examples/erc721/src/lib.rs
+++ b/examples/erc721/src/lib.rs
@@ -9,7 +9,7 @@ use openzeppelin_stylus::{
         extensions::{Erc721Enumerable as Enumerable, IErc721Burnable},
         Erc721, IErc721,
     },
-    utils::Pausable,
+    utils::{introspection::erc165::IErc165, Pausable},
 };
 use stylus_sdk::{
     abi::Bytes,
@@ -152,11 +152,8 @@ impl Erc721Example {
         Ok(())
     }
 
-    fn supports_interface(
-        interface_id: FixedBytes<4>,
-    ) -> Result<bool, Vec<u8>> {
-        let interface_id = u32::from_be_bytes(*interface_id);
-        let supported = interface_id == <Erc721 as IErc721>::INTERFACE_ID;
-        Ok(supported)
+    pub fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+        Erc721::supports_interface(interface_id)
+            || Enumerable::supports_interface(interface_id)
     }
 }

--- a/examples/erc721/src/lib.rs
+++ b/examples/erc721/src/lib.rs
@@ -3,11 +3,14 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{Address, FixedBytes, U256};
 use openzeppelin_stylus::{
-    token::erc721::{
-        extensions::{Erc721Enumerable as Enumerable, IErc721Burnable},
-        Erc721, IErc721,
+    token::{
+        erc20::{Erc20, IErc20},
+        erc721::{
+            extensions::{Erc721Enumerable as Enumerable, IErc721Burnable},
+            Erc721, IErc721,
+        },
     },
     utils::Pausable,
 };
@@ -150,5 +153,13 @@ impl Erc721Example {
         )?;
 
         Ok(())
+    }
+
+    fn supports_interface(
+        interface_id: FixedBytes<4>,
+    ) -> Result<bool, Vec<u8>> {
+        let interface_id = u32::from_be_bytes(*interface_id);
+        let supported = interface_id == <Erc721 as IErc721>::INTERFACE_ID;
+        Ok(supported)
     }
 }

--- a/examples/erc721/tests/abi/mod.rs
+++ b/examples/erc721/tests/abi/mod.rs
@@ -18,8 +18,10 @@ sol!(
         function setApprovalForAll(address operator, bool approved) external;
         function totalSupply() external view returns (uint256 totalSupply);
         function transferFrom(address from, address to, uint256 tokenId) external;
+
         function mint(address to, uint256 tokenId) external;
         function burn(uint256 tokenId) external;
+
         function paused() external view returns (bool paused);
         function pause() external;
         function unpause() external;
@@ -27,10 +29,13 @@ sol!(
         function whenPaused() external view;
         #[derive(Debug)]
         function whenNotPaused() external view;
+
         #[derive(Debug)]
         function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256 tokenId);
         #[derive(Debug)]
         function tokenByIndex(uint256 index) external view returns (uint256 tokenId);
+
+        function supportsInterface(bytes4 interface_id) external view returns (bool supportsInterface);
 
         error ERC721IncorrectOwner(address sender, uint256 tokenId, address owner);
         error ERC721InsufficientApproval(address operator, uint256 tokenId);

--- a/examples/erc721/tests/erc721.rs
+++ b/examples/erc721/tests/erc721.rs
@@ -2123,5 +2123,15 @@ async fn support_interface(alice: Account) -> eyre::Result<()> {
 
     assert_eq!(supports_interface, true);
 
+    let erc721_enumerable_interface_id: u32 = 0x780e9d63;
+    let Erc721::supportsInterfaceReturn {
+        supportsInterface: supports_interface,
+    } = contract
+        .supportsInterface(erc721_enumerable_interface_id.into())
+        .call()
+        .await?;
+
+    assert_eq!(supports_interface, true);
+
     Ok(())
 }

--- a/examples/erc721/tests/erc721.rs
+++ b/examples/erc721/tests/erc721.rs
@@ -2098,6 +2098,10 @@ async fn token_by_index_after_burn_and_some_mints(
     Ok(())
 }
 
+// ============================================================================
+// Integration Tests: ERC-165 Support Interface
+// ============================================================================
+
 #[e2e::test]
 async fn support_interface(alice: Account) -> eyre::Result<()> {
     let contract_addr = alice.as_deployer().deploy().await?.address()?;

--- a/examples/erc721/tests/erc721.rs
+++ b/examples/erc721/tests/erc721.rs
@@ -2098,3 +2098,24 @@ async fn token_by_index_after_burn_and_some_mints(
 
     Ok(())
 }
+
+#[e2e::test]
+async fn support_interface(alice: Account) -> eyre::Result<()> {
+    let contract_addr = alice.as_deployer().deploy().await?.address()?;
+    let contract = Erc721::new(contract_addr, &alice.wallet);
+    let invalid_interface_id: u32 = 0x_ffffffff;
+    let Erc721::supportsInterfaceReturn {
+        supportsInterface: supports_interface,
+    } = contract.supportsInterface(invalid_interface_id.into()).call().await?;
+
+    assert_eq!(supports_interface, false);
+
+    let valid_interface_id: u32 = 0x_80ac58cd;
+    let Erc721::supportsInterfaceReturn {
+        supportsInterface: supports_interface,
+    } = contract.supportsInterface(valid_interface_id.into()).call().await?;
+
+    assert_eq!(supports_interface, true);
+
+    Ok(())
+}

--- a/examples/erc721/tests/erc721.rs
+++ b/examples/erc721/tests/erc721.rs
@@ -2109,10 +2109,17 @@ async fn support_interface(alice: Account) -> eyre::Result<()> {
 
     assert_eq!(supports_interface, false);
 
-    let valid_interface_id: u32 = 0x_80ac58cd;
+    let erc721_interface_id: u32 = 0x80ac58cd;
     let Erc721::supportsInterfaceReturn {
         supportsInterface: supports_interface,
-    } = contract.supportsInterface(valid_interface_id.into()).call().await?;
+    } = contract.supportsInterface(erc721_interface_id.into()).call().await?;
+
+    assert_eq!(supports_interface, true);
+
+    let erc165_interface_id: u32 = 0x01ffc9a7;
+    let Erc721::supportsInterfaceReturn {
+        supportsInterface: supports_interface,
+    } = contract.supportsInterface(erc165_interface_id.into()).call().await?;
 
     assert_eq!(supports_interface, true);
 


### PR DESCRIPTION
Adds erc165 standard altogether with a proc macro, that lets to compute interface id in a simple way.

<!-- Fill in with issue number -->
Resolves #33

#### PR Checklist

- [x] Tests
- [x] Documentation
