### PR TITLE
chore: use mini-alloc indirectly through stylus sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,6 @@ dependencies = [
  "alloy-primitives",
  "e2e",
  "eyre",
- "mini-alloc",
  "openzeppelin-stylus",
  "stylus-sdk",
  "tokio",
@@ -37,7 +36,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cipher",
  "cpufeatures",
 ]
@@ -59,7 +58,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -254,7 +253,7 @@ dependencies = [
  "alloy-rlp",
  "arbitrary",
  "bytes",
- "cfg-if 1.0.0",
+ "cfg-if",
  "const-hex",
  "derive_arbitrary",
  "derive_more",
@@ -766,7 +765,7 @@ checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -796,7 +795,6 @@ name = "basic-example"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
- "mini-alloc",
  "openzeppelin-stylus",
  "stylus-sdk",
 ]
@@ -985,12 +983,6 @@ checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -1057,7 +1049,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb8a24a26d37e1ffd45343323dc9fe6654ceea44c12f2fcb3d7ac29e610bc6"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "hex",
  "proptest",
@@ -1108,7 +1100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80128832c58ea9cbd041d2a759ec449224487b2c1e400453d99d244eead87a8e"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "scopeguard",
  "windows-sys 0.33.0",
@@ -1267,7 +1259,6 @@ dependencies = [
  "alloy-primitives",
  "e2e",
  "eyre",
- "mini-alloc",
  "openzeppelin-stylus",
  "stylus-sdk",
  "tokio",
@@ -1322,7 +1313,7 @@ version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
@@ -1518,7 +1509,6 @@ dependencies = [
  "alloy-primitives",
  "e2e",
  "eyre",
- "mini-alloc",
  "openzeppelin-stylus",
  "stylus-sdk",
  "tokio",
@@ -1532,7 +1522,6 @@ dependencies = [
  "alloy-primitives",
  "e2e",
  "eyre",
- "mini-alloc",
  "openzeppelin-stylus",
  "stylus-sdk",
  "tokio",
@@ -1547,7 +1536,6 @@ dependencies = [
  "alloy-sol-types",
  "e2e",
  "eyre",
- "mini-alloc",
  "openzeppelin-stylus",
  "rand",
  "stylus-sdk",
@@ -1562,7 +1550,6 @@ dependencies = [
  "alloy-primitives",
  "e2e",
  "eyre",
- "mini-alloc",
  "openzeppelin-stylus",
  "rand",
  "stylus-sdk",
@@ -1577,7 +1564,6 @@ dependencies = [
  "alloy-primitives",
  "e2e",
  "eyre",
- "mini-alloc",
  "openzeppelin-stylus",
  "rand",
  "stylus-sdk",
@@ -1867,7 +1853,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -2196,7 +2182,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "ecdsa",
  "elliptic-curve",
  "once_cell",
@@ -2346,18 +2332,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
-
-[[package]]
 name = "merkle-proofs-example"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "mini-alloc",
  "openzeppelin-crypto",
  "stylus-sdk",
 ]
@@ -2370,12 +2349,11 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mini-alloc"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9993556d3850cdbd0da06a3dc81297edcfa050048952d84d75e8b944e8f5af"
+checksum = "14eacc4bfcf10da9b6d5185ef51b2dc75434afac34b4d8aabe40f6b141ee071c"
 dependencies = [
- "cfg-if 1.0.0",
- "wee_alloc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -2526,7 +2504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
  "bitflags 2.6.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -2568,7 +2546,6 @@ name = "openzeppelin-crypto"
 version = "0.1.0"
 dependencies = [
  "hex-literal",
- "mini-alloc",
  "rand",
  "tiny-keccak",
 ]
@@ -2583,7 +2560,6 @@ dependencies = [
  "alloy-sol-macro-input",
  "alloy-sol-types",
  "keccak-const",
- "mini-alloc",
  "motsu",
  "openzeppelin-stylus-proc",
  "rand",
@@ -2608,7 +2584,6 @@ dependencies = [
  "alloy-primitives",
  "e2e",
  "eyre",
- "mini-alloc",
  "openzeppelin-stylus",
  "stylus-sdk",
  "tokio",
@@ -2662,7 +2637,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -3387,7 +3362,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -3409,7 +3384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9b57fd861253bff08bb1919e995f90ba8f4889de2726091c8876f3a4e823b40"
 dependencies = [
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -3526,7 +3501,7 @@ checksum = "9fd02e91dffe7b73df84a861c992494d6b72054bc9a17fe73e147e34e9a64ef3"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "cfg-if 1.0.0",
+ "cfg-if",
  "convert_case 0.6.0",
  "lazy_static",
  "proc-macro2",
@@ -3545,11 +3520,12 @@ checksum = "26042693706e29fb7e3cf3d71c99534ac97fca98b6f81ba77ab658022ab2e210"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "cfg-if 1.0.0",
+ "cfg-if",
  "derivative",
  "hex",
  "keccak-const",
  "lazy_static",
+ "mini-alloc",
  "stylus-proc",
 ]
 
@@ -3617,7 +3593,7 @@ version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "rustix",
  "windows-sys 0.52.0",
@@ -3997,7 +3973,7 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -4045,7 +4021,7 @@ version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -4096,7 +4072,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78caedecd8cb71ed47ccca03b68d69414a3d278bb031e6f93f15759344efdd52"
 dependencies = [
  "bytes",
- "cfg-if 1.0.0",
+ "cfg-if",
  "derivative",
  "indexmap 1.9.3",
  "js-sys",
@@ -4124,7 +4100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726a8450541af4a57c34af7b6973fdbfc79f896cc7e733429577dfd1d1687180"
 dependencies = [
  "backtrace",
- "cfg-if 1.0.0",
+ "cfg-if",
  "enum-iterator",
  "enumset",
  "lazy_static",
@@ -4195,7 +4171,7 @@ checksum = "043118ec4f16d1714fed3aab758b502b864bd865e1d5188626c9ad290100563f"
 dependencies = [
  "backtrace",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "corosensei",
  "dashmap",
  "derivative",
@@ -4254,18 +4230,6 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "memory_units",
- "winapi",
 ]
 
 [[package]]
@@ -4496,7 +4460,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "windows-sys 0.48.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,7 @@ all = "warn"
 
 [workspace.dependencies]
 # stylus-related
-stylus-sdk = { version = "=0.6.0", default-features = false }
-mini-alloc = "0.4.2"
+stylus-sdk = { version = "=0.6.0", default-features = false, features = ["mini-alloc"] }
 
 alloy = { version = "=0.1.4", features = [
   "contract",

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -15,7 +15,6 @@ alloy-sol-macro.workspace = true
 alloy-sol-macro-expander.workspace = true
 alloy-sol-macro-input.workspace = true
 stylus-sdk.workspace = true
-mini-alloc.workspace = true
 keccak-const.workspace = true
 openzeppelin-stylus-proc.workspace = true
 

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -43,9 +43,6 @@ impl MyContract { }
 #![deny(rustdoc::broken_intra_doc_links)]
 extern crate alloc;
 
-#[global_allocator]
-static ALLOC: mini_alloc::MiniAlloc = mini_alloc::MiniAlloc::INIT;
-
 pub mod access;
 pub mod token;
 pub mod utils;

--- a/examples/access-control/Cargo.toml
+++ b/examples/access-control/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 stylus-sdk.workspace = true
-mini-alloc.workspace = true
 
 [dev-dependencies]
 alloy.workspace = true

--- a/examples/basic/token/Cargo.toml
+++ b/examples/basic/token/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 stylus-sdk.workspace = true
-mini-alloc.workspace = true
 
 [features]
 std = []

--- a/examples/ecdsa/Cargo.toml
+++ b/examples/ecdsa/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 stylus-sdk.workspace = true
-mini-alloc.workspace = true
 
 [dev-dependencies]
 alloy.workspace = true

--- a/examples/erc20-permit/Cargo.toml
+++ b/examples/erc20-permit/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 openzeppelin-stylus.workspace = true
 alloy-primitives = { workspace = true, features = ["tiny-keccak"] }
 stylus-sdk.workspace = true
-mini-alloc.workspace = true
 
 [dev-dependencies]
 alloy.workspace = true

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 stylus-sdk.workspace = true
-mini-alloc.workspace = true
 
 [dev-dependencies]
 alloy.workspace = true

--- a/examples/erc721-consecutive/Cargo.toml
+++ b/examples/erc721-consecutive/Cargo.toml
@@ -11,7 +11,6 @@ openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 stylus-sdk.workspace = true
-mini-alloc.workspace = true
 
 [dev-dependencies]
 alloy.workspace = true

--- a/examples/erc721-metadata/Cargo.toml
+++ b/examples/erc721-metadata/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 stylus-sdk.workspace = true
-mini-alloc.workspace = true
 
 [dev-dependencies]
 alloy.workspace = true

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -10,7 +10,6 @@ version.workspace = true
 openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 stylus-sdk.workspace = true
-mini-alloc.workspace = true
 
 [dev-dependencies]
 alloy.workspace = true

--- a/examples/merkle-proofs/Cargo.toml
+++ b/examples/merkle-proofs/Cargo.toml
@@ -11,7 +11,6 @@ openzeppelin-crypto.workspace = true
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 stylus-sdk.workspace = true
-mini-alloc.workspace = true
 
 [features]
 # Enables using the standard library. This is not included in the default

--- a/examples/merkle-proofs/src/lib.rs
+++ b/examples/merkle-proofs/src/lib.rs
@@ -14,9 +14,6 @@ use stylus_sdk::{
     stylus_proc::SolidityError,
 };
 
-#[global_allocator]
-static ALLOC: mini_alloc::MiniAlloc = mini_alloc::MiniAlloc::INIT;
-
 #[cfg(target_arch = "wasm32")]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {

--- a/examples/ownable/Cargo.toml
+++ b/examples/ownable/Cargo.toml
@@ -10,7 +10,6 @@ version = "0.0.0"
 openzeppelin-stylus.workspace = true
 alloy-primitives.workspace = true
 stylus-sdk.workspace = true
-mini-alloc.workspace = true
 
 [dev-dependencies]
 alloy.workspace = true

--- a/lib/crypto/Cargo.toml
+++ b/lib/crypto/Cargo.toml
@@ -9,7 +9,6 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-mini-alloc.workspace = true
 tiny-keccak.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
Currently, we're pinned to 0.4.2 version of the mini-alloc crate, but stylus sdk already supports 0.6.0.
Relieve the pain of tracking an actual mini-alloc version and use one from the stylus sdk.