### PR TITLE
Add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -
 
-## [0.1.0] - 2024-10-16
+## [0.1.0] - 2024-10-17
 
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+-
+
+### Changed
+
+-
+
+### Fixed
+
+-
+
+## [0.1.0] - 2024-10-16
+
+- Initial release


### PR DESCRIPTION
Resolves #292 

Sets the general structure for a Changelog that we can follow starting with the changes for `v0.2.0`. 
Structure and how to maintain it based on: https://keepachangelog.com/en/1.1.0/ 

DO NOT MERGE UNTIL WE RELEASE `0.1.0` SINCE WE ARE SPECIFYING THE DATE OF THAT RELEASE
