### PR TITLE
fix: reference-types error on nightly version

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.wasm32-unknown-unknown]
-rustflags = ["-C", "link-arg=-zstack-size=8192"]
+rustflags = ["-C", "link-arg=-zstack-size=8192", "-C", "target-cpu=mvp"]
 
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]

--- a/.github/workflows/check-publish.yml
+++ b/.github/workflows/check-publish.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
 
       - name: Check motsu-proc
         run: cargo publish -p motsu-proc --dry-run

--- a/.github/workflows/check-publish.yml
+++ b/.github/workflows/check-publish.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           target: wasm32-unknown-unknown
           components: rust-src
-          toolchain: nightly-2024-01-01
+          toolchain: nightly-2024-09-05
 
       - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/check-publish.yml
+++ b/.github/workflows/check-publish.yml
@@ -18,27 +18,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: set up rust
-        uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          target: wasm32-unknown-unknown
-          components: rust-src
-          toolchain: nightly-2024-09-05
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - uses: Swatinem/rust-cache@v2
-
-      - name: check motsu-proc
+      - name: Check motsu-proc
         run: cargo publish -p motsu-proc --dry-run
 
-      - name: check motsu
+      - name: Check motsu
         run: cargo publish -p motsu --dry-run
 
-      - name: check openzeppelin-crypto
+      - name: Check openzeppelin-crypto
         run: cargo publish -p openzeppelin-crypto --target wasm32-unknown-unknown  --dry-run
 
-      - name: check openzeppelin-stylus-proc
+      - name: Check openzeppelin-stylus-proc
         run: cargo publish -p openzeppelin-stylus-proc --target wasm32-unknown-unknown  --dry-run
 
-      - name: check openzeppelin-stylus
+      - name: Check openzeppelin-stylus
         run: cargo publish -p openzeppelin-stylus --target wasm32-unknown-unknown  --dry-run

--- a/.github/workflows/check-wasm.yml
+++ b/.github/workflows/check-wasm.yml
@@ -19,20 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: set up rust
-        uses: dtolnay/rust-toolchain@master
-        id: toolchain
-        with:
-          target: wasm32-unknown-unknown
-          components: rust-src
-          toolchain: nightly-2024-09-05
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - uses: Swatinem/rust-cache@v2
-
-      - name: install cargo-stylus
+      - name: Install cargo-stylus
         run: cargo install cargo-stylus@0.5.1
 
-      - name: run wasm check
-        run: |
-          export RUSTUP_TOOLCHAIN=${{steps.toolchain.outputs.name}}
-          ./scripts/check-wasm.sh
+      - name: Run wasm check
+        run: ./scripts/check-wasm.sh

--- a/.github/workflows/check-wasm.yml
+++ b/.github/workflows/check-wasm.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           target: wasm32-unknown-unknown
           components: rust-src
-          toolchain: nightly-2024-01-01
+          toolchain: nightly-2024-09-05
 
       - uses: Swatinem/rust-cache@v2
 
@@ -34,5 +34,5 @@ jobs:
 
       - name: run wasm check
         run: |
-          export NIGHTLY_TOOLCHAIN=${{steps.toolchain.outputs.name}}
+          export RUSTUP_TOOLCHAIN=${{steps.toolchain.outputs.name}}
           ./scripts/check-wasm.sh

--- a/.github/workflows/check-wasm.yml
+++ b/.github/workflows/check-wasm.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          # Set default empty to avoid overriding rustflags with `.
+          # Set default empty to avoid overriding rustflags with `-D warnings`.
           rustflags: ""
 
       - name: Install cargo-stylus

--- a/.github/workflows/check-wasm.yml
+++ b/.github/workflows/check-wasm.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          # Set default empty to avoid overriding rustflags with `-D warnings`.
           rustflags: ""
 
       - name: Install cargo-stylus

--- a/.github/workflows/check-wasm.yml
+++ b/.github/workflows/check-wasm.yml
@@ -21,9 +21,12 @@ jobs:
 
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # Set default empty to avoid overriding rustflags with `.
+          rustflags: ""
 
       - name: Install cargo-stylus
-        run: cargo install cargo-stylus@0.5.1
+        run: cargo install cargo-stylus@0.5.3
 
       - name: Run wasm check
         run: ./scripts/check-wasm.sh

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -31,13 +31,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install stable
+
+      - name: Install rust
         # We run in nightly to make use of some features only available there.
         # Check out `rustfmt.toml` to see which ones.
