### PR TITLE
chore: use stylus-proc indirectly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,6 @@ dependencies = [
  "eyre",
  "mini-alloc",
  "openzeppelin-stylus",
- "stylus-proc",
  "stylus-sdk",
  "tokio",
 ]
@@ -799,7 +798,6 @@ dependencies = [
  "alloy-primitives",
  "mini-alloc",
  "openzeppelin-stylus",
- "stylus-proc",
  "stylus-sdk",
 ]
 
@@ -1270,7 +1268,6 @@ dependencies = [
  "eyre",
  "mini-alloc",
  "openzeppelin-stylus",
- "stylus-proc",
  "stylus-sdk",
  "tokio",
 ]
@@ -1522,7 +1519,6 @@ dependencies = [
  "eyre",
  "mini-alloc",
  "openzeppelin-stylus",
- "stylus-proc",
  "stylus-sdk",
  "tokio",
 ]
@@ -1537,7 +1533,6 @@ dependencies = [
  "eyre",
  "mini-alloc",
  "openzeppelin-stylus",
- "stylus-proc",
  "stylus-sdk",
  "tokio",
 ]
@@ -1554,7 +1549,6 @@ dependencies = [
  "mini-alloc",
  "openzeppelin-stylus",
  "rand",
- "stylus-proc",
  "stylus-sdk",
  "tokio",
 ]
@@ -1570,7 +1564,6 @@ dependencies = [
  "mini-alloc",
  "openzeppelin-stylus",
  "rand",
- "stylus-proc",
  "stylus-sdk",
  "tokio",
 ]
@@ -1586,7 +1579,6 @@ dependencies = [
  "mini-alloc",
  "openzeppelin-stylus",
  "rand",
- "stylus-proc",
  "stylus-sdk",
  "tokio",
 ]
@@ -2366,7 +2358,6 @@ dependencies = [
  "alloy-sol-types",
  "mini-alloc",
  "openzeppelin-crypto",
- "stylus-proc",
  "stylus-sdk",
 ]
 
@@ -2432,7 +2423,6 @@ dependencies = [
  "motsu",
  "proc-macro2",
  "quote",
- "stylus-proc",
  "stylus-sdk",
  "syn 2.0.68",
 ]
@@ -2592,7 +2582,6 @@ dependencies = [
  "mini-alloc",
  "motsu",
  "rand",
- "stylus-proc",
  "stylus-sdk",
 ]
 
