### PR TITLE
build: cargo stylus v0.5.8

### DIFF
--- a/.github/workflows/check-wasm.yml
+++ b/.github/workflows/check-wasm.yml
@@ -25,7 +25,7 @@ jobs:
           rustflags: ""
 
       - name: Install cargo-stylus
-        run: cargo install cargo-stylus@0.5.7
+        run: cargo install cargo-stylus@0.5.8
 
       - name: Run wasm check
         run: ./scripts/check-wasm.sh

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,7 +33,7 @@ jobs:
           rustflags: ""
 
       - name: Install cargo-stylus
-        run: cargo install cargo-stylus@0.5.7
+        run: cargo install cargo-stylus@0.5.8
 
       - name: Install solc
         run: |

--- a/.github/workflows/gas-bench.yml
+++ b/.github/workflows/gas-bench.yml
@@ -26,7 +26,7 @@ jobs:
           rustflags: ""
 
       - name: Install cargo-stylus
-        run: cargo install cargo-stylus@0.5.7
+        run: cargo install cargo-stylus@0.5.8
 
       - name: Install wasm-opt
         run: cargo install wasm-opt@0.116.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed (Breaking)
 
 - Bump cargo-stylus to v0.5.8. #493
-- Bump cargo-stylus to v0.5.7. #484
 - Constants `TYPE_HASH`, `FIELDS`, `SALT` and `TYPED_DATA_PREFIX`, and type `DomainSeparatorTuple` are no longer exported from `utils::cryptography::eip712`. #478
 - Bump Stylus SDK to v0.7.0. #433
 - Bump `alloy` dependencies to v0.8.14. #433

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (Breaking)
 
+- Bump cargo-stylus to v0.5.8. #493
 - Bump cargo-stylus to v0.5.7. #484
 - Constants `TYPE_HASH`, `FIELDS`, `SALT` and `TYPED_DATA_PREFIX`, and type `DomainSeparatorTuple` are no longer exported from `utils::cryptography::eip712`. #478
 - Bump Stylus SDK to v0.7.0. #433

--- a/scripts/nitro-testnode.sh
+++ b/scripts/nitro-testnode.sh
@@ -51,7 +51,7 @@ then
   git clone --recurse-submodules https://github.com/OffchainLabs/nitro-testnode.git
   cd ./nitro-testnode || exit
   git pull origin release --recurse-submodules
-  git checkout d4244cd5c2cb56ca3d11c23478ef9642f8ebf472 || exit
+  git checkout af851769d52cab38bc3733dbd0a4db6120fa7864 || exit
 
   ./test-node.bash --no-run --init || exit
 fi


### PR DESCRIPTION
- Bump cargo-stylus to [`v0.5.8`](https://github.com/OffchainLabs/cargo-stylus/releases/tag/v0.5.8).
- Bump nitro-testnode to https://github.com/OffchainLabs/nitro-testnode/commit/af851769d52cab38bc3733dbd0a4db6120fa7864.