-        uses: dtolnay/rust-toolchain@nightly
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: nightly
           components: rustfmt
-      - name: cargo fmt --all --check
+
+      - name: Check formatting
         run: cargo fmt --all --check
   clippy:
     runs-on: ubuntu-latest
@@ -55,12 +58,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install ${{ matrix.toolchain }}
-        uses: dtolnay/rust-toolchain@master
+
+      - name: Install rust ${{ matrix.toolchain }}
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
-      - name: cargo clippy
+
+      - name: Cargo clippy
         uses: giraffate/clippy-action@v1
         with:
           reporter: 'github-pr-check'
@@ -76,9 +81,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install nightly
-        uses: dtolnay/rust-toolchain@nightly
-      - name: cargo doc
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+
+      - name: Cargo doc
         run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: --cfg docsrs
@@ -91,17 +100,20 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: stable
           target: wasm32-unknown-unknown
-      - name: cargo install cargo-hack
+
+      - name: Cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack
         # Intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
         # `--feature-powerset` runs for every combination of features. Note that
         # target in this context means one of `--lib`, `--bin`, etc, and not the
         # target triple.
-      - name: cargo hack
+      - name: Cargo hack
         run: cargo hack check --feature-powerset --depth 2 --release --target wasm32-unknown-unknown --skip std --workspace --exclude e2e --exclude basic-example-script --exclude benches
   typos:
     runs-on: ubuntu-latest
@@ -109,5 +121,6 @@ jobs:
     steps:
       - name: Checkout Actions Repository
         uses: actions/checkout@v4
+
       - name: Check spelling of files in the workspace
         uses: crate-ci/typos@v1.24.1

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           toolchain: nightly
           components: rustfmt
+          rustflags: ""
 
       - name: Check formatting
         run: cargo fmt --all --check
@@ -64,6 +65,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
+          rustflags: ""
 
       - name: Cargo clippy
         uses: giraffate/clippy-action@v1
@@ -86,6 +88,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly
+          rustflags: ""
 
       - name: Cargo doc
         run: cargo doc --no-deps --all-features
@@ -106,6 +109,7 @@ jobs:
         with:
           toolchain: stable
           target: wasm32-unknown-unknown
+          rustflags: ""
 
       - name: Cargo install cargo-hack
         uses: taiki-e/install-action@cargo-hack

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -30,9 +30,11 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "e2e-tests"
+          # Set default empty to avoid overriding rustflags with `.
+          rustflags: ""
 
       - name: Install cargo-stylus
-        run: cargo install cargo-stylus@0.5.1
+        run: cargo install cargo-stylus@0.5.3
 
       - name: Install solc
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           target: wasm32-unknown-unknown
           components: rust-src
-          toolchain: nightly-2024-01-01
+          toolchain: nightly-2024-09-05
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -51,5 +51,5 @@ jobs:
         run: ./scripts/nitro-testnode.sh -d -i
       - name: run integration tests
         run: |
-          export NIGHTLY_TOOLCHAIN=${{steps.toolchain.outputs.name}}
+          export RUSTUP_TOOLCHAIN=${{steps.toolchain.outputs.name}}
           ./scripts/e2e-tests.sh

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "e2e-tests"
-          # Set default empty to avoid overriding rustflags with `-D warnings`.
           rustflags: ""
 
       - name: Install cargo-stylus

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "e2e-tests"
-          # Set default empty to avoid overriding rustflags with `.
+          # Set default empty to avoid overriding rustflags with `-D warnings`.
           rustflags: ""
 
       - name: Install cargo-stylus

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,7 +1,7 @@
 # This workflow runs our end-to-end tests suite.
 #
 # It roughly follows these steps:
-# - Install Rust
+# - Install rust
 # - Install `cargo-stylus`
 # - Install `solc`
 # - Spin up `nitro-testnode`
@@ -26,30 +26,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: set up rust
-        uses: dtolnay/rust-toolchain@master
-        id: toolchain
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          target: wasm32-unknown-unknown
-          components: rust-src
-          toolchain: nightly-2024-09-05
+          cache-key: "e2e-tests"
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: "e2e-tests"
-
-      - name: install cargo-stylus
+      - name: Install cargo-stylus
         run: cargo install cargo-stylus@0.5.1
 
