### PR TITLE
fix(L-04): Public Exposure of pause and unpause Functions

### DIFF
--- a/contracts/src/utils/pausable.rs
+++ b/contracts/src/utils/pausable.rs
@@ -8,8 +8,7 @@
 //! which can be added to the functions of your contract.
 //!
 //! Note that they will not be pausable by simply including this module,
-//! only once functions [`Pausable::when_not_paused`] and
-//! [`Pausable::when_paused`] are put in place.
+//! only once function [`Pausable::when_not_paused`] is put in place.
 //!
 //! Note that [`Pausable::pause`] and [`Pausable::unpause`] methods are not
 //! exposed by default.

--- a/contracts/src/utils/pausable.rs
+++ b/contracts/src/utils/pausable.rs
@@ -9,6 +9,10 @@
 //!
 //! Note that they will not be pausable by simply including this module,
 //! only once the modifiers are put in place.
+//!
+//! Note that [`Pausable::pause`] and [`Pausable::unpause`] methods are not
+//! exposed by default.
+//! You should expose them manually in your contract's abi.
 
 use alloy_sol_types::sol;
 use stylus_proc::{public, sol_storage, SolidityError};
@@ -68,40 +72,6 @@ impl Pausable {
         self._paused.get()
     }
 
-    /// Triggers `Paused` state.
-    ///
-    /// # Arguments
-    ///
-    /// * `&mut self` - Write access to the contract's state.
-    ///
-    /// # Errors
-    ///
-    /// If the contract is in `Paused` state, then the error
-    /// [`Error::EnforcedPause`] is returned.
-    pub fn pause(&mut self) -> Result<(), Error> {
-        self.when_not_paused()?;
-        self._paused.set(true);
-        evm::log(Paused { account: msg::sender() });
-        Ok(())
-    }
-
-    /// Triggers `Unpaused` state.
-    ///
-    /// # Arguments
-    ///
-    /// * `&mut self` - Write access to the contract's state.
-    ///
-    /// # Errors
-    ///
-    /// If the contract is in `Unpaused` state, then the error
-    /// [`Error::ExpectedPause`] is returned.
-    pub fn unpause(&mut self) -> Result<(), Error> {
-        self.when_paused()?;
-        self._paused.set(false);
-        evm::log(Unpaused { account: msg::sender() });
-        Ok(())
-    }
-
     /// Modifier to make a function callable only when the contract is NOT
     /// paused.
     ///
@@ -135,6 +105,42 @@ impl Pausable {
         if !self._paused.get() {
             return Err(Error::ExpectedPause(ExpectedPause {}));
         }
+        Ok(())
+    }
+}
+
+impl Pausable {
+    /// Triggers `Paused` state.
+    ///
+    /// # Arguments
+    ///
+    /// * `&mut self` - Write access to the contract's state.
+    ///
+    /// # Errors
+    ///
+    /// If the contract is in `Paused` state, then the error
+    /// [`Error::EnforcedPause`] is returned.
+    pub fn pause(&mut self) -> Result<(), Error> {
+        self.when_not_paused()?;
+        self._paused.set(true);
+        evm::log(Paused { account: msg::sender() });
+        Ok(())
+    }
+
+    /// Triggers `Unpaused` state.
+    ///
+    /// # Arguments
+    ///
+    /// * `&mut self` - Write access to the contract's state.
+    ///
+    /// # Errors
+    ///
+    /// If the contract is in `Unpaused` state, then the error
+    /// [`Error::ExpectedPause`] is returned.
+    pub fn unpause(&mut self) -> Result<(), Error> {
+        self.when_paused()?;
+        self._paused.set(false);
+        evm::log(Unpaused { account: msg::sender() });
         Ok(())
     }
 }

--- a/contracts/src/utils/pausable.rs
+++ b/contracts/src/utils/pausable.rs
@@ -8,7 +8,8 @@
 //! which can be added to the functions of your contract.
 //!
 //! Note that they will not be pausable by simply including this module,
-//! only once the modifiers are put in place.
+//! only once functions [`Pausable::when_not_paused`] and
+//! [`Pausable::when_paused`] are put in place.
 //!
 //! Note that [`Pausable::pause`] and [`Pausable::unpause`] methods are not
 //! exposed by default.
