### PR TITLE
fix(L-03): Missing Checks in ERC-20 Implementation

### DIFF
--- a/contracts/src/token/erc20/extensions/burnable.rs
+++ b/contracts/src/token/erc20/extensions/burnable.rs
@@ -158,7 +158,7 @@ mod tests {
     }
 
     #[motsu::test]
-    fn burns_from_errors_when_invalid_sender(contract: Erc20) {
+    fn burns_from_errors_when_invalid_approver(contract: Erc20) {
         let one = uint!(1_U256);
 
         contract

--- a/contracts/src/token/erc20/extensions/burnable.rs
+++ b/contracts/src/token/erc20/extensions/burnable.rs
@@ -168,7 +168,7 @@ mod tests {
             .set(one);
 
         let result = contract.burn_from(Address::ZERO, one);
-        assert!(matches!(result, Err(Error::InvalidSender(_))));
+        assert!(matches!(result, Err(Error::InvalidApprover(_))));
     }
 
     #[motsu::test]

--- a/contracts/src/token/erc20/extensions/permit.rs
+++ b/contracts/src/token/erc20/extensions/permit.rs
@@ -173,7 +173,7 @@ impl<T: IEip712 + StorageType> Erc20Permit<T> {
             return Err(ERC2612InvalidSigner { signer, owner }.into());
         }
 
-        self.erc20._approve(owner, spender, value)?;
+        self.erc20._approve(owner, spender, value, true)?;
 
         Ok(())
     }

--- a/contracts/src/token/erc20/mod.rs
+++ b/contracts/src/token/erc20/mod.rs
@@ -835,7 +835,7 @@ mod tests {
     }
 
     #[motsu::test]
-    fn transfer_from_errors_when_invalid_sender(contract: Erc20) {
+    fn transfer_from_errors_when_invalid_approver(contract: Erc20) {
         let alice = address!("A11CEacF9aa32246d767FCCD72e02d6bCbcC375d");
         let one = uint!(1_U256);
         contract


### PR DESCRIPTION
Add additional check to `approve` + emit_event flag like in solidity. Rely on that `approve` inside `_spend_allowance`.

Resolves #313