### PR TITLE
feat: implement Deref for Erc20Permit and Ownable2Step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--
+- Implement `Deref<Target = Ownable>` for `Ownable2Step` and `Deref<Target = Erc20>` for `Erc20Permit`. #552
 
 ### Changed (Breaking)
 

--- a/contracts/src/access/ownable_two_step.rs
+++ b/contracts/src/access/ownable_two_step.rs
@@ -17,6 +17,7 @@
 //! available.
 
 use alloc::vec::Vec;
+use core::ops::{Deref, DerefMut};
 
 use alloy_primitives::Address;
 pub use sol::*;
@@ -66,6 +67,20 @@ pub struct Ownable2Step {
     pub ownable: Ownable,
     /// Pending owner of the contract.
     pub(crate) pending_owner: StorageAddress,
+}
+
+impl Deref for Ownable2Step {
+    type Target = Ownable;
+
+    fn deref(&self) -> &Self::Target {
+        &self.ownable
+    }
+}
+
+impl DerefMut for Ownable2Step {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.ownable
+    }
 }
 
 /// Interface for an [`Ownable2Step`] contract.

--- a/contracts/src/token/erc20/extensions/permit.rs
+++ b/contracts/src/token/erc20/extensions/permit.rs
@@ -13,6 +13,7 @@
 //! [ERC]: https://eips.ethereum.org/EIPS/eip-2612
 
 use alloc::vec::Vec;
+use core::ops::{Deref, DerefMut};
 
 use alloy_primitives::{keccak256, Address, B256, U256};
 use alloy_sol_types::SolType;
@@ -84,6 +85,20 @@ pub struct Erc20Permit<T: IEip712 + StorageType> {
     pub(crate) nonces: Nonces,
     /// Contract implementing [`IEip712`] trait.
     pub(crate) eip712: T,
+}
+
+impl<T: IEip712 + StorageType> Deref for Erc20Permit<T> {
+    type Target = Erc20;
+
+    fn deref(&self) -> &Self::Target {
+        &self.erc20
+    }
+}
+
+impl<T: IEip712 + StorageType> DerefMut for Erc20Permit<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.erc20
+    }
 }
 
 /// NOTE: Implementation of [`TopLevelStorage`] to be able use `&mut self` when

--- a/examples/ownable-two-step/src/lib.rs
+++ b/examples/ownable-two-step/src/lib.rs
@@ -27,7 +27,7 @@ impl Ownable2StepExample {
         to: Address,
         value: U256,
     ) -> Result<(), Vec<u8>> {
-        self.ownable.ownable.only_owner()?;
+        self.ownable.only_owner()?;
         self.erc20.transfer(to, value)?;
         Ok(())
     }


### PR DESCRIPTION
This will allow devs to implement a `permit + burnable` combination without accessing the nested `Erc20Permit.erc20` instance.

Implementing `Deref`:
- makes the implementation more intuitive.
- makes implementing Wizard's function printing logic more straightforward ([current](https://github.com/OpenZeppelin/contracts-wizard/blob/76dee5295d843c227b0d24c4f78cf62d1933d427/packages/core/stylus/src/erc20.ts#L220-L225) VS [if this PR is merged](https://github.com/OpenZeppelin/contracts-wizard/blob/b536968c1a3b3ba91c5f2217b22ffa946cc7d789/packages/core/stylus/src/erc20.ts#L218-L223))

```rust
// other imports...
use openzeppelin_stylus::{
    token::erc20::extensions::{Erc20Permit, IErc20Burnable},
    utils::cryptography::eip712::IEip712,
};

#[entrypoint]
#[storage]
struct Erc20PermitExample {
    #[borrow]
    pub erc20_permit: Erc20Permit<Eip712>,
}

// define Eip712...

#[public]
#[inherit(Erc20Permit<Eip712>)]
impl Erc20PermitExample {
    pub fn burn(&mut self, value: U256) -> Result<(), Vec<u8>> {
        // before:
        // self.erc20_permit.erc20.burn(value).map_err(|e| e.into())
        // now:
        self.erc20_permit.burn(value).map_err(|e| e.into())
    }

    pub fn burn_from(
        &mut self,
        account: Address,
        value: U256,
    ) -> Result<(), Vec<u8>> {
        // before:
        // self.erc20_permit.erc20.burn_from(account, value).map_err(|e| e.into())
        // now:
        self.erc20_permit.burn_from(account, value).map_err(|e| e.into())
    }
}
```