@@ -71,42 +72,6 @@ impl Pausable {
     fn paused(&self) -> bool {
         self._paused.get()
     }
-
-    /// Modifier to make a function callable only when the contract is NOT
-    /// paused.
-    ///
-    /// # Arguments
-    ///
-    /// * `&self` - Read access to the contract's state.
-    ///
-    /// # Errors
-    ///
-    /// If the contract is in the `Paused` state, then the error
-    /// [`Error::EnforcedPause`] is returned.
-    pub fn when_not_paused(&self) -> Result<(), Error> {
-        if self._paused.get() {
-            return Err(Error::EnforcedPause(EnforcedPause {}));
-        }
-        Ok(())
-    }
-
-    /// Modifier to make a function callable
-    /// only when the contract is paused.
-    ///
-    /// # Arguments
-    ///
-    /// * `&self` - Read access to the contract's state.
-    ///
-    /// # Errors
-    ///
-    /// If the contract is in `Unpaused` state, then the error
-    /// [`Error::ExpectedPause`] is returned.
-    pub fn when_paused(&self) -> Result<(), Error> {
-        if !self._paused.get() {
-            return Err(Error::ExpectedPause(ExpectedPause {}));
-        }
-        Ok(())
-    }
 }
 
 impl Pausable {
@@ -141,6 +106,40 @@ impl Pausable {
         self.when_paused()?;
         self._paused.set(false);
         evm::log(Unpaused { account: msg::sender() });
+        Ok(())
+    }
+
+    /// Returns error when the contract is NOT paused.
+    ///
+    /// # Arguments
+    ///
+    /// * `&self` - Read access to the contract's state.
+    ///
+    /// # Errors
+    ///
+    /// If the contract is in the `Paused` state, then the error
+    /// [`Error::EnforcedPause`] is returned.
+    pub fn when_not_paused(&self) -> Result<(), Error> {
+        if self._paused.get() {
+            return Err(Error::EnforcedPause(EnforcedPause {}));
+        }
+        Ok(())
+    }
+
+    /// Returns error when the contract is paused.
+    ///
+    /// # Arguments
+    ///
+    /// * `&self` - Read access to the contract's state.
+    ///
+    /// # Errors
+    ///
+    /// If the contract is in `Unpaused` state, then the error
+    /// [`Error::ExpectedPause`] is returned.
+    pub fn when_paused(&self) -> Result<(), Error> {
+        if !self._paused.get() {
+            return Err(Error::ExpectedPause(ExpectedPause {}));
+        }
         Ok(())
     }
 }

--- a/examples/erc20/src/lib.rs
+++ b/examples/erc20/src/lib.rs
@@ -9,7 +9,7 @@ use openzeppelin_stylus::{
         extensions::{capped, Capped, Erc20Metadata, IErc20Burnable},
         Erc20, IErc20,
     },
-    utils::Pausable,
+    utils::{pausable::Error, Pausable},
 };
 use stylus_sdk::prelude::{entrypoint, public, sol_storage};
 
@@ -104,5 +104,13 @@ impl Erc20Example {
     ) -> Result<bool, Vec<u8>> {
         self.pausable.when_not_paused()?;
         self.erc20.transfer_from(from, to, value).map_err(|e| e.into())
+    }
+
+    pub fn pause(&mut self) -> Result<(), Error> {
+        self.pausable.pause()
+    }
+
+    pub fn unpause(&mut self) -> Result<(), Error> {
+        self.pausable.unpause()
     }
 }

--- a/examples/erc20/src/lib.rs
+++ b/examples/erc20/src/lib.rs
@@ -9,7 +9,7 @@ use openzeppelin_stylus::{
         extensions::{capped, Capped, Erc20Metadata, IErc20Burnable},
         Erc20, IErc20,
     },
-    utils::{pausable::Error, Pausable},
+    utils::Pausable,
 };
 use stylus_sdk::prelude::{entrypoint, public, sol_storage};
 
@@ -106,11 +106,11 @@ impl Erc20Example {
         self.erc20.transfer_from(from, to, value).map_err(|e| e.into())
     }
 
