### PR TITLE
ref: make all proptests stand-alone + replace prop_assume calls with helper fn

### DIFF
--- a/lib/crypto/src/field/fp.rs
+++ b/lib/crypto/src/field/fp.rs
@@ -1088,14 +1088,14 @@ mod tests {
         })
     }
 
+    /// Compute a^b in an expensive and iterative way.
+    fn dumb_pow(a: i128, b: i128) -> i128 {
+        (0..b).fold(1, |acc, _| (acc * a).rem_euclid(MODULUS))
+    }
+
     #[test]
     fn pow() {
         proptest!(|(a: i64, b in 0_u32..1000)| {
-            /// Compute a^b in an expensive and iterative way.
-            fn dumb_pow(a: i128, b: i128) -> i128 {
-                (0..b).fold(1, |acc, _| (acc * a).rem_euclid(MODULUS))
-            }
-
             let res = Field64::from(a).pow(b);
             let res: i128 = res.into();
             let a = i128::from(a);

--- a/lib/crypto/src/field/fp.rs
+++ b/lib/crypto/src/field/fp.rs
@@ -1011,6 +1011,18 @@ mod tests {
 
     const MODULUS: i128 = 1000003; // Prime number
 
+    prop_compose! {
+        fn non_zero_modulo_i64()(
+            b in 1..i64::MAX
+        ) -> i64 {
+            if i128::from(b) % MODULUS == 0 {
+                b + 1
+            } else {
+                b
+            }
+        }
+    }
+
     #[test]
     fn add() {
         proptest!(|(a: i64, b: i64)| {
@@ -1066,12 +1078,7 @@ mod tests {
 
     #[test]
     fn div() {
-        proptest!(|(a: i64, b: i64)| {
-            // Skip if `b` is zero.
-            if i128::from(b) % MODULUS == 0 {
-                return Ok(());
-            }
-
+        proptest!(|(a: i64, b in non_zero_modulo_i64())| {
             let res = Field64::from(a) / Field64::from(b);
             let res: i128 = res.into();
             let a = i128::from(a);

--- a/lib/crypto/src/field/fp.rs
+++ b/lib/crypto/src/field/fp.rs
@@ -1011,52 +1011,62 @@ mod tests {
 
     const MODULUS: i128 = 1000003; // Prime number
 
-    proptest! {
-        #[test]
-        fn add(a: i64, b: i64) {
+    #[test]
+    fn add() {
+        proptest!(|(a: i64, b: i64)| {
             let res = Field64::from(a) + Field64::from(b);
             let res: i128 = res.into();
             let a = i128::from(a);
             let b = i128::from(b);
             prop_assert_eq!(res, (a + b).rem_euclid(MODULUS));
-        }
+        })
+    }
 
-        #[test]
-        fn double(a: i64) {
+    #[test]
+    fn double() {
+        proptest!(|(a: i64)| {
             let res = Field64::from(a).double();
             let res: i128 = res.into();
             let a = i128::from(a);
             prop_assert_eq!(res, (a + a).rem_euclid(MODULUS));
-        }
+        })
+    }
 
-        #[test]
-        fn sub(a: i64, b: i64) {
+    #[test]
+    fn sub() {
+        proptest!(|(a: i64, b: i64)| {
             let res = Field64::from(a) - Field64::from(b);
             let res: i128 = res.into();
             let a = i128::from(a);
             let b = i128::from(b);
             prop_assert_eq!(res, (a - b).rem_euclid(MODULUS));
-        }
+        })
+    }
 
-        #[test]
-        fn mul(a: i64, b: i64) {
+    #[test]
+    fn mul() {
+        proptest!(|(a: i64, b: i64)| {
             let res = Field64::from(a) * Field64::from(b);
             let res: i128 = res.into();
             let a = i128::from(a);
             let b = i128::from(b);
             prop_assert_eq!(res, (a * b).rem_euclid(MODULUS));
-        }
+        })
+    }
 
-        #[test]
-        fn square(a: i64) {
+    #[test]
+    fn square() {
+        proptest!(|(a: i64)| {
             let res = Field64::from(a).square();
             let res: i128 = res.into();
             let a = i128::from(a);
             prop_assert_eq!(res, (a * a).rem_euclid(MODULUS));
-        }
+        })
+    }
 
-        #[test]
-        fn div(a: i64, b: i64) {
+    #[test]
+    fn div() {
+        proptest!(|(a: i64, b: i64)| {
             // Skip if `b` is zero.
             if i128::from(b) % MODULUS == 0 {
                 return Ok(());
@@ -1068,10 +1078,12 @@ mod tests {
             let b = i128::from(b);
             // a / b = res mod M => res * b = a mod M
             prop_assert_eq!((res * b).rem_euclid(MODULUS), a.rem_euclid(MODULUS));
-        }
+        })
+    }
 
-        #[test]
-        fn pow(a: i64, b in 0_u32..1000) {
+    #[test]
+    fn pow() {
+        proptest!(|(a: i64, b in 0_u32..1000)| {
             /// Compute a^b in an expensive and iterative way.
             fn dumb_pow(a: i128, b: i128) -> i128 {
                 (0..b).fold(1, |acc, _| (acc * a).rem_euclid(MODULUS))
@@ -1082,18 +1094,22 @@ mod tests {
             let a = i128::from(a);
             let b = i128::from(b);
             prop_assert_eq!(res, dumb_pow(a, b));
-        }
+        })
+    }
 
-        #[test]
-        fn neg(a: i64) {
+    #[test]
+    fn neg() {
+        proptest!(|(a: i64)| {
             let res = -Field64::from(a);
             let res: i128 = res.into();
             let a = i128::from(a);
             prop_assert_eq!(res, (-a).rem_euclid(MODULUS));
-        }
+        })
+    }
 
-        #[test]
-        fn one(a: i64) {
+    #[test]
+    fn one() {
+        proptest!(|(a: i64)| {
             let res = Field64::one();
             let res: i128 = res.into();
             prop_assert_eq!(res, 1);
@@ -1102,10 +1118,12 @@ mod tests {
             let res: i128 = res.into();
             let a: i128 = a.into();
             prop_assert_eq!(res, a.rem_euclid(MODULUS));
-        }
+        })
+    }
 
-        #[test]
-        fn zero(a: i64) {
+    #[test]
+    fn zero() {
+        proptest!(|(a: i64)| {
             let res = Field64::zero();
             let res: i128 = res.into();
             prop_assert_eq!(res, 0);
@@ -1114,6 +1132,6 @@ mod tests {
             let res: i128 = res.into();
             let a: i128 = a.into();
             prop_assert_eq!(res, a.rem_euclid(MODULUS));
-        }
+        })
     }
 }

--- a/lib/crypto/src/field/fp.rs
+++ b/lib/crypto/src/field/fp.rs
@@ -1011,18 +1011,6 @@ mod tests {
 
     const MODULUS: i128 = 1000003; // Prime number
 
-    prop_compose! {
-        fn non_zero_modulo_i64()(
-            b in 1..i64::MAX
-        ) -> i64 {
-            if i128::from(b) % MODULUS == 0 {
-                b + 1
-            } else {
-                b
-            }
-        }
-    }
-
     #[test]
     fn add() {
         proptest!(|(a: i64, b: i64)| {
@@ -1074,6 +1062,18 @@ mod tests {
             let a = i128::from(a);
             prop_assert_eq!(res, (a * a).rem_euclid(MODULUS));
         })
+    }
+
+    prop_compose! {
+        fn non_zero_modulo_i64()(
+            b in 1..i64::MAX
+        ) -> i64 {
+            if i128::from(b) % MODULUS == 0 {
+                b + 1
+            } else {
+                b
+            }
+        }
     }
 
     #[test]

--- a/lib/crypto/src/hash.rs
+++ b/lib/crypto/src/hash.rs
@@ -158,7 +158,7 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::KeccakBuilder;
+    use crate::{test_helpers::non_empty_u8_vec_strategy, KeccakBuilder};
 
     // Helper impl for testing
     impl Hash for Vec<u8> {
@@ -179,8 +179,8 @@ mod tests {
 
     #[test]
     fn regular_hash_is_order_dependent() {
-        proptest!(|(a in prop::collection::vec(any::<u8>(), 1..ProptestConfig::default().max_default_size_range),
-                    b in prop::collection::vec(any::<u8>(), 1..ProptestConfig::default().max_default_size_range))| {
+        proptest!(|(a in non_empty_u8_vec_strategy(),
+                    b in non_empty_u8_vec_strategy())| {
             prop_assume!(a != b);
             let builder = KeccakBuilder;
             let hash1 = hash_pair(&a, &b, builder.build_hasher());

--- a/lib/crypto/src/hash.rs
+++ b/lib/crypto/src/hash.rs
@@ -167,54 +167,55 @@ mod tests {
         }
     }
 
-    proptest! {
-        #[test]
-        fn commutative_hash_is_order_independent(
-            a: Vec<u8>,
-            b: Vec<u8>
-        ) {
+    #[test]
+    fn commutative_hash_is_order_independent() {
+        proptest!(|(a: Vec<u8>, b: Vec<u8>)| {
             let builder = KeccakBuilder;
             let hash1 = commutative_hash_pair(&a, &b, builder.build_hasher());
             let hash2 = commutative_hash_pair(&b, &a, builder.build_hasher());
             prop_assert_eq!(hash1, hash2);
-        }
+        })
+    }
 
-        #[test]
-        fn regular_hash_is_order_dependent(
-            a: Vec<u8>,
-            b: Vec<u8>
-        ) {
-            prop_assume!(!a.is_empty());
-            prop_assume!(!b.is_empty());
+    #[test]
+    fn regular_hash_is_order_dependent() {
+        proptest!(|(a in prop::collection::vec(any::<u8>(), 1..ProptestConfig::default().max_default_size_range),
+                    b in prop::collection::vec(any::<u8>(), 1..ProptestConfig::default().max_default_size_range))| {
             prop_assume!(a != b);
             let builder = KeccakBuilder;
             let hash1 = hash_pair(&a, &b, builder.build_hasher());
             let hash2 = hash_pair(&b, &a, builder.build_hasher());
             prop_assert_ne!(hash1, hash2);
-        }
+        })
+    }
 
-        #[test]
-        fn hash_pair_deterministic(a: Vec<u8>, b: Vec<u8>) {
+    #[test]
+    fn hash_pair_deterministic() {
+        proptest!(|(a: Vec<u8>, b: Vec<u8>)| {
             let builder = KeccakBuilder;
             let hash1 = hash_pair(&a, &b, builder.build_hasher());
             let hash2 = hash_pair(&a, &b, builder.build_hasher());
             prop_assert_eq!(hash1, hash2);
-        }
+        })
+    }
 
-        #[test]
-        fn commutative_hash_pair_deterministic(a: Vec<u8>, b: Vec<u8>) {
+    #[test]
+    fn commutative_hash_pair_deterministic() {
+        proptest!(|(a: Vec<u8>, b: Vec<u8>)| {
             let builder = KeccakBuilder;
             let hash1 = commutative_hash_pair(&a, &b, builder.build_hasher());
             let hash2 = commutative_hash_pair(&a, &b, builder.build_hasher());
             prop_assert_eq!(hash1, hash2);
-        }
+        })
+    }
 
-        #[test]
-        fn identical_pairs_hash(a: Vec<u8>) {
+    #[test]
+    fn identical_pairs_hash() {
+        proptest!(|(a: Vec<u8>)| {
             let builder = KeccakBuilder;
             let hash1 = hash_pair(&a, &a, builder.build_hasher());
             let hash2 = commutative_hash_pair(&a, &a, builder.build_hasher());
             assert_eq!(hash1, hash2);
-        }
+        })
     }
 }

--- a/lib/crypto/src/keccak.rs
+++ b/lib/crypto/src/keccak.rs
@@ -52,9 +52,9 @@ mod tests {
 
     use super::*;
 
-    proptest! {
-        #[test]
-        fn single_bit_change_affects_output(data: Vec<u8>) {
+    #[test]
+    fn single_bit_change_affects_output() {
+        proptest!(|(data: Vec<u8>)| {
             prop_assume!(!data.is_empty());
 
             let mut modified = data.clone();
@@ -66,10 +66,12 @@ mod tests {
             hasher2.update(&modified);
 
             prop_assert_ne!(hasher1.finalize(), hasher2.finalize());
-        }
+        })
+    }
 
-        #[test]
-        fn sequential_updates_match_concatenated(data1: Vec<u8>, data2: Vec<u8>) {
+    #[test]
+    fn sequential_updates_match_concatenated() {
+        proptest!(|(data1: Vec<u8>, data2: Vec<u8>)| {
             let builder = KeccakBuilder;
 
             let mut hasher1 = builder.build_hasher();
@@ -84,10 +86,12 @@ mod tests {
             let result2 = hasher2.finalize();
 
             prop_assert_eq!(result1, result2);
-        }
+        })
+    }
 
-        #[test]
-        fn split_updates_match_full_update(data: Vec<u8>, split_point: usize) {
+    #[test]
+    fn split_updates_match_full_update() {
+        proptest!(|(data: Vec<u8>, split_point: usize)| {
             prop_assume!(!data.is_empty());
 
             let builder = KeccakBuilder;
@@ -103,13 +107,12 @@ mod tests {
             let result2 = hasher2.finalize();
 
             prop_assert_eq!(result1, result2);
-        }
+        })
+    }
 
-        #[test]
-        fn multiple_hasher_instances_are_consistent(
-            data1: Vec<u8>,
-            data2: Vec<u8>,
-        ) {
+    #[test]
+    fn multiple_hasher_instances_are_consistent() {
+        proptest!(|(data1: Vec<u8>, data2: Vec<u8>)| {
             let builder = KeccakBuilder;
 
             let mut hasher1 = builder.build_hasher();
@@ -123,19 +126,23 @@ mod tests {
             let result2 = hasher2.finalize();
 
             prop_assert_eq!(result1, result2);
-        }
+        })
+    }
 
-        #[test]
-        fn output_is_always_32_bytes(data: Vec<u8>) {
+    #[test]
+    fn output_is_always_32_bytes() {
+        proptest!(|(data: Vec<u8>)| {
             let builder = KeccakBuilder;
             let mut hasher = builder.build_hasher();
             hasher.update(&data);
             let result = hasher.finalize();
             assert_eq!(result.len(), 32);
-        }
+        })
+    }
 
-        #[test]
-        fn update_order_dependence(data1: Vec<u8>, data2: Vec<u8>) {
+    #[test]
+    fn update_order_dependence() {
+        proptest!(|(data1: Vec<u8>, data2: Vec<u8>)| {
             prop_assume!(!data1.is_empty());
             prop_assume!(!data2.is_empty());
             prop_assume!(data1 != data2);
@@ -150,10 +157,12 @@ mod tests {
             hasher2.update(&data1);
 
             prop_assert_ne!(hasher1.finalize(), hasher2.finalize());
-        }
+        })
+    }
 
-        #[test]
-        fn empty_input_order_independence(data: Vec<u8>) {
+    #[test]
+    fn empty_input_order_independence() {
+        proptest!(|(data: Vec<u8>)| {
             prop_assume!(!data.is_empty());
 
             let mut hasher1 = KeccakBuilder.build_hasher();
@@ -167,10 +176,12 @@ mod tests {
             hasher2.update(&data);
 
             prop_assert_eq!(hasher1.finalize(), hasher2.finalize());
-        }
+        })
+    }
 
-        #[test]
-        fn trailing_zero_affects_output(data: Vec<u8>) {
+    #[test]
+    fn trailing_zero_affects_output() {
+        proptest!(|(data: Vec<u8>)| {
             let mut hasher1 = KeccakBuilder.build_hasher();
             let mut hasher2 = KeccakBuilder.build_hasher();
 
@@ -181,10 +192,12 @@ mod tests {
             hasher2.update(&padded);
 
             prop_assert_ne!(hasher1.finalize(), hasher2.finalize());
-        }
+        })
+    }
 
-        #[test]
-        fn leading_zeros_affect_output(data: Vec<u8>) {
+    #[test]
+    fn leading_zeros_affect_output() {
+        proptest!(|(data: Vec<u8>)| {
             prop_assume!(!data.is_empty());
 
             let mut hasher1 = KeccakBuilder.build_hasher();
@@ -199,10 +212,12 @@ mod tests {
             let hash2 = hasher2.finalize();
 
             prop_assert_ne!(hash1, hash2);
-        }
+        })
+    }
 
-        #[test]
-        fn no_trivial_collisions_same_length(data: Vec<u8>) {
+    #[test]
+    fn no_trivial_collisions_same_length() {
+        proptest!(|(data: Vec<u8>)| {
             prop_assume!(!data.is_empty());
             let mut modified = data.clone();
             modified[data.len() - 1] = modified[data.len() - 1].wrapping_add(1);
@@ -214,10 +229,12 @@ mod tests {
             hasher2.update(&modified);
 
             prop_assert_ne!(hasher1.finalize(), hasher2.finalize());
-        }
+        })
+    }
 
-        #[test]
-        fn length_extension_attack_resistance(data1: Vec<u8>, data2: Vec<u8>) {
+    #[test]
+    fn length_extension_attack_resistance() {
+        proptest!(|(data1: Vec<u8>, data2: Vec<u8>)| {
             prop_assume!(!data1.is_empty());
             prop_assume!(!data2.is_empty());
 
@@ -236,7 +253,7 @@ mod tests {
             let hash3 = hasher3.finalize();
 
             prop_assert_ne!(hash2, hash3);
-        }
+        })
     }
 
     #[test]

--- a/lib/crypto/src/lib.rs
+++ b/lib/crypto/src/lib.rs
@@ -36,3 +36,6 @@ pub mod merkle;
 pub mod poseidon2;
 
 pub use keccak::KeccakBuilder;
+
+#[cfg(all(test, feature = "std"))]
+mod test_helpers;

--- a/lib/crypto/src/test_helpers.rs
+++ b/lib/crypto/src/test_helpers.rs
@@ -1,0 +1,8 @@
+use proptest::prelude::*;
+
+pub(crate) fn non_empty_u8_vec_strategy() -> impl Strategy<Value = Vec<u8>> {
+    prop::collection::vec(
+        any::<u8>(),
+        1..ProptestConfig::default().max_default_size_range,
+    )
+}


### PR DESCRIPTION
Making all prop tests stand-alone is helpful as it enables devs using certain IDEs to run each test individually by clicking an appropriate button that appears next to individual tests