-      - name: install solc
+      - name: Install solc
         run: |
           curl -LO https://github.com/ethereum/solidity/releases/download/v0.8.21/solc-static-linux
           sudo mv solc-static-linux /usr/bin/solc
           sudo chmod a+x /usr/bin/solc
 
-      - name: setup nitro node
+      - name: Setup nitro node
         run: ./scripts/nitro-testnode.sh -d -i
       - name: run integration tests
-        run: |
-          export RUSTUP_TOOLCHAIN=${{steps.toolchain.outputs.name}}
-          ./scripts/e2e-tests.sh
+        run: ./scripts/e2e-tests.sh

--- a/.github/workflows/gas-bench.yml
+++ b/.github/workflows/gas-bench.yml
@@ -14,32 +14,23 @@ env:
   CARGO_TERM_COLOR: always
 jobs:
   required:
-    name: gas usage report
+    name: Gas usage report
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: set up rust
-        uses: dtolnay/rust-toolchain@master
-        id: toolchain
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          target: wasm32-unknown-unknown
-          components: rust-src
-          toolchain: nightly-2024-09-05
+          cache-key: "gas-bench"
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: "gas-bench"
-
-      - name: install solc
+      - name: Install solc
         run: |
           curl -LO https://github.com/ethereum/solidity/releases/download/v0.8.21/solc-static-linux
           sudo mv solc-static-linux /usr/bin/solc
           sudo chmod a+x /usr/bin/solc
 
-      - name: setup nitro node
+      - name: Setup nitro node
         run: ./scripts/nitro-testnode.sh -d -i
       - name: run benches
-        run: |
-          export RUSTUP_TOOLCHAIN=${{steps.toolchain.outputs.name}}
-          ./scripts/bench.sh
+        run: ./scripts/bench.sh

--- a/.github/workflows/gas-bench.yml
+++ b/.github/workflows/gas-bench.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           target: wasm32-unknown-unknown
           components: rust-src
-          toolchain: nightly-2024-01-01
+          toolchain: nightly-2024-09-05
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -41,5 +41,5 @@ jobs:
         run: ./scripts/nitro-testnode.sh -d -i
       - name: run benches
         run: |
-          export NIGHTLY_TOOLCHAIN=${{steps.toolchain.outputs.name}}
+          export RUSTUP_TOOLCHAIN=${{steps.toolchain.outputs.name}}
           ./scripts/bench.sh

--- a/.github/workflows/gas-bench.yml
+++ b/.github/workflows/gas-bench.yml
@@ -23,7 +23,6 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "gas-bench"
-          # Set default empty to avoid overriding rustflags with `-D warnings`.
           rustflags: ""
 
       - name: Install solc

--- a/.github/workflows/gas-bench.yml
+++ b/.github/workflows/gas-bench.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "gas-bench"
+          # Set default empty to avoid overriding rustflags with `.
+          rustflags: ""
 
       - name: Install solc
         run: |

--- a/.github/workflows/gas-bench.yml
+++ b/.github/workflows/gas-bench.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "gas-bench"
-          # Set default empty to avoid overriding rustflags with `.
+          # Set default empty to avoid overriding rustflags with `-D warnings`.
           rustflags: ""
 
       - name: Install solc

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          rustflags: ""
 
       - name: Add rust targets ${{ matrix.target }}
         run: rustup target add ${{ matrix.target }}

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -24,9 +24,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
-      - name: rustup target add ${{ matrix.target }}
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Add rust targets ${{ matrix.target }}
         run: rustup target add ${{ matrix.target }}
-      - name: cargo check
+
+      - name: Cargo check
         run: cargo check --release --target ${{ matrix.target }} --no-default-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
+          rustflags: ""
 
       - name: Cargo generate-lockfile
         # Enable this ci template to run regardless of whether the lockfile is
@@ -75,6 +76,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          rustflags: ""
 
       - name: Cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
@@ -116,6 +118,7 @@ jobs:
         with:
           toolchain: stable
           components: llvm-tools-preview
+          rustflags: ""
 
       - name: Cargo install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,20 +37,24 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install ${{ matrix.toolchain }}
-        uses: dtolnay/rust-toolchain@master
+
+      - name: Install rust ${{ matrix.toolchain }}
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
-      - name: cargo generate-lockfile
+
+      - name: Cargo generate-lockfile
         # Enable this ci template to run regardless of whether the lockfile is
         # checked in or not.
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
+
         # https://twitter.com/jonhoo/status/1571290371124260865