-    pub fn pause(&mut self) -> Result<(), Error> {
-        self.pausable.pause()
+    pub fn pause(&mut self) -> Result<(), Vec<u8>> {
+        self.pausable.pause().map_err(|e| e.into())
     }
 
-    pub fn unpause(&mut self) -> Result<(), Error> {
-        self.pausable.unpause()
+    pub fn unpause(&mut self) -> Result<(), Vec<u8>> {
+        self.pausable.unpause().map_err(|e| e.into())
     }
 }

--- a/examples/erc20/tests/abi/mod.rs
+++ b/examples/erc20/tests/abi/mod.rs
@@ -24,10 +24,6 @@ sol!(
         function paused() external view returns (bool paused);
         function pause() external;
         function unpause() external;
-        #[derive(Debug)]
-        function whenPaused() external view;
-        #[derive(Debug)]
-        function whenNotPaused() external view;
 
         error EnforcedPause();
         error ExpectedPause();

--- a/examples/erc20/tests/erc20.rs
+++ b/examples/erc20/tests/erc20.rs
@@ -1061,18 +1061,6 @@ async fn pauses(alice: Account) -> eyre::Result<()> {
 
     assert_eq!(true, paused);
 
-    let result = contract.whenPaused().call().await;
-
-    assert!(result.is_ok());
-
-    let err = contract
-        .whenNotPaused()
-        .call()
-        .await
-        .expect_err("should return `EnforcedPause`");
-
-    assert!(err.reverted_with(Erc20::EnforcedPause {}));
-
     Ok(())
 }
 
@@ -1095,18 +1083,6 @@ async fn unpauses(alice: Account) -> eyre::Result<()> {
     let Erc20::pausedReturn { paused } = contract.paused().call().await?;
 
     assert_eq!(false, paused);
-
-    let result = contract.whenNotPaused().call().await;
-
-    assert!(result.is_ok());
-
-    let err = contract
-        .whenPaused()
-        .call()
-        .await
-        .expect_err("should return `ExpectedPause`");
-
-    assert!(err.reverted_with(Erc20::ExpectedPause {}));
 
     Ok(())
 }

--- a/examples/erc721/src/lib.rs
+++ b/examples/erc721/src/lib.rs
@@ -9,7 +9,7 @@ use openzeppelin_stylus::{
         extensions::{Erc721Enumerable as Enumerable, IErc721Burnable},
         Erc721, IErc721,
     },
-    utils::{pausable::Error, Pausable},
+    utils::Pausable,
 };
 use stylus_sdk::{
     abi::Bytes,
@@ -152,11 +152,11 @@ impl Erc721Example {
         Ok(())
     }
 
-    pub fn pause(&mut self) -> Result<(), Error> {
-        self.pausable.pause()
+    pub fn pause(&mut self) -> Result<(), Vec<u8>> {
+        self.pausable.pause().map_err(|e| e.into())
     }
 
-    pub fn unpause(&mut self) -> Result<(), Error> {
-        self.pausable.unpause()
+    pub fn unpause(&mut self) -> Result<(), Vec<u8>> {
+        self.pausable.unpause().map_err(|e| e.into())
     }
 }

--- a/examples/erc721/src/lib.rs
+++ b/examples/erc721/src/lib.rs
@@ -9,7 +9,7 @@ use openzeppelin_stylus::{
         extensions::{Erc721Enumerable as Enumerable, IErc721Burnable},
         Erc721, IErc721,
     },
-    utils::Pausable,
+    utils::{pausable::Error, Pausable},
 };
 use stylus_sdk::{
     abi::Bytes,
@@ -150,5 +150,13 @@ impl Erc721Example {
         )?;
 
         Ok(())
+    }
+
+    pub fn pause(&mut self) -> Result<(), Error> {
+        self.pausable.pause()
+    }
+
+    pub fn unpause(&mut self) -> Result<(), Error> {
+        self.pausable.unpause()
     }
 }

--- a/examples/erc721/tests/abi/mod.rs
+++ b/examples/erc721/tests/abi/mod.rs
@@ -24,10 +24,6 @@ sol!(
         function pause() external;
         function unpause() external;
         #[derive(Debug)]
-        function whenPaused() external view;
-        #[derive(Debug)]
-        function whenNotPaused() external view;
-        #[derive(Debug)]
         function tokenOfOwnerByIndex(address owner, uint256 index) external view returns (uint256 tokenId);
         #[derive(Debug)]
         function tokenByIndex(uint256 index) external view returns (uint256 tokenId);

--- a/examples/erc721/tests/erc721.rs
+++ b/examples/erc721/tests/erc721.rs
@@ -1371,18 +1371,6 @@ async fn pauses(alice: Account) -> eyre::Result<()> {
 
     assert!(paused);
 
-    let result = contract.whenPaused().call().await;
-
-    assert!(result.is_ok());
-
-    let err = contract
-        .whenNotPaused()
-        .call()
-        .await
-        .expect_err("should return `EnforcedPause`");
-
-    assert!(err.reverted_with(Erc721::EnforcedPause {}));
-
     Ok(())
 }
 
@@ -1400,18 +1388,6 @@ async fn unpauses(alice: Account) -> eyre::Result<()> {
     let Erc721::pausedReturn { paused } = contract.paused().call().await?;
 
     assert_eq!(false, paused);
-
-    let result = contract.whenNotPaused().call().await;
-
-    assert!(result.is_ok());
-
-    let err = contract
-        .whenPaused()
-        .call()
-        .await
-        .expect_err("should return `ExpectedPause`");
-
-    assert!(err.reverted_with(Erc721::ExpectedPause {}));
 
     Ok(())
 }


### PR DESCRIPTION
Methods `pause` and `unpause` are not exposed by default now.

Resolves #314

