### PR TITLE
fix: clippy warning in AccessControl

### DIFF
--- a/contracts/src/access/control.rs
+++ b/contracts/src/access/control.rs
@@ -244,7 +244,6 @@ pub trait IAccessControl {
 impl IAccessControl for AccessControl {
     type Error = Error;
 
-    #[must_use]
     fn has_role(&self, role: B256, account: Address) -> bool {
         self.roles.getter(role).has_role.get(account)
     }
@@ -253,7 +252,6 @@ impl IAccessControl for AccessControl {
         self._check_role(role, msg::sender())
     }
 
-    #[must_use]
     fn get_role_admin(&self, role: B256) -> B256 {
         *self.roles.getter(role).admin_role
     }


### PR DESCRIPTION
Resolves #580 