### PR TITLE
fix(e2e): deploy contracts without Solidity constructor when not needed

### DIFF
--- a/examples/ecdsa/src/constructor.sol
+++ b/examples/ecdsa/src/constructor.sol
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.21;
-
-contract ECDSAExample {
-    constructor() {}
-}

--- a/lib/e2e/src/deploy.rs
+++ b/lib/e2e/src/deploy.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use alloy::{rpc::types::TransactionReceipt, sol_types::SolConstructor};
 use koba::config::Deploy;
 
@@ -45,11 +46,16 @@ impl Deployer {
         let pkg = Crate::new()?;
         let wasm_path = pkg.wasm;
         let sol_path = pkg.manifest_dir.join("src/constructor.sol");
+        let sol = if Path::new(&sol_path).exists() {
+            Some(sol_path)
+        } else {
+            None
+        };
 
         let config = Deploy {
             generate_config: koba::config::Generate {
                 wasm: wasm_path.clone(),
-                sol: Some(sol_path),
+                sol,
                 args: self.ctr_args,
                 legacy: false,
             },

--- a/lib/e2e/src/deploy.rs
+++ b/lib/e2e/src/deploy.rs
@@ -1,6 +1,6 @@
-use std::path::Path;
 use alloy::{rpc::types::TransactionReceipt, sol_types::SolConstructor};
 use koba::config::Deploy;
+use std::path::Path;
 
 use crate::project::Crate;
 
@@ -46,11 +46,8 @@ impl Deployer {
         let pkg = Crate::new()?;
         let wasm_path = pkg.wasm;
         let sol_path = pkg.manifest_dir.join("src/constructor.sol");
-        let sol = if Path::new(&sol_path).exists() {
-            Some(sol_path)
-        } else {
-            None
-        };
+        let sol =
+            if Path::new(&sol_path).exists() { Some(sol_path) } else { None };
 
         let config = Deploy {
             generate_config: koba::config::Generate {

--- a/lib/e2e/src/deploy.rs
+++ b/lib/e2e/src/deploy.rs
@@ -1,6 +1,7 @@
+use std::path::Path;
+
 use alloy::{rpc::types::TransactionReceipt, sol_types::SolConstructor};
 use koba::config::Deploy;
-use std::path::Path;
 
 use crate::project::Crate;
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OpenZeppelin!

Consider opening an issue for discussion prior to submitting a PR. New features will be merged faster if they were first discussed and designed with the team.

Describe the changes introduced in this pull request. Include any context necessary for understanding the PR's purpose.
-->
This PR changes the `e2e` testing library to allow deployments of contracts without a constructor., when the constructor file is not present. This is already allowed by [koba](https://github.com/OpenZeppelin/koba/blob/main/src/generator.rs#L27-L30).

<!-- Fill in with issue number -->
~Resolves #???~

#### PR Checklist

<!--
Before merging the pull request all of the following must be completed.
Feel free to submit a PR or Draft PR even if some items are pending.
Some of the items may not apply.
-->

- [x] Tests
- [ ] ~Documentation~ (not required)
