### PR TITLE
fix: update keywords for contracts-proc

### DIFF
--- a/contracts-proc/Cargo.toml
+++ b/contracts-proc/Cargo.toml
@@ -5,7 +5,8 @@ version.workspace = true
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
-keywords.workspace = true
+categories = ["cryptography::cryptocurrencies", "no-std", "wasm"]
+keywords = ["arbitrum", "ethereum", "stylus", "smart-contracts", "standards"]
 repository.workspace = true
 
 


### PR DESCRIPTION
Due to automerge `openzeppelin-stylus-proc` crate is using keywords from the workspace and breaks the build.