### PR TITLE
fix: contract caching for benchmarks

### DIFF
--- a/.github/workflows/gas-bench.yml
+++ b/.github/workflows/gas-bench.yml
@@ -25,6 +25,9 @@ jobs:
           cache-key: "gas-bench"
           rustflags: ""
 
+      - name: Install cargo-stylus
+        run: cargo install cargo-stylus@0.5.3
+
       - name: Install solc
         run: |
           curl -LO https://github.com/ethereum/solidity/releases/download/v0.8.24/solc-static-linux


### PR DESCRIPTION
Benchmarks require cargo stylus to be installed even though we're using koba for deployment.
That is used for caching a contract.