-      - name: cargo test --locked
+      - name: Run unit tests
         run: cargo test --locked --features std --all-targets
+
         # https://github.com/rust-lang/cargo/issues/6669
-      - name: cargo test --doc
+      - name: Run doc tests
         run: cargo test --locked --features std --doc
   os-check:
     # Run cargo test on MacOS and Windows.
@@ -66,12 +70,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
-      - name: cargo generate-lockfile
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
-      - name: cargo test
+
+      - name: Run unit tests
         run: cargo test --locked --features std --all-targets
   coverage:
     # Use llvm-cov to build and collect coverage and outputs in a format that
@@ -101,20 +110,26 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: stable
           components: llvm-tools-preview
-      - name: cargo install cargo-llvm-cov
+
+      - name: Cargo install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
-      - name: cargo generate-lockfile
+
+      - name: Cargo generate-lockfile
         if: hashFiles('Cargo.lock') == ''
         run: cargo generate-lockfile
-      - name: cargo llvm-cov
-        # FIXME: Include e2e tests in coverage.
+
+      - name: Cargo llvm-cov
         run: cargo llvm-cov --locked --features std --lcov --output-path lcov.info
+
       - name: Record Rust version
         run: echo "RUST=$(rustc --version)" >> "$GITHUB_ENV"
+
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v4
         with:

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -160,7 +160,7 @@ impl MethodError for Error {
     }
 }
 
-pub use receiver::*;
+pub use receiver::IERC721Receiver;
 #[allow(missing_docs)]
 mod receiver {
     stylus_proc::sol_interface! {

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -160,25 +160,28 @@ impl MethodError for Error {
     }
 }
 
-sol_interface! {
-    /// [`Erc721`] token receiver interface.
-    ///
-    /// Interface for any contract that wants to support `safe_transfers`
-    /// from [`Erc721`] asset contracts.
-    interface IERC721Receiver {
-        /// Whenever an [`Erc721`] `token_id` token is transferred
-        /// to this contract via [`Erc721::safe_transfer_from`].
+#[allow(missing_docs)]
+pub mod receiver {
+    stylus_proc::sol_interface! {
+        /// [`Erc721`] token receiver interface.
         ///
-        /// It must return its function selector to confirm the token transfer.
-        /// If any other value is returned or the interface is not implemented
-        /// by the recipient, the transfer will be reverted.
-        #[allow(missing_docs)]
-        function onERC721Received(
-            address operator,
-            address from,
-            uint256 token_id,
-            bytes calldata data
-        ) external returns (bytes4);
+        /// Interface for any contract that wants to support `safe_transfers`
+        /// from [`Erc721`] asset contracts.
+        interface IERC721Receiver {
+            /// Whenever an [`Erc721`] `token_id` token is transferred
+            /// to this contract via [`Erc721::safe_transfer_from`].
+            ///
+            /// It must return its function selector to confirm the token transfer.
+            /// If any other value is returned or the interface is not implemented
+            /// by the recipient, the transfer will be reverted.
+            #[allow(missing_docs)]
+            function onERC721Received(
+                address operator,
+                address from,
+                uint256 token_id,
+                bytes calldata data
+            ) external returns (bytes4);
+        }
     }
 }
 
@@ -1117,7 +1120,7 @@ impl Erc721 {
             return Ok(());
         }
 
-        let receiver = IERC721Receiver::new(to);
+        let receiver = receiver::IERC721Receiver::new(to);
         let call = Call::new_in(self);
         let result = receiver.on_erc_721_received(
             call,

--- a/contracts/src/token/erc721/mod.rs
+++ b/contracts/src/token/erc721/mod.rs
@@ -160,8 +160,9 @@ impl MethodError for Error {
     }
 }
 
+pub use receiver::*;
 #[allow(missing_docs)]
-pub mod receiver {
+mod receiver {
     stylus_proc::sol_interface! {
         /// [`Erc721`] token receiver interface.
         ///
@@ -1120,7 +1121,7 @@ impl Erc721 {
             return Ok(());
         }
 
-        let receiver = receiver::IERC721Receiver::new(to);
+        let receiver = IERC721Receiver::new(to);
         let call = Call::new_in(self);
         let result = receiver.on_erc_721_received(
             call,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,4 +3,4 @@
 # the size limit.
 channel = "nightly-2024-09-05"
 components = ["rust-src"]
-targets = [ "wasm32-unknown-unknown"]
+targets = ["wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # We should use stable here once nitro-testnode is updated and the contracts fit
-# the size limit.
+# the size limit (issue <https://github.com/OpenZeppelin/rust-contracts-stylus/issues/129>).
 channel = "nightly-2024-09-05"
 components = ["rust-src"]
 targets = ["wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+[toolchain]
+# We should use stable here once nitro-testnode is updated and the contracts fit
+# the size limit.
+channel = "nightly-2024-09-05"
+components = ["rust-src"]
+targets = [ "wasm32-unknown-unknown"]

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -5,8 +5,9 @@ MYDIR=$(realpath "$(dirname "$0")")
 cd "$MYDIR"
 cd ..
 
-NIGHTLY_TOOLCHAIN=${NIGHTLY_TOOLCHAIN:-nightly}
-cargo +"$NIGHTLY_TOOLCHAIN" build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:-nightly}
+
+cargo build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 
 export RPC_URL=http://localhost:8547
 cargo run --release -p benches

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -5,8 +5,6 @@ MYDIR=$(realpath "$(dirname "$0")")
 cd "$MYDIR"
 cd ..
 
-RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:-nightly}
-
 cargo build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 
 export RPC_URL=http://localhost:8547

--- a/scripts/check-wasm.sh
+++ b/scripts/check-wasm.sh
@@ -22,9 +22,9 @@ get_example_crate_names () {
   find ./examples -maxdepth 2 -type f -name "Cargo.toml" | xargs grep 'name = ' | grep -oE '".*"' | tr -d "'\""
 }
 
-NIGHTLY_TOOLCHAIN=${NIGHTLY_TOOLCHAIN:-nightly}
+RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:-nightly}
 
-cargo +"$NIGHTLY_TOOLCHAIN" build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+cargo build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 
 for CRATE_NAME in $(get_example_crate_names)
 do

--- a/scripts/check-wasm.sh
+++ b/scripts/check-wasm.sh
@@ -22,8 +22,6 @@ get_example_crate_names () {
   find ./examples -maxdepth 2 -type f -name "Cargo.toml" | xargs grep 'name = ' | grep -oE '".*"' | tr -d "'\""
 }
 
-RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:-nightly}
-
 cargo build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 
 for CRATE_NAME in $(get_example_crate_names)

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -5,10 +5,6 @@ MYDIR=$(realpath "$(dirname "$0")")
 cd "$MYDIR"
 cd ..
 
-# We should use stable here once nitro-testnode is updated and the contracts fit
-# the size limit.
-RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:-nightly}
-
 cargo build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 
 export RPC_URL=http://localhost:8547

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -5,10 +5,12 @@ MYDIR=$(realpath "$(dirname "$0")")
 cd "$MYDIR"
 cd ..
 
-NIGHTLY_TOOLCHAIN=${NIGHTLY_TOOLCHAIN:-nightly}
-cargo +"$NIGHTLY_TOOLCHAIN" build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
+# We should use stable here once nitro-testnode is updated and the contracts fit
+# the size limit.
+RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:-nightly}
+
+cargo build --release --target wasm32-unknown-unknown -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort
 
 export RPC_URL=http://localhost:8547
-# We should use stable here once nitro-testnode is updated and the contracts fit
-# the size limit. Work tracked [here](https://github.com/OpenZeppelin/rust-contracts-stylus/issues/87)
-cargo +"$NIGHTLY_TOOLCHAIN" test --features std,e2e --test "*"
+
+cargo test --features std,e2e --test "*"


### PR DESCRIPTION
It seems that reference types from WASM are not supported by `wasm-parser` crate (https://github.com/rustwasm/wasm-bindgen/issues/4211).
It makes us pin to the recent nightly toolchain version that works, and contribution experience gets quite convoluted.
Hopefully there is an option to disable `reference-types` with a flag: `-C target-cpu=mvp` for `wasm32-unknown-unknown` target.

Resolves #374

Single source of rust toolchain from `rust-toolchain.toml` added for ci pipelines (actions-rust-lang/setup-rust-toolchain@v1 gh action used for that).

Resolves #294