@@ -2606,7 +2595,6 @@ dependencies = [
  "eyre",
  "mini-alloc",
  "openzeppelin-stylus",
- "stylus-proc",
  "stylus-sdk",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ all = "warn"
 [workspace.dependencies]
 # stylus-related
 stylus-sdk = { version = "=0.6.0", default-features = false }
-stylus-proc = { version = "=0.6.0", default-features = false }
 mini-alloc = "0.4.2"
 
 alloy = { version = "0.1.4", features = [

--- a/README.md
+++ b/README.md
@@ -17,20 +17,25 @@
 - [Unit] and [integration] test affordances, used in our own tests.
 
 [`openzeppelin-contracts`]: https://github.com/OpenZeppelin/openzeppelin-contracts
+
 [`koba`]: https://github.com/OpenZeppelin/koba
+
 [Unit]: ./lib/motsu/README.md
+
 [integration]: ./lib/e2e/README.md
 
 ## Usage
 
-You can import OpenZeppelin Contracts from crates.io by adding the following line to your `Cargo.toml` (We recommend pinning to a specific version):
+You can import OpenZeppelin Contracts from crates.io by adding the following
+line to your `Cargo.toml` (We recommend pinning to a specific version):
 
 ```toml
 [dependencies]
 openzeppelin-stylus = "0.1.0-rc"
 ```
 
-Optionally,you can specify a git dependency if you want to have the latest changes from the `main` branch:
+Optionally, you can specify a git dependency if you want to have the latest
+changes from the `main` branch:
 
 ```toml
 [dependencies]
@@ -53,7 +58,7 @@ sol_storage! {
 
 #[external]
 #[inherit(Erc20)]
-impl Erc20Example { }
+impl Erc20Example {}
 ```
 
 For a more complex display of what this library offers, refer to our
@@ -66,11 +71,12 @@ For more information on what this library will include in the future, see our
 [roadmap].
 
 [basic]: ./examples/basic
+
 [roadmap]: https://github.com/OpenZeppelin/rust-contracts-stylus/milestone/1
 
 ## Contribute
 
-OpenZeppelin Contracts for Stylus exists thanks to its contributors. There are
+OpenZeppelin Contracts for Stylus exist thanks to its contributors. There are
 many ways you can participate and help build high-quality software. Check out
 the [contribution guide](CONTRIBUTING.md)!
 
@@ -85,4 +91,5 @@ Refer to our [Security Policy](SECURITY.md) for more details.
 
 ## License
 
-OpenZeppelin Contracts for Stylus is released under the [MIT License](./LICENSE).
+OpenZeppelin Contracts for Stylus is released under
+the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For more information on what this library will include in the future, see our
 
 ## Contribute
 
-OpenZeppelin Contracts for Stylus exist thanks to its contributors. There are
+OpenZeppelin Contracts for Stylus exists thanks to its contributors. There are
 many ways you can participate and help build high-quality software. Check out
 the [contribution guide](CONTRIBUTING.md)!
 

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -12,7 +12,6 @@ version.workspace = true
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 stylus-sdk.workspace = true
-stylus-proc.workspace = true
 mini-alloc.workspace = true
 keccak-const.workspace = true
 

--- a/contracts/src/access/control.rs
+++ b/contracts/src/access/control.rs
@@ -42,10 +42,9 @@
 //! this role.
 use alloy_primitives::{Address, B256};
 use alloy_sol_types::sol;
-use stylus_proc::SolidityError;
 use stylus_sdk::{
     evm, msg,
-    stylus_proc::{public, sol_storage},
+    stylus_proc::{public, sol_storage, SolidityError},
 };
 
 sol! {

--- a/contracts/src/access/ownable.rs
+++ b/contracts/src/access/ownable.rs
@@ -10,10 +10,9 @@
 //! to the owner.
 use alloy_primitives::Address;
 use alloy_sol_types::sol;
-use stylus_proc::SolidityError;
 use stylus_sdk::{
     evm, msg,
-    stylus_proc::{public, sol_storage},
+    stylus_proc::{public, sol_storage, SolidityError},
 };
 
 sol! {

--- a/contracts/src/token/erc20/extensions/capped.rs
+++ b/contracts/src/token/erc20/extensions/capped.rs
@@ -7,7 +7,7 @@
 
 use alloy_primitives::U256;
 use alloy_sol_types::sol;
-use stylus_proc::{public, sol_storage, SolidityError};
+use stylus_sdk::stylus_proc::{public, sol_storage, SolidityError};
 
 sol! {
     /// Indicates an error related to the operation that failed

--- a/contracts/src/token/erc20/extensions/metadata.rs
+++ b/contracts/src/token/erc20/extensions/metadata.rs
@@ -2,7 +2,7 @@
 
 use alloc::string::String;
 
-use stylus_proc::{public, sol_storage};
+use stylus_sdk::stylus_proc::{public, sol_storage};
 
 /// Number of decimals used by default on implementors of [`Metadata`].
 pub const DEFAULT_DECIMALS: u8 = 18;

--- a/contracts/src/token/erc20/extensions/permit.rs
+++ b/contracts/src/token/erc20/extensions/permit.rs
@@ -11,8 +11,12 @@
 //! and thus is not required to hold Ether at all.
 use alloy_primitives::{b256, keccak256, Address, B256, U256};
 use alloy_sol_types::{sol, SolType};
-use stylus_proc::{public, sol_storage, SolidityError};
-use stylus_sdk::{block, prelude::StorageType, storage::TopLevelStorage};
+use stylus_sdk::{
+    block,
+    prelude::StorageType,
+    storage::TopLevelStorage,
+    stylus_proc::{public, sol_storage, SolidityError},
+};
 
 use crate::{
     token::erc20::{self, Erc20, IErc20},

--- a/contracts/src/token/erc20/mod.rs
+++ b/contracts/src/token/erc20/mod.rs
@@ -6,11 +6,10 @@
 //! [`Erc20`] applications.
 use alloy_primitives::{Address, U256};
 use alloy_sol_types::sol;
-use stylus_proc::SolidityError;
 use stylus_sdk::{
     call::MethodError,
     evm, msg,
-    stylus_proc::{public, sol_storage},
+    stylus_proc::{public, sol_storage, SolidityError},
 };
 
 pub mod extensions;

--- a/contracts/src/token/erc721/extensions/consecutive.rs
+++ b/contracts/src/token/erc721/extensions/consecutive.rs
@@ -26,8 +26,12 @@ use alloc::vec;
 
 use alloy_primitives::{uint, Address, U256};
 use alloy_sol_types::sol;
-use stylus_proc::{public, sol_storage, SolidityError};
-use stylus_sdk::{abi::Bytes, evm, msg, prelude::TopLevelStorage};
+use stylus_sdk::{
+    abi::Bytes,
+    evm, msg,
+    prelude::TopLevelStorage,
+    stylus_proc::{public, sol_storage, SolidityError},
+};
 
 use crate::{
     token::{

--- a/contracts/src/token/erc721/extensions/enumerable.rs
+++ b/contracts/src/token/erc721/extensions/enumerable.rs
@@ -12,7 +12,7 @@
 
 use alloy_primitives::{uint, Address, U256};
 use alloy_sol_types::sol;
-use stylus_proc::{public, sol_storage, SolidityError};
+use stylus_sdk::stylus_proc::{public, sol_storage, SolidityError};
 
 use crate::token::{erc721, erc721::IErc721};
 

--- a/contracts/src/token/erc721/extensions/metadata.rs
+++ b/contracts/src/token/erc721/extensions/metadata.rs
@@ -2,7 +2,7 @@
 
 use alloc::string::String;
 
-use stylus_proc::{public, sol_storage};
+use stylus_sdk::stylus_proc::{public, sol_storage};
 
 use crate::utils::Metadata;
 

--- a/contracts/src/token/erc721/extensions/uri_storage.rs
+++ b/contracts/src/token/erc721/extensions/uri_storage.rs
@@ -5,8 +5,10 @@ use alloc::string::String;
 
 use alloy_primitives::U256;
 use alloy_sol_types::sol;
-use stylus_proc::{public, sol_storage};
-use stylus_sdk::evm;
+use stylus_sdk::{
+    evm,
+    stylus_proc::{public, sol_storage},
+};
 
 sol! {
     /// This event gets emitted when the metadata of a token is changed.

--- a/contracts/src/utils/cryptography/ecdsa.rs
+++ b/contracts/src/utils/cryptography/ecdsa.rs
@@ -6,10 +6,10 @@ use alloc::vec::Vec;
 
 use alloy_primitives::{address, uint, Address, B256, U256};
 use alloy_sol_types::{sol, SolType};
-use stylus_proc::SolidityError;
 use stylus_sdk::{
     call::{self, Call, MethodError},
     storage::TopLevelStorage,
+    stylus_proc::SolidityError,
 };
 
 use crate::utils::cryptography::ecdsa;

--- a/contracts/src/utils/metadata.rs
+++ b/contracts/src/utils/metadata.rs
@@ -1,7 +1,7 @@
 //! Common Metadata Smart Contract.
 use alloc::string::String;
 
-use stylus_proc::{public, sol_storage};
+use stylus_sdk::stylus_proc::{public, sol_storage};
 
 sol_storage! {
     /// Metadata of the token.

--- a/contracts/src/utils/nonces.rs
+++ b/contracts/src/utils/nonces.rs
@@ -4,7 +4,7 @@
 
 use alloy_primitives::{uint, Address, U256};
 use alloy_sol_types::sol;
-use stylus_proc::{public, sol_storage, SolidityError};
+use stylus_sdk::stylus_proc::{public, sol_storage, SolidityError};
 
 const ONE: U256 = uint!(1_U256);
 

--- a/contracts/src/utils/pausable.rs
+++ b/contracts/src/utils/pausable.rs
@@ -11,8 +11,10 @@
 //! only once the modifiers are put in place.
 
 use alloy_sol_types::sol;
-use stylus_proc::{public, sol_storage, SolidityError};
-use stylus_sdk::{evm, msg};
+use stylus_sdk::{
+    evm, msg,
+    stylus_proc::{public, sol_storage, SolidityError},
+};
 
 sol! {
     /// Emitted when pause is triggered by `account`.

--- a/contracts/src/utils/structs/bitmap.rs
+++ b/contracts/src/utils/structs/bitmap.rs
@@ -14,7 +14,7 @@
 //!
 //! [merkle-distributor]: https://github.com/Uniswap/merkle-distributor/blob/master/contracts/MerkleDistributor.sol
 use alloy_primitives::{uint, U256};
-use stylus_proc::sol_storage;
+use stylus_sdk::stylus_proc::sol_storage;
 
 const ONE: U256 = uint!(0x1_U256);
 const HEX_FF: U256 = uint!(0xff_U256);

--- a/contracts/src/utils/structs/checkpoints.rs
+++ b/contracts/src/utils/structs/checkpoints.rs
@@ -6,10 +6,10 @@
 //! block using the [`Trace160::push`] function.
 use alloy_primitives::{uint, Uint, U256, U32};
 use alloy_sol_types::sol;
-use stylus_proc::{sol_storage, SolidityError};
 use stylus_sdk::{
     call::MethodError,
     storage::{StorageGuard, StorageGuardMut},
+    stylus_proc::{sol_storage, SolidityError},
 };
 
 use crate::utils::math::alloy::Math;

--- a/examples/access-control/Cargo.toml
+++ b/examples/access-control/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 stylus-sdk.workspace = true
-stylus-proc.workspace = true
 mini-alloc.workspace = true
 
 [dev-dependencies]

--- a/examples/basic/token/Cargo.toml
+++ b/examples/basic/token/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 stylus-sdk.workspace = true
-stylus-proc.workspace = true
 mini-alloc.workspace = true
 
 [features]

--- a/examples/ecdsa/Cargo.toml
+++ b/examples/ecdsa/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 stylus-sdk.workspace = true
-stylus-proc.workspace = true
 mini-alloc.workspace = true
 
 [dev-dependencies]

--- a/examples/erc20-permit/Cargo.toml
+++ b/examples/erc20-permit/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 openzeppelin-stylus.workspace = true
 alloy-primitives = { workspace = true, features = ["tiny-keccak"] }
 stylus-sdk.workspace = true
-stylus-proc.workspace = true
 mini-alloc.workspace = true
 
 [dev-dependencies]

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 stylus-sdk.workspace = true
-stylus-proc.workspace = true
 mini-alloc.workspace = true
 
 [dev-dependencies]

--- a/examples/erc721-consecutive/Cargo.toml
+++ b/examples/erc721-consecutive/Cargo.toml
@@ -11,7 +11,6 @@ openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 stylus-sdk.workspace = true
-stylus-proc.workspace = true
 mini-alloc.workspace = true
 
 [dev-dependencies]

--- a/examples/erc721-metadata/Cargo.toml
+++ b/examples/erc721-metadata/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 stylus-sdk.workspace = true
-stylus-proc.workspace = true
 mini-alloc.workspace = true
 
 [dev-dependencies]

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 stylus-sdk.workspace = true
-stylus-proc.workspace = true
 mini-alloc.workspace = true
 
 [dev-dependencies]

--- a/examples/merkle-proofs/Cargo.toml
+++ b/examples/merkle-proofs/Cargo.toml
@@ -11,7 +11,6 @@ openzeppelin-crypto.workspace = true
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 stylus-sdk.workspace = true
-stylus-proc.workspace = true
 mini-alloc.workspace = true
 
 [features]

--- a/examples/merkle-proofs/src/lib.rs
+++ b/examples/merkle-proofs/src/lib.rs
@@ -8,10 +8,10 @@ use openzeppelin_crypto::{
     merkle::{self, Verifier},
     KeccakBuilder,
 };
-use stylus_proc::SolidityError;
 use stylus_sdk::{
     alloy_sol_types::sol,
     prelude::{entrypoint, public, sol_storage},
+    stylus_proc::SolidityError,
 };
 
 #[global_allocator]

--- a/examples/ownable/Cargo.toml
+++ b/examples/ownable/Cargo.toml
@@ -10,7 +10,6 @@ version = "0.0.0"
 openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 stylus-sdk.workspace = true
-stylus-proc.workspace = true
 mini-alloc.workspace = true
 
 [dev-dependencies]

--- a/lib/motsu-proc/Cargo.toml
+++ b/lib/motsu-proc/Cargo.toml
@@ -17,7 +17,7 @@ motsu.workspace = true
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 stylus-sdk.workspace = true
-stylus-proc.workspace = true
+
 
 [lib]
 proc-macro = true

--- a/lib/motsu-proc/Cargo.toml
+++ b/lib/motsu-proc/Cargo.toml
@@ -19,7 +19,6 @@ alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 stylus-sdk.workspace = true
 
-
 [lib]
 proc-macro = true
 


### PR DESCRIPTION
`stylus-sdk` already reexports matching `stylus-proc` version. Make sense to simplify dependencies a bit and use reexported library everywhere.