### PR TITLE
ref: Use `enum Error` instead of `Vec<u8>` in Results + Implement `MethodError` for all Contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--
+- `access::control::Error` implements `MethodError`. #PR_ID
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Implement `MethodError` for all contracts. #594
+- Implement `MethodError` for all contracts' errors. #594
 
 ### Changed
 
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (Breaking)
 
-- In `Ownable2Step` remove `ownable_two_step::Error` wrapper, and emit `ownable::Error` directly. #594
+- Remove `ownable_two_step::Error` wrapper in `Ownable2Step`, and emit `ownable::Error` directly. #594
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (Breaking)
 
--
+- Remove `ownable_two_step::Error` wrapper and instead directly emit `ownable::Error` in `Ownable2Step`. #PR_ID
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `access::control::Error` implements `MethodError`. #PR_ID
+- Implement `MethodError` for all contracts. #594
 
 ### Changed
 
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (Breaking)
 
-- Remove `ownable_two_step::Error` wrapper and instead directly emit `ownable::Error` in `Ownable2Step`. #PR_ID
+- In `Ownable2Step` remove `ownable_two_step::Error` wrapper, and emit `ownable::Error` directly. #594
 
 ### Fixed
 

--- a/contracts-proc/README.md
+++ b/contracts-proc/README.md
@@ -22,8 +22,10 @@ use openzeppelin_stylus_proc::interface_id;
 
 #[interface_id]
 pub trait IErc721 {
-    fn balance_of(&self, owner: Address) -> Result<U256, Vec<u8>>;
-    fn owner_of(&self, token_id: U256) -> Result<Address, Vec<u8>>;
+    type Error: Into<alloc::vec::Vec<u8>>;
+
+    fn balance_of(&self, owner: Address) -> Result<U256, Self::Error>;
+    fn owner_of(&self, token_id: U256) -> Result<Address, Self::Error>;
 
     // ...
 }
@@ -52,7 +54,7 @@ fn safe_transfer_from_with_data(
     to: Address,
     token_id: U256,
     data: Bytes,
-) -> Result<(), Vec<u8>>;
+) -> Result<(), Self::Error>;
 ```
 
 This ensures compatibility with Solidity's naming conventions.

--- a/contracts/src/access/control.rs
+++ b/contracts/src/access/control.rs
@@ -45,6 +45,7 @@ use alloy_primitives::{Address, FixedBytes, B256};
 use openzeppelin_stylus_proc::interface_id;
 pub use sol::*;
 use stylus_sdk::{
+    call::MethodError,
     evm, msg,
     prelude::*,
     storage::{StorageBool, StorageFixedBytes, StorageMap},
@@ -105,6 +106,12 @@ pub enum Error {
     UnauthorizedAccount(AccessControlUnauthorizedAccount),
     /// The caller of a afunction is not the expected one.
     BadConfirmation(AccessControlBadConfirmation),
+}
+
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
 }
 
 /// State of a [`RoleData`] contract.

--- a/contracts/src/access/ownable_two_step.rs
+++ b/contracts/src/access/ownable_two_step.rs
@@ -105,8 +105,8 @@ pub trait IOwnable2Step {
     ///
     /// # Errors
     ///
-    /// * [`OwnableError::UnauthorizedAccount`] - If called by any account other
-    ///   than the owner.
+    /// * [`ownable::Error::UnauthorizedAccount`] - If called by any account
+    ///   other than the owner.
     ///
     /// # Events
     ///
@@ -125,8 +125,8 @@ pub trait IOwnable2Step {
     ///
     /// # Errors
     ///
-    /// * [`OwnableError::UnauthorizedAccount`] - If called by any account other
-    ///   than the pending owner.
+    /// * [`ownable::Error::UnauthorizedAccount`] - If called by any account
+    ///   other than the pending owner.
     ///
     /// # Events
     ///
@@ -146,7 +146,7 @@ pub trait IOwnable2Step {
     ///
     /// # Errors
     ///
-    /// * [`OwnableError::UnauthorizedAccount`] - If not called by the owner.
+    /// * [`ownable::Error::UnauthorizedAccount`] - If not called by the owner.
     ///
     /// # Events
     ///

--- a/contracts/src/access/ownable_two_step.rs
+++ b/contracts/src/access/ownable_two_step.rs
@@ -187,8 +187,7 @@ impl IOwnable2Step for Ownable2Step {
         if sender != pending_owner {
             return Err(ownable::Error::UnauthorizedAccount(
                 OwnableUnauthorizedAccount { account: sender },
-            )
-            .into());
+            ));
         }
         self._transfer_ownership(sender);
         Ok(())

--- a/contracts/src/access/ownable_two_step.rs
+++ b/contracts/src/access/ownable_two_step.rs
@@ -21,15 +21,10 @@ use core::ops::{Deref, DerefMut};
 
 use alloy_primitives::Address;
 pub use sol::*;
-use stylus_sdk::{
-    evm, msg,
-    prelude::*,
-    storage::StorageAddress,
-    stylus_proc::{public, SolidityError},
-};
+use stylus_sdk::{evm, msg, prelude::*, storage::StorageAddress};
 
 use crate::access::ownable::{
-    Error as OwnableError, IOwnable, Ownable, OwnableUnauthorizedAccount,
+    self, IOwnable, Ownable, OwnableUnauthorizedAccount,
 };
 
 #[cfg_attr(coverage_nightly, coverage(off))]
@@ -48,14 +43,6 @@ mod sol {
         );
 
     }
-}
-
-/// An error that occurred in the implementation of an [`Ownable2Step`]
-/// contract.
-#[derive(SolidityError, Debug)]
-pub enum Error {
-    /// Error type from [`Ownable`] contract.
-    Ownable(OwnableError),
 }
 
 /// State of an [`Ownable2Step`] contract.
@@ -169,7 +156,7 @@ pub trait IOwnable2Step {
 
 #[public]
 impl IOwnable2Step for Ownable2Step {
-    type Error = Error;
+    type Error = ownable::Error;
 
     fn owner(&self) -> Address {
         self.ownable.owner()
@@ -198,7 +185,7 @@ impl IOwnable2Step for Ownable2Step {
         let sender = msg::sender();
         let pending_owner = self.pending_owner();
         if sender != pending_owner {
-            return Err(OwnableError::UnauthorizedAccount(
+            return Err(ownable::Error::UnauthorizedAccount(
                 OwnableUnauthorizedAccount { account: sender },
             )
             .into());
@@ -207,7 +194,7 @@ impl IOwnable2Step for Ownable2Step {
         Ok(())
     }
 
-    fn renounce_ownership(&mut self) -> Result<(), Error> {
+    fn renounce_ownership(&mut self) -> Result<(), Self::Error> {
         self.ownable.only_owner()?;
         self._transfer_ownership(Address::ZERO);
         Ok(())
@@ -242,7 +229,7 @@ mod tests {
     use motsu::prelude::Contract;
     use stylus_sdk::prelude::TopLevelStorage;
 
-    use super::{Error, IOwnable2Step, Ownable2Step, OwnableError};
+    use super::{ownable::Error, IOwnable2Step, Ownable2Step};
 
     unsafe impl TopLevelStorage for Ownable2Step {}
 
@@ -299,10 +286,7 @@ mod tests {
         });
 
         let err = contract.sender(alice).transfer_ownership(dave).unwrap_err();
-        assert!(matches!(
-            err,
-            Error::Ownable(OwnableError::UnauthorizedAccount(_))
-        ));
+        assert!(matches!(err, Error::UnauthorizedAccount(_)));
     }
 
     #[motsu::test]
@@ -337,10 +321,7 @@ mod tests {
         });
 
         let err = contract.sender(alice).accept_ownership().unwrap_err();
-        assert!(matches!(
-            err,
-            Error::Ownable(OwnableError::UnauthorizedAccount(_))
-        ));
+        assert!(matches!(err, Error::UnauthorizedAccount(_)));
     }
 
     #[motsu::test]
@@ -392,10 +373,7 @@ mod tests {
         });
 
         let err = contract.sender(alice).renounce_ownership().unwrap_err();
-        assert!(matches!(
-            err,
-            Error::Ownable(OwnableError::UnauthorizedAccount(_))
-        ));
+        assert!(matches!(err, Error::UnauthorizedAccount(_)));
     }
 
     #[motsu::test]

--- a/contracts/src/access/ownable_two_step.rs
+++ b/contracts/src/access/ownable_two_step.rs
@@ -228,7 +228,9 @@ mod tests {
     use motsu::prelude::Contract;
     use stylus_sdk::prelude::TopLevelStorage;
 
-    use super::{ownable::Error, IOwnable2Step, Ownable2Step};
+    use super::{
+        ownable::Error, IOwnable2Step, Ownable2Step, OwnableUnauthorizedAccount,
+    };
 
     unsafe impl TopLevelStorage for Ownable2Step {}
 
@@ -285,7 +287,12 @@ mod tests {
         });
 
         let err = contract.sender(alice).transfer_ownership(dave).unwrap_err();
-        assert!(matches!(err, Error::UnauthorizedAccount(_)));
+        assert!(matches!(
+            err,
+            Error::UnauthorizedAccount(OwnableUnauthorizedAccount {
+                account
+            }) if account == alice
+        ));
     }
 
     #[motsu::test]
@@ -320,7 +327,12 @@ mod tests {
         });
 
         let err = contract.sender(alice).accept_ownership().unwrap_err();
-        assert!(matches!(err, Error::UnauthorizedAccount(_)));
+        assert!(matches!(
+            err,
+            Error::UnauthorizedAccount(OwnableUnauthorizedAccount {
+                account
+            }) if account == alice
+        ));
     }
 
     #[motsu::test]
@@ -372,7 +384,12 @@ mod tests {
         });
 
         let err = contract.sender(alice).renounce_ownership().unwrap_err();
-        assert!(matches!(err, Error::UnauthorizedAccount(_)));
+        assert!(matches!(
+            err,
+            Error::UnauthorizedAccount(OwnableUnauthorizedAccount {
+                account
+            }) if account == alice
+        ));
     }
 
     #[motsu::test]

--- a/contracts/src/finance/vesting_wallet.rs
+++ b/contracts/src/finance/vesting_wallet.rs
@@ -32,7 +32,7 @@ use openzeppelin_stylus_proc::interface_id;
 pub use sol::*;
 use stylus_sdk::{
     block,
-    call::{self, call, Call},
+    call::{self, call, Call, MethodError},
     contract, evm, function_selector,
     prelude::*,
     storage::{StorageMap, StorageU256, StorageU64},
@@ -93,6 +93,12 @@ pub enum Error {
     SafeErc20(safe_erc20::Error),
     /// The token address is not valid. (eg. `Address::ZERO`).
     InvalidToken(InvalidToken),
+}
+
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
 }
 
 /// State of a [`VestingWallet`] Contract.

--- a/contracts/src/token/common/erc2981.rs
+++ b/contracts/src/token/common/erc2981.rs
@@ -23,6 +23,7 @@ use alloy_primitives::{Address, FixedBytes, U256};
 use openzeppelin_stylus_proc::interface_id;
 pub use sol::*;
 use stylus_sdk::{
+    call::MethodError,
     prelude::*,
     storage::{StorageAddress, StorageMap},
     stylus_proc::SolidityError,
@@ -94,6 +95,12 @@ pub enum Error {
 
     /// Indicates that the royalty receiver for `token_id` is invalid.
     InvalidTokenRoyaltyReceiver(ERC2981InvalidTokenRoyaltyReceiver),
+}
+
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
 }
 
 /// Struct for Royalty Information of tokens.

--- a/contracts/src/token/erc20/extensions/capped.rs
+++ b/contracts/src/token/erc20/extensions/capped.rs
@@ -10,6 +10,7 @@ use alloc::{vec, vec::Vec};
 use alloy_primitives::U256;
 pub use sol::*;
 use stylus_sdk::{
+    call::MethodError,
     prelude::*,
     storage::StorageU256,
     stylus_proc::{public, SolidityError},
@@ -43,6 +44,12 @@ pub enum Error {
     /// Indicates an error related to the operation that failed
     /// because the supplied `cap` is not a valid cap value.
     InvalidCap(ERC20InvalidCap),
+}
+
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
 }
 
 /// State of a [`Capped`] Contract.

--- a/contracts/src/token/erc20/extensions/erc4626.rs
+++ b/contracts/src/token/erc20/extensions/erc4626.rs
@@ -12,7 +12,7 @@ use alloc::{vec, vec::Vec};
 use alloy_primitives::{uint, Address, U256, U8};
 pub use sol::*;
 use stylus_sdk::{
-    call::Call,
+    call::{Call, MethodError},
     contract, evm, msg,
     prelude::*,
     storage::{StorageAddress, StorageU8},
@@ -122,6 +122,12 @@ pub enum Error {
     SafeErc20(safe_erc20::Error),
     /// Error type from [`Erc20`] contract [`erc20::Error`].
     Erc20(erc20::Error),
+}
+
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
 }
 
 /// State of an [`Erc4626`] token.

--- a/contracts/src/token/erc20/extensions/erc4626.rs
+++ b/contracts/src/token/erc20/extensions/erc4626.rs
@@ -208,8 +208,8 @@ pub trait IErc4626 {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// fn convert_to_shares(&mut self, assets: U256) -> Result<U256, Vec<u8>> {
-    ///     Ok(self.erc4626.convert_to_shares(assets, &self.erc20)?)
+    /// fn convert_to_shares(&mut self, assets: U256) -> Result<U256, erc4626::Error> {
+    ///     self.erc4626.convert_to_shares(assets, &self.erc20)
     /// }
     /// ```
     fn convert_to_shares(
@@ -252,8 +252,8 @@ pub trait IErc4626 {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// fn convert_to_assets(&mut self, shares: U256) -> Result<U256, Vec<u8>> {
-    ///     Ok(self.erc4626.convert_to_assets(shares, &self.erc20)?)
+    /// fn convert_to_assets(&mut self, shares: U256) -> Result<U256, erc4626::Error> {
+    ///     self.erc4626.convert_to_assets(shares, &self.erc20)
     /// }
     /// ```
     fn convert_to_assets(
@@ -304,8 +304,8 @@ pub trait IErc4626 {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// fn preview_deposit(&mut self, assets: U256) -> Result<U256, Vec<u8>> {
-    ///     Ok(self.erc4626.preview_deposit(assets, &self.erc20)?)
+    /// fn preview_deposit(&mut self, assets: U256) -> Result<U256, erc4626::Error> {
+    ///     self.erc4626.preview_deposit(assets, &self.erc20)
     /// }
     /// ```
     fn preview_deposit(
@@ -356,10 +356,10 @@ pub trait IErc4626 {
     /// ```rust,ignore
     /// fn deposit(
     ///     &mut self,
-    ///    assets: U256,
-    ///    receiver: Address,
-    /// ) -> Result<U256, Vec<u8>> {
-    ///     Ok(self.erc4626.deposit(assets, receiver, &mut self.erc20)?)
+    ///     assets: U256,
+    ///     receiver: Address,
+    /// ) -> Result<U256, erc4626::Error> {
+    ///     self.erc4626.deposit(assets, receiver, &mut self.erc20)
     /// }
     /// ```
     fn deposit(
@@ -411,8 +411,8 @@ pub trait IErc4626 {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// fn preview_mint(&mut self, shares: U256) -> Result<U256, Vec<u8>> {
-    ///     Ok(self.erc4626.preview_mint(shares, &self.erc20)?)
+    /// fn preview_mint(&mut self, shares: U256) -> Result<U256, erc4626::Error> {
+    ///     self.erc4626.preview_mint(shares, &self.erc20)
     /// }
     /// ```
     fn preview_mint(
@@ -466,10 +466,10 @@ pub trait IErc4626 {
     /// ```rust,ignore
     /// fn mint(
     ///     &mut self,
-    ///    shares: U256,
-    ///    receiver: Address,
-    /// ) -> Result<U256, Vec<u8>> {
-    ///     Ok(self.erc4626.mint(shares, receiver, &mut self.erc20)?)
+    ///     shares: U256,
+    ///     receiver: Address,
+    /// ) -> Result<U256, erc4626::Error> {
+    ///     self.erc4626.mint(shares, receiver, &mut self.erc20)
     /// }
     /// ```
     fn mint(
@@ -507,8 +507,8 @@ pub trait IErc4626 {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// fn max_withdraw(&mut self, owner: Address) -> Result<U256, Vec<u8>> {
-    ///     Ok(self.erc4626.max_withdraw(owner, &self.erc20)?)
+    /// fn max_withdraw(&mut self, owner: Address) -> Result<U256, erc4626::Error> {
+    ///     self.erc4626.max_withdraw(owner, &self.erc20)
     /// }
     /// ```
     fn max_withdraw(
@@ -545,8 +545,8 @@ pub trait IErc4626 {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// fn preview_withdraw(&mut self, assets: U256) -> Result<U256, Vec<u8>> {
-    ///     Ok(self.erc4626.preview_withdraw(assets, &self.erc20)?)
+    /// fn preview_withdraw(&mut self, assets: U256) -> Result<U256, erc4626::Error> {
+    ///     self.erc4626.preview_withdraw(assets, &self.erc20)
     /// }
     /// ```
     fn preview_withdraw(
@@ -605,11 +605,11 @@ pub trait IErc4626 {
     /// ```rust,ignore
     /// fn withdraw(
     ///     &mut self,
-    ///    assets: U256,
-    ///    receiver: Address,
-    ///    owner: Address,
-    /// ) -> Result<U256, Vec<u8>> {
-    ///     Ok(self.erc4626.withdraw(assets, receiver, owner, &mut self.erc20)?)
+    ///     assets: U256,
+    ///     receiver: Address,
+    ///     owner: Address,
+    /// ) -> Result<U256, erc4626::Error> {
+    ///     self.erc4626.withdraw(assets, receiver, owner, &mut self.erc20)
     /// }
     /// ```
     fn withdraw(
@@ -639,7 +639,7 @@ pub trait IErc4626 {
     ///
     /// ```rust,ignore
     /// fn max_redeem(&mut self, owner: Address) -> U256 {
-    ///     Ok(self.erc4626.max_redeem(owner, &self.erc20)?)
+    ///     self.erc4626.max_redeem(owner, &self.erc20)
     /// }
     /// ```
     fn max_redeem(&self, owner: Address, erc20: &Erc20) -> U256;
@@ -677,8 +677,8 @@ pub trait IErc4626 {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// fn preview_redeem(&mut self, shares: U256) -> Result<U256, Vec<u8>> {
-    ///     Ok(self.erc4626.preview_redeem(shares, &self.erc20)?)
+    /// fn preview_redeem(&mut self, shares: U256) -> Result<U256, erc4626::Error> {
+    ///     self.erc4626.preview_redeem(shares, &self.erc20)
     /// }
     /// ```
     fn preview_redeem(
@@ -731,10 +731,10 @@ pub trait IErc4626 {
     /// fn redeem(
     ///     &mut self,
     ///     shares: U256,
-    ///    receiver: Address,
-    ///    owner: Address,
-    /// ) -> Result<U256, Vec<u8>> {
-    ///     Ok(self.erc4626.redeem(shares, receiver, owner, &mut self.erc20)?)
+    ///     receiver: Address,
+    ///     owner: Address,
+    /// ) -> Result<U256, erc4626::Error> {
+    ///     self.erc4626.redeem(shares, receiver, owner, &mut self.erc20)
     /// }
     /// ```
     fn redeem(

--- a/contracts/src/token/erc20/extensions/flash_mint.rs
+++ b/contracts/src/token/erc20/extensions/flash_mint.rs
@@ -22,7 +22,7 @@ use alloc::{vec, vec::Vec};
 use alloy_primitives::{Address, U256};
 use stylus_sdk::{
     abi::Bytes,
-    call::Call,
+    call::{Call, MethodError},
     contract, msg,
     prelude::*,
     storage::{StorageAddress, StorageU256},
@@ -76,6 +76,12 @@ pub enum Error {
     InvalidReceiver(ERC3156InvalidReceiver),
     /// Error type from [`Erc20`] contract [`erc20::Error`].
     Erc20(erc20::Error),
+}
+
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
 }
 
 pub use borrower::IERC3156FlashBorrower;

--- a/contracts/src/token/erc20/extensions/flash_mint.rs
+++ b/contracts/src/token/erc20/extensions/flash_mint.rs
@@ -179,8 +179,8 @@ pub trait IErc3156FlashLender {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// fn flash_fee(&self, token: Address, value: U256) -> Result<U256, Vec<u8>> {
-    ///     Ok(self.erc20_flash_mint.flash_fee(token, value)?)
+    /// fn flash_fee(&self, token: Address, value: U256) -> Result<U256, flash_mint::Error> {
+    ///     self.erc20_flash_mint.flash_fee(token, value)
     /// }
     /// ```
     fn flash_fee(
@@ -238,14 +238,14 @@ pub trait IErc3156FlashLender {
     ///     token: Address,
     ///     value: U256,
     ///     data: Bytes,
-    /// ) -> Result<bool, Vec<u8>> {
-    ///     Ok(self.erc20_flash_mint.flash_loan(
+    /// ) -> Result<bool, flash_mint::Error> {
+    ///     self.erc20_flash_mint.flash_loan(
     ///         receiver,
     ///         token,
     ///         value,
     ///         data,
     ///         &mut self.erc20,
-    ///     )?)
+    ///     )
     /// }
     /// ```
     fn flash_loan(

--- a/contracts/src/token/erc20/extensions/permit.rs
+++ b/contracts/src/token/erc20/extensions/permit.rs
@@ -18,6 +18,7 @@ use alloy_primitives::{keccak256, Address, B256, U256};
 use alloy_sol_types::SolType;
 use stylus_sdk::{
     block,
+    call::MethodError,
     prelude::*,
     stylus_proc::{public, SolidityError},
 };
@@ -70,6 +71,12 @@ pub enum Error {
     Erc20(erc20::Error),
     /// Error type from [`ecdsa`] contract [`ecdsa::Error`].
     ECDSA(ecdsa::Error),
+}
+
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
 }
 
 /// State of an [`Erc20Permit`] Contract.

--- a/contracts/src/token/erc721/extensions/consecutive.rs
+++ b/contracts/src/token/erc721/extensions/consecutive.rs
@@ -30,6 +30,7 @@ use core::ops::{Deref, DerefMut};
 use alloy_primitives::{uint, Address, U256};
 use stylus_sdk::{
     abi::Bytes,
+    call::MethodError,
     evm, msg,
     prelude::*,
     stylus_proc::{public, SolidityError},
@@ -53,38 +54,6 @@ use crate::{
 
 type U96 = <S160 as Size>::Key;
 type StorageU96 = <S160 as Size>::KeyStorage;
-
-/// State of an [`Erc721Consecutive`] token.
-#[storage]
-pub struct Erc721Consecutive {
-    /// [`Erc721`] contract.
-    pub erc721: Erc721,
-    /// [`Trace`] contract for sequential ownership.
-    pub(crate) sequential_ownership: Trace<S160>,
-    /// [`BitMap`] contract for sequential burn of tokens.
-    pub(crate) sequential_burn: BitMap,
-    /// Used to offset the first token id in `next_consecutive_id` calculation.
-    pub(crate) first_consecutive_id: StorageU96,
-    /// Maximum size of a batch of consecutive tokens. This is designed to
-    /// limit stress on off-chain indexing services that have to record one
-    /// entry per token, and have protections against "unreasonably large"
-    /// batches of tokens.
-    pub(crate) max_batch_size: StorageU96,
-}
-
-impl Deref for Erc721Consecutive {
-    type Target = Erc721;
-
-    fn deref(&self) -> &Self::Target {
-        &self.erc721
-    }
-}
-
-impl DerefMut for Erc721Consecutive {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.erc721
-    }
-}
 
 pub use sol::*;
 #[cfg_attr(coverage_nightly, coverage(off))]
@@ -149,6 +118,44 @@ pub enum Error {
     ForbiddenMint(ERC721ForbiddenMint),
     /// Batch burn is not supported.
     ForbiddenBatchBurn(ERC721ForbiddenBatchBurn),
+}
+
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
+}
+
+/// State of an [`Erc721Consecutive`] token.
+#[storage]
+pub struct Erc721Consecutive {
+    /// [`Erc721`] contract.
+    pub erc721: Erc721,
+    /// [`Trace`] contract for sequential ownership.
+    pub(crate) sequential_ownership: Trace<S160>,
+    /// [`BitMap`] contract for sequential burn of tokens.
+    pub(crate) sequential_burn: BitMap,
+    /// Used to offset the first token id in `next_consecutive_id` calculation.
+    pub(crate) first_consecutive_id: StorageU96,
+    /// Maximum size of a batch of consecutive tokens. This is designed to
+    /// limit stress on off-chain indexing services that have to record one
+    /// entry per token, and have protections against "unreasonably large"
+    /// batches of tokens.
+    pub(crate) max_batch_size: StorageU96,
+}
+
+impl Deref for Erc721Consecutive {
+    type Target = Erc721;
+
+    fn deref(&self) -> &Self::Target {
+        &self.erc721
+    }
+}
+
+impl DerefMut for Erc721Consecutive {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.erc721
+    }
 }
 
 /// NOTE: Implementation of [`TopLevelStorage`] to be able use `&mut self` when

--- a/contracts/src/token/erc721/extensions/enumerable.rs
+++ b/contracts/src/token/erc721/extensions/enumerable.rs
@@ -15,6 +15,7 @@ use alloy_primitives::{uint, Address, FixedBytes, U256};
 use openzeppelin_stylus_proc::interface_id;
 pub use sol::*;
 use stylus_sdk::{
+    call::MethodError,
     prelude::*,
     storage::{StorageMap, StorageU256, StorageVec},
     stylus_proc::{public, SolidityError},
@@ -58,6 +59,12 @@ pub enum Error {
 
     /// Indicates an error related to batch minting not allowed.
     EnumerableForbiddenBatchMint(ERC721EnumerableForbiddenBatchMint),
+}
+
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
 }
 
 /// State of an [`Erc721Enumerable`] contract.

--- a/contracts/src/token/erc721/extensions/metadata.rs
+++ b/contracts/src/token/erc721/extensions/metadata.rs
@@ -101,7 +101,7 @@ impl Erc721Metadata {
     ///
     /// # Errors
     ///
-    /// * [`Error::NonexistentToken`] - If the token does not exist.
+    /// * [`erc721::Error::NonexistentToken`] - If the token does not exist.
     ///
     /// # Examples
     ///

--- a/contracts/src/token/erc721/extensions/metadata.rs
+++ b/contracts/src/token/erc721/extensions/metadata.rs
@@ -11,7 +11,7 @@ use openzeppelin_stylus_proc::interface_id;
 use stylus_sdk::{prelude::*, storage::StorageString, stylus_proc::public};
 
 use crate::{
-    token::erc721::{Error, IErc721},
+    token::erc721::{self, IErc721},
     utils::{
         introspection::erc165::{Erc165, IErc165},
         Metadata,
@@ -114,8 +114,8 @@ impl Erc721Metadata {
     pub fn token_uri(
         &self,
         token_id: U256,
-        erc721: &impl IErc721<Error = Error>,
-    ) -> Result<String, Error> {
+        erc721: &impl IErc721<Error = erc721::Error>,
+    ) -> Result<String, erc721::Error> {
         erc721.owner_of(token_id)?;
 
         let base_uri = self.base_uri();

--- a/contracts/src/token/erc721/extensions/metadata.rs
+++ b/contracts/src/token/erc721/extensions/metadata.rs
@@ -107,8 +107,8 @@ impl Erc721Metadata {
     ///
     /// ```rust,ignore
     /// #[selector(name = "tokenURI")]
-    /// pub fn token_uri(&self, token_id: U256) -> Result<String, Vec<u8>> {
-    ///     Ok(self.metadata.token_uri(token_id, &self.erc721)?)
+    /// pub fn token_uri(&self, token_id: U256) -> Result<String, erc721::Error> {
+    ///     self.metadata.token_uri(token_id, &self.erc721)
     /// }
     /// ```
     pub fn token_uri(

--- a/contracts/src/token/erc721/extensions/mod.rs
+++ b/contracts/src/token/erc721/extensions/mod.rs
@@ -6,6 +6,7 @@ pub mod metadata;
 pub mod uri_storage;
 
 pub use burnable::IErc721Burnable;
+pub use consecutive::Erc721Consecutive;
 pub use enumerable::{Erc721Enumerable, IErc721Enumerable};
 pub use metadata::{Erc721Metadata, IErc721Metadata};
 pub use uri_storage::Erc721UriStorage;

--- a/contracts/src/token/erc721/extensions/uri_storage.rs
+++ b/contracts/src/token/erc721/extensions/uri_storage.rs
@@ -76,7 +76,7 @@ impl Erc721UriStorage {
     ///
     /// # Errors
     ///
-    /// * [`Error::NonexistentToken`] - If the token does not exist.
+    /// * [`erc721::Error::NonexistentToken`] - If the token does not exist.
     ///
     /// # Examples
     ///

--- a/contracts/src/token/erc721/extensions/uri_storage.rs
+++ b/contracts/src/token/erc721/extensions/uri_storage.rs
@@ -11,7 +11,7 @@ use stylus_sdk::{
     storage::{StorageMap, StorageString},
 };
 
-use crate::token::erc721::{extensions::Erc721Metadata, Error, IErc721};
+use crate::token::erc721::{self, extensions::Erc721Metadata, IErc721};
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod sol {
@@ -92,9 +92,9 @@ impl Erc721UriStorage {
     pub fn token_uri(
         &self,
         token_id: U256,
-        erc721: &impl IErc721<Error = Error>,
+        erc721: &impl IErc721<Error = erc721::Error>,
         metadata: &Erc721Metadata,
-    ) -> Result<String, Error> {
+    ) -> Result<String, erc721::Error> {
         erc721.owner_of(token_id)?;
 
         let token_uri = self.token_uris.getter(token_id).get_string();

--- a/contracts/src/token/erc721/extensions/uri_storage.rs
+++ b/contracts/src/token/erc721/extensions/uri_storage.rs
@@ -82,12 +82,12 @@ impl Erc721UriStorage {
     ///
     /// ```rust,ignore
     /// #[selector(name = "tokenURI")]
-    /// pub fn token_uri(&self, token_id: U256) -> Result<String, Vec<u8>> {
-    ///     Ok(self.uri_storage.token_uri(
+    /// pub fn token_uri(&self, token_id: U256) -> Result<String, erc721::Error> {
+    ///     self.uri_storage.token_uri(
     ///        token_id,
     ///        &self.erc721,
     ///        &self.metadata,
-    ///    )?)
+    ///     )
     /// }
     pub fn token_uri(
         &self,
@@ -123,7 +123,7 @@ mod tests {
     use stylus_sdk::prelude::*;
 
     use super::Erc721UriStorage;
-    use crate::token::erc721::{extensions::Erc721Metadata, Erc721};
+    use crate::token::erc721::{self, extensions::Erc721Metadata, Erc721};
 
     const TOKEN_ID: U256 = uint!(1_U256);
 
@@ -137,12 +137,8 @@ mod tests {
     #[public]
     impl Erc721MetadataExample {
         #[selector(name = "tokenURI")]
-        fn token_uri(&self, token_id: U256) -> Result<String, Vec<u8>> {
-            Ok(self.uri_storage.token_uri(
-                token_id,
-                &self.erc721,
-                &self.metadata,
-            )?)
+        fn token_uri(&self, token_id: U256) -> Result<String, erc721::Error> {
+            self.uri_storage.token_uri(token_id, &self.erc721, &self.metadata)
         }
 
         #[selector(name = "setTokenURI")]

--- a/contracts/src/utils/nonces.rs
+++ b/contracts/src/utils/nonces.rs
@@ -6,6 +6,7 @@ use alloc::{vec, vec::Vec};
 
 use alloy_primitives::{uint, Address, U256};
 use stylus_sdk::{
+    call::MethodError,
     prelude::*,
     storage::{StorageMap, StorageU256},
     stylus_proc::{public, SolidityError},
@@ -33,6 +34,12 @@ mod sol {
 pub enum Error {
     /// The nonce used for an `account` is not the expected current nonce.
     InvalidAccountNonce(InvalidAccountNonce),
+}
+
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
 }
 
 /// State of a [`Nonces`] Contract.

--- a/contracts/src/utils/pausable.rs
+++ b/contracts/src/utils/pausable.rs
@@ -18,6 +18,7 @@ use alloc::{vec, vec::Vec};
 
 pub use sol::*;
 use stylus_sdk::{
+    call::MethodError,
     evm, msg,
     prelude::*,
     storage::StorageBool,
@@ -62,6 +63,12 @@ pub enum Error {
     /// Indicates an error related to the operation that failed
     /// because the contract had been in `Unpaused` state.
     ExpectedPause(ExpectedPause),
+}
+
+impl MethodError for Error {
+    fn encode(self) -> alloc::vec::Vec<u8> {
+        self.into()
+    }
 }
 
 /// State of a [`Pausable`] Contract.

--- a/docs/modules/ROOT/pages/access-control.adoc
+++ b/docs/modules/ROOT/pages/access-control.adoc
@@ -23,7 +23,7 @@ enum Error {
 #[storage]
 struct OwnableExample {
     #[borrow]
-    pub ownable: Ownable,
+    ownable: Ownable,
 }
 
 #[public]
@@ -33,9 +33,7 @@ impl MyContract {
         // anyone can call this normal_thing()
     }
 
-    pub fn special_thing(
-        &mut self,
-    ) -> Result<(), Error> {
+    fn special_thing(&mut self) -> Result<(), Error> {
         self.ownable.only_owner()?;
 
         // only the owner can call special_thing()!
@@ -93,18 +91,18 @@ enum Error {
 #[storage]
 struct Example {
     #[borrow]
-    pub erc20: Erc20,
+    erc20: Erc20,
     #[borrow]
-    pub access: AccessControl,
+    access: AccessControl,
 }
 
-pub const MINTER_ROLE: [u8; 32] =
+const MINTER_ROLE: [u8; 32] =
     keccak_const::Keccak256::new().update(b"MINTER_ROLE").finalize();
 
 #[public]
 #[inherit(Erc20, AccessControl)]
 impl Example {
-    pub fn mint(&mut self, to: Address, amount: U256) -> Result<(), Error> {
+    fn mint(&mut self, to: Address, amount: U256) -> Result<(), Error> {
         self.access.only_role(MINTER_ROLE.into())?;
         self.erc20._mint(to, amount)?;
         Ok(())
@@ -135,27 +133,27 @@ enum Error {
 #[storage]
 struct Example {
     #[borrow]
-    pub erc20: Erc20,
+    erc20: Erc20,
     #[borrow]
-    pub access: AccessControl,
+    access: AccessControl,
 }
 
-pub const MINTER_ROLE: [u8; 32] =
+const MINTER_ROLE: [u8; 32] =
     keccak_const::Keccak256::new().update(b"MINTER_ROLE").finalize();
 
-pub const BURNER_ROLE: [u8; 32] =
+const BURNER_ROLE: [u8; 32] =
     keccak_const::Keccak256::new().update(b"BURNER_ROLE").finalize();
 
 #[public]
 #[inherit(Erc20, AccessControl)]
 impl Example {
-    pub fn mint(&mut self, to: Address, amount: U256) -> Result<(), Error> {
+    fn mint(&mut self, to: Address, amount: U256) -> Result<(), Error> {
         self.access.only_role(MINTER_ROLE.into())?;
         self.erc20._mint(to, amount)?;
         Ok(())
     }
 
-    pub fn burn(&mut self, from: Address, amount: U256) -> Result<(), Error> {
+    fn burn(&mut self, from: Address, amount: U256) -> Result<(), Error> {
         self.access.only_role(BURNER_ROLE.into())?;
         self.erc20._burn(from, amount)?;
         Ok(())

--- a/docs/modules/ROOT/pages/access-control.adoc
+++ b/docs/modules/ROOT/pages/access-control.adoc
@@ -11,7 +11,13 @@ OpenZeppelin Contracts for Stylus provides https://docs.rs/openzeppelin-stylus/0
 
 [source,rust]
 ----
-use openzeppelin_stylus::access::ownable::Ownable;
+use openzeppelin_stylus::access::ownable::{self, Ownable};
+
+#[derive(SolidityError, Debug)]
+enum Error {
+    Ownable(ownable::Error),
+    // other custom errors...
+}
 
 #[entrypoint]
 #[storage]
@@ -29,7 +35,7 @@ impl MyContract {
 
     pub fn special_thing(
         &mut self,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         self.ownable.only_owner()?;
 
         // only the owner can call special_thing()!
@@ -72,6 +78,17 @@ Here's a simple example of using `AccessControl` in an xref:erc20.adoc[ERC-20 to
 
 [source,rust]
 ----
+use openzeppelin_stylus::{
+    access::control::{self, AccessControl, IAccessControl},
+    token::erc20::{self, Erc20, IErc20},
+};
+
+#[derive(SolidityError, Debug)]
+enum Error {
+    AccessControl(control::Error),
+    Erc20(erc20::Error),
+}
+
 #[entrypoint]
 #[storage]
 struct Example {
@@ -87,10 +104,8 @@ pub const MINTER_ROLE: [u8; 32] =
 #[public]
 #[inherit(Erc20, AccessControl)]
 impl Example {
-    pub fn mint(&mut self, to: Address, amount: U256) -> Result<(), Vec<u8>> {
-        if self.access.has_role(MINTER_ROLE.into(), msg::sender()) {
-            return Err(Vec::new());
-        }
+    pub fn mint(&mut self, to: Address, amount: U256) -> Result<(), Error> {
+        self.access.only_role(MINTER_ROLE.into())?;
         self.erc20._mint(to, amount)?;
         Ok(())
     }
@@ -105,6 +120,17 @@ Let's augment our ERC-20 token example by also defining a 'burner' role, which l
 
 [source,rust]
 ----
+use openzeppelin_stylus::{
+    access::control::{self, AccessControl, IAccessControl},
+    token::erc20::{self, Erc20, IErc20},
+};
+
+#[derive(SolidityError, Debug)]
+enum Error {
+    AccessControl(control::Error),
+    Erc20(erc20::Error),
+}
+
 #[entrypoint]
 #[storage]
 struct Example {
@@ -123,13 +149,13 @@ pub const BURNER_ROLE: [u8; 32] =
 #[public]
 #[inherit(Erc20, AccessControl)]
 impl Example {
-    pub fn mint(&mut self, to: Address, amount: U256) -> Result<(), Vec<u8>> {
+    pub fn mint(&mut self, to: Address, amount: U256) -> Result<(), Error> {
         self.access.only_role(MINTER_ROLE.into())?;
         self.erc20._mint(to, amount)?;
         Ok(())
     }
 
-    pub fn burn(&mut self, from: Address, amount: U256) -> Result<(), Vec<u8>> {
+    pub fn burn(&mut self, from: Address, amount: U256) -> Result<(), Error> {
         self.access.only_role(BURNER_ROLE.into())?;
         self.erc20._burn(from, amount)?;
         Ok(())

--- a/docs/modules/ROOT/pages/crypto.adoc
+++ b/docs/modules/ROOT/pages/crypto.adoc
@@ -16,7 +16,7 @@ https://docs.rs/openzeppelin-crypto/0.2.0-alpha.4/openzeppelin_crypto/merkle/str
 
 [source,rust]
 ----
-pub fn verify(&self, proof: Vec<B256>, root: B256, leaf: B256) -> bool {
+fn verify(&self, proof: Vec<B256>, root: B256, leaf: B256) -> bool {
     let proof: Vec<[u8; 32]> = proof.into_iter().map(|m| *m).collect();
     Verifier::<KeccakBuilder>::verify(&proof, *root, *leaf)
 }

--- a/docs/modules/ROOT/pages/deploy.adoc
+++ b/docs/modules/ROOT/pages/deploy.adoc
@@ -33,16 +33,16 @@ For a contract like this:
 #[entrypoint]
 #[storage]
 struct Counter {
-    pub number: StorageU256,
+    number: StorageU256,
 }
 
 #[public]
 impl Counter {
-    pub fn number(&self) -> U256 {
+    fn number(&self) -> U256 {
         self.number.get()
     }
 
-    pub fn increment(&mut self) {
+    fn increment(&mut self) {
         let number = self.number.get();
         self.set_number(number + U256::from(1));
     }

--- a/docs/modules/ROOT/pages/erc1155-burnable.adoc
+++ b/docs/modules/ROOT/pages/erc1155-burnable.adoc
@@ -11,7 +11,7 @@ In order to make https://docs.rs/openzeppelin-stylus/0.2.0-alpha.4/openzeppelin_
 [source,rust]
 ----
 use openzeppelin_stylus::{
-    token::erc1155::{extensions::IErc1155Burnable, Erc1155},
+    token::erc1155::{extensions::IErc1155Burnable, Erc1155, Error},
     utils::introspection::erc165::IErc165,
 };
 
@@ -19,7 +19,7 @@ use openzeppelin_stylus::{
 #[storage]
 struct Erc1155Example {
     #[borrow]
-    pub erc1155: Erc1155,
+    erc1155: Erc1155,
 }
 
 #[public]
@@ -30,7 +30,7 @@ impl Erc1155Example {
         account: Address,
         token_id: U256,
         value: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // ...
         self.erc1155.burn(account, token_id, value)?;
         // ...
@@ -42,7 +42,7 @@ impl Erc1155Example {
         account: Address,
         token_ids: Vec<U256>,
         values: Vec<U256>,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // ...
         self.erc1155.burn_batch(account, token_ids, values)?;
         // ...

--- a/docs/modules/ROOT/pages/erc1155-burnable.adoc
+++ b/docs/modules/ROOT/pages/erc1155-burnable.adoc
@@ -11,7 +11,7 @@ In order to make https://docs.rs/openzeppelin-stylus/0.2.0-alpha.4/openzeppelin_
 [source,rust]
 ----
 use openzeppelin_stylus::{
-    token::erc1155::{extensions::IErc1155Burnable, Erc1155, Error},
+    token::erc1155::{self, extensions::IErc1155Burnable, Erc1155},
     utils::introspection::erc165::IErc165,
 };
 
@@ -30,7 +30,7 @@ impl Erc1155Example {
         account: Address,
         token_id: U256,
         value: U256,
-    ) -> Result<(), Error> {
+    ) -> Result<(), erc1155::Error> {
         // ...
         self.erc1155.burn(account, token_id, value)?;
         // ...
@@ -42,7 +42,7 @@ impl Erc1155Example {
         account: Address,
         token_ids: Vec<U256>,
         values: Vec<U256>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), erc1155::Error> {
         // ...
         self.erc1155.burn_batch(account, token_ids, values)?;
         // ...

--- a/docs/modules/ROOT/pages/erc1155-metadata-uri.adoc
+++ b/docs/modules/ROOT/pages/erc1155-metadata-uri.adoc
@@ -21,9 +21,9 @@ use openzeppelin_stylus::{
 #[storage]
 struct Erc1155Example {
     #[borrow]
-    pub erc1155: Erc1155,
+    erc1155: Erc1155,
     #[borrow]
-    pub metadata_uri: Erc1155MetadataUri,
+    metadata_uri: Erc1155MetadataUri,
 }
 
 #[public]

--- a/docs/modules/ROOT/pages/erc1155-pausable.adoc
+++ b/docs/modules/ROOT/pages/erc1155-pausable.adoc
@@ -12,17 +12,23 @@ In order to make your xref:erc1155.adoc[ERC-1155] token `pausable`, you need to 
 [source,rust]
 ----
 use openzeppelin_stylus::{
-    token::erc1155::{Erc1155, IErc1155},
-    utils::{introspection::erc165::IErc165, Pausable},
+    token::erc1155::{self, extensions::IErc1155Burnable, Erc1155, IErc1155},
+    utils::{introspection::erc165::IErc165, pausable, Pausable},
 };
+
+#[derive(SolidityError, Debug)]
+enum Error {
+    Erc1155(erc1155::Error),
+    Pausable(pausable::Error),
+}
 
 #[entrypoint]
 #[storage]
 struct Erc1155Example {
     #[borrow]
-    pub erc1155: Erc1155,
+    erc1155: Erc1155,
     #[borrow]
-    pub pausable: Pausable,
+    pausable: Pausable,
 }
 
 #[public]
@@ -34,7 +40,7 @@ impl Erc1155Example {
         token_id: U256,
         amount: U256,
         data: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
@@ -48,7 +54,7 @@ impl Erc1155Example {
         token_ids: Vec<U256>,
         amounts: Vec<U256>,
         data: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
@@ -61,7 +67,7 @@ impl Erc1155Example {
         account: Address,
         token_id: U256,
         value: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
@@ -74,7 +80,7 @@ impl Erc1155Example {
         account: Address,
         token_ids: Vec<U256>,
         values: Vec<U256>,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
@@ -89,7 +95,7 @@ impl Erc1155Example {
         id: U256,
         value: U256,
         data: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
@@ -104,7 +110,7 @@ impl Erc1155Example {
         ids: Vec<U256>,
         values: Vec<U256>,
         data: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
@@ -114,19 +120,6 @@ impl Erc1155Example {
 
     fn supports_interface(interface_id: FixedBytes<4>) -> bool {
         Erc1155::supports_interface(interface_id)
-    }
-}
-----
-
-Additionally, you need to ensure proper initialization during xref:deploy.adoc[contract deployment]. Make sure to include the following code in your Solidity Constructor:
-
-[source,solidity]
-----
-contract Erc1155Example {
-    bool private _paused;
-
-    constructor() {
-        _paused = false;
     }
 }
 ----

--- a/docs/modules/ROOT/pages/erc1155-supply.adoc
+++ b/docs/modules/ROOT/pages/erc1155-supply.adoc
@@ -25,7 +25,7 @@ use openzeppelin_stylus::{
 #[storage]
 struct Erc1155Example {
     #[borrow]
-    pub erc1155_supply: Erc1155Supply,
+    erc1155_supply: Erc1155Supply,
 }
 
 #[public]

--- a/docs/modules/ROOT/pages/erc1155-uri-storage.adoc
+++ b/docs/modules/ROOT/pages/erc1155-uri-storage.adoc
@@ -25,9 +25,9 @@ use openzeppelin_stylus::{
 #[storage]
 struct Erc1155MetadataUriExample {
     #[borrow]
-    pub erc1155: Erc1155,
-    pub metadata_uri: Erc1155MetadataUri,
-    pub uri_storage: Erc1155UriStorage,
+    erc1155: Erc1155,
+    metadata_uri: Erc1155MetadataUri,
+    uri_storage: Erc1155UriStorage,
 }
 
 #[public]

--- a/docs/modules/ROOT/pages/erc20-burnable.adoc
+++ b/docs/modules/ROOT/pages/erc20-burnable.adoc
@@ -17,18 +17,18 @@ use openzeppelin_stylus::token::erc20::{
 #[storage]
 struct Erc20Example {
     #[borrow]
-    pub erc20: Erc20,
+    erc20: Erc20,
 }
 
 #[public]
 #[inherit(Erc20)]
 impl Erc20Example {
-    pub fn burn(&mut self, value: U256) -> Result<(), erc20::Error> {
+    fn burn(&mut self, value: U256) -> Result<(), erc20::Error> {
         // ...
         self.erc20.burn(value)
     }
 
-    pub fn burn_from(
+    fn burn_from(
         &mut self,
         account: Address,
         value: U256,

--- a/docs/modules/ROOT/pages/erc20-burnable.adoc
+++ b/docs/modules/ROOT/pages/erc20-burnable.adoc
@@ -10,7 +10,7 @@ In order to make https://docs.rs/openzeppelin-stylus/0.2.0-alpha.4/openzeppelin_
 [source,rust]
 ----
 use openzeppelin_stylus::token::erc20::{
-    extensions::IErc20Burnable, Erc20, Error, IErc20,
+    self, extensions::IErc20Burnable, Erc20, IErc20,
 };
 
 #[entrypoint]
@@ -23,7 +23,7 @@ struct Erc20Example {
 #[public]
 #[inherit(Erc20)]
 impl Erc20Example {
-    pub fn burn(&mut self, value: U256) -> Result<(), Error> {
+    pub fn burn(&mut self, value: U256) -> Result<(), erc20::Error> {
         // ...
         self.erc20.burn(value)
     }
@@ -32,7 +32,7 @@ impl Erc20Example {
         &mut self,
         account: Address,
         value: U256,
-    ) -> Result<(), Error> {
+    ) -> Result<(), erc20::Error> {
         // ...
         self.erc20.burn_from(account, value)
     }

--- a/docs/modules/ROOT/pages/erc20-burnable.adoc
+++ b/docs/modules/ROOT/pages/erc20-burnable.adoc
@@ -9,11 +9,8 @@ In order to make https://docs.rs/openzeppelin-stylus/0.2.0-alpha.4/openzeppelin_
 
 [source,rust]
 ----
-use openzeppelin_stylus::{
-    token::erc20::{
-        extensions::IErc20Burnable,
-        Erc20, IErc20,
-    },
+use openzeppelin_stylus::token::erc20::{
+    extensions::IErc20Burnable, Erc20, Error, IErc20,
 };
 
 #[entrypoint]
@@ -26,18 +23,18 @@ struct Erc20Example {
 #[public]
 #[inherit(Erc20)]
 impl Erc20Example {
-    pub fn burn(&mut self, value: U256) -> Result<(), Vec<u8>> {
+    pub fn burn(&mut self, value: U256) -> Result<(), Error> {
         // ...
-        self.erc20.burn(value).map_err(|e| e.into())
+        self.erc20.burn(value)
     }
 
     pub fn burn_from(
         &mut self,
         account: Address,
         value: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // ...
-        self.erc20.burn_from(account, value).map_err(|e| e.into())
+        self.erc20.burn_from(account, value)
     }
 }
 ----

--- a/docs/modules/ROOT/pages/erc20-capped.adoc
+++ b/docs/modules/ROOT/pages/erc20-capped.adoc
@@ -9,20 +9,25 @@ In order to make https://docs.rs/openzeppelin-stylus/0.2.0-alpha.4/openzeppelin_
 
 [source,rust]
 ----
-use openzeppelin_stylus::{
-    token::erc20::{
-        extensions::{capped, Capped},
-        Erc20, IErc20,
-    }
+use openzeppelin_stylus::token::erc20::{
+    self,
+    extensions::{capped, Capped},
+    Erc20, IErc20,
 };
+
+#[derive(SolidityError, Debug)]
+enum Error {
+    Capped(capped::Error),
+    Erc20(erc20::Error),
+}
 
 #[entrypoint]
 #[storage]
 struct Erc20Example {
     #[borrow]
-    pub erc20: Erc20,
+    erc20: Erc20,
     #[borrow]
-    pub capped: Capped,
+    capped: Capped,
 }
 
 #[public]
@@ -33,12 +38,11 @@ impl Erc20Example {
     // Make sure to handle `Capped` properly. You should not call
     // [`Erc20::_update`] to mint tokens -- it will the break `Capped`
     // mechanism.
-    pub fn mint(
+    fn mint(
         &mut self,
         account: Address,
         value: U256,
-    ) -> Result<(), Vec<u8>> {
-        self.pausable.when_not_paused()?;
+    ) -> Result<(), Error> {
         let max_supply = self.capped.cap();
 
         // Overflow check required.

--- a/docs/modules/ROOT/pages/erc20-flash-mint.adoc
+++ b/docs/modules/ROOT/pages/erc20-flash-mint.adoc
@@ -10,9 +10,16 @@ In order to make https://docs.rs/openzeppelin-stylus/0.2.0-alpha.4/openzeppelin_
 [source,rust]
 ----
 use openzeppelin_stylus::token::erc20::{
-    extensions::{Erc20FlashMint, IErc3156FlashLender},
+    self,
+    extensions::{flash_mint, Erc20FlashMint, IErc3156FlashLender},
     Erc20,
 };
+
+#[derive(SolidityError, Debug)]
+enum Error {
+    Erc20(erc20::Error),
+    Erc20FlashMint(flash_mint::Error),
+}
 
 #[entrypoint]
 #[storage]
@@ -30,7 +37,7 @@ impl Erc20FlashMintExample {
         self.flash_mint.max_flash_loan(token, &self.erc20)
     }
 
-    fn flash_fee(&self, token: Address, value: U256) -> Result<U256, Vec<u8>> {
+    fn flash_fee(&self, token: Address, value: U256) -> Result<U256, Error> {
         Ok(self.flash_mint.flash_fee(token, value)?)
     }
 
@@ -40,7 +47,7 @@ impl Erc20FlashMintExample {
         token: Address,
         value: U256,
         data: Bytes,
-    ) -> Result<bool, Vec<u8>> {
+    ) -> Result<bool, Error> {
         Ok(self.flash_mint.flash_loan(
             receiver,
             token,

--- a/docs/modules/ROOT/pages/erc20-metadata.adoc
+++ b/docs/modules/ROOT/pages/erc20-metadata.adoc
@@ -20,9 +20,9 @@ use openzeppelin_stylus::{
 #[storage]
 struct Erc20Example {
     #[borrow]
-    pub erc20: Erc20,
+    erc20: Erc20,
     #[borrow]
-    pub metadata: Erc20Metadata,
+    metadata: Erc20Metadata,
 }
 
 #[public]

--- a/docs/modules/ROOT/pages/erc20-pausable.adoc
+++ b/docs/modules/ROOT/pages/erc20-pausable.adoc
@@ -12,45 +12,47 @@ In order to make your ERC20 token `pausable`, you need to use the https://docs.r
 [source,rust]
 ----
 use openzeppelin_stylus::{
-    token::erc20::Erc20,
-    utils::Pausable,
+    token::erc20::{self, extensions::IErc20Burnable, Erc20, IErc20},
+    utils::{pausable, Pausable},
 };
+
+#[derive(SolidityError, Debug)]
+enum Error {
+    Erc20(erc20::Error),
+    Pausable(pausable::Error),
+}
 
 #[entrypoint]
 #[storage]
 struct Erc20Example {
     #[borrow]
-    pub erc20: Erc20,
+    erc20: Erc20,
     #[borrow]
-    pub pausable: Pausable,
+    pausable: Pausable,
 }
 
 #[public]
 #[inherit(Erc20, Pausable)]
 impl Erc20Example {
-    pub fn burn(&mut self, value: U256) -> Result<(), Vec<u8>> {
+    fn burn(&mut self, value: U256) -> Result<(), Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
         self.erc20.burn(value).map_err(|e| e.into())
     }
 
-    pub fn burn_from(
+    fn burn_from(
         &mut self,
         account: Address,
         value: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
         self.erc20.burn_from(account, value).map_err(|e| e.into())
     }
 
-    pub fn mint(
-        &mut self,
-        account: Address,
-        value: U256,
-    ) -> Result<(), Vec<u8>> {
+    fn mint(&mut self, account: Address, value: U256) -> Result<(), Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
@@ -58,42 +60,23 @@ impl Erc20Example {
         Ok(())
     }
 
-
-    pub fn transfer(
-        &mut self,
-        to: Address,
-        value: U256,
-    ) -> Result<bool, Vec<u8>> {
+    fn transfer(&mut self, to: Address, value: U256) -> Result<bool, Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
         self.erc20.transfer(to, value).map_err(|e| e.into())
     }
 
-    pub fn transfer_from(
+    fn transfer_from(
         &mut self,
         from: Address,
         to: Address,
         value: U256,
-    ) -> Result<bool, Vec<u8>> {
+    ) -> Result<bool, Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
         self.erc20.transfer_from(from, to, value).map_err(|e| e.into())
-    }
-
-}
-----
-
-Additionally, you need to ensure proper initialization during xref:deploy.adoc[contract deployment]. Make sure to include the following code in your Solidity Constructor:
-
-[source,solidity]
-----
-contract Erc20Example {
-    bool private _paused;
-
-    constructor() {
-        _paused = false;
     }
 }
 ----

--- a/docs/modules/ROOT/pages/erc20-permit.adoc
+++ b/docs/modules/ROOT/pages/erc20-permit.adoc
@@ -28,7 +28,7 @@ struct Erc20PermitExample {
 }
 
 #[storage]
-struct Eip712 {}
+struct Eip712;
 
 // Define `NAME` and `VERSION` for your contract.
 impl IEip712 for Eip712 {

--- a/docs/modules/ROOT/pages/erc20-permit.adoc
+++ b/docs/modules/ROOT/pages/erc20-permit.adoc
@@ -12,7 +12,10 @@ In order to have https://docs.rs/openzeppelin-stylus/0.2.0-alpha.4/openzeppelin_
 [source,rust]
 ----
 use openzeppelin_stylus::{
-    token::erc20::{extensions::Erc20Permit, Erc20},
+    token::erc20::{
+        extensions::{permit, Erc20Permit},
+        Erc20,
+    },
     utils::{cryptography::eip712::IEip712, nonces::Nonces},
 };
 
@@ -20,11 +23,11 @@ use openzeppelin_stylus::{
 #[storage]
 struct Erc20PermitExample {
     #[borrow]
-    pub erc20: Erc20,
+    erc20: Erc20,
     #[borrow]
-    pub nonces: Nonces,
+    nonces: Nonces,
     #[borrow]
-    pub erc20_permit: Erc20Permit<Eip712>,
+    erc20_permit: Erc20Permit<Eip712>,
 }
 
 #[storage]
@@ -40,9 +43,12 @@ impl IEip712 for Eip712 {
 #[inherit(Erc20, Nonces, Erc20Permit<Eip712>)]
 impl Erc20PermitExample {
     // Add token minting feature.
-    fn mint(&mut self, account: Address, value: U256) -> Result<(), Vec<u8>> {
-        self.erc20._mint(account, value)?;
-        Ok(())
+    fn mint(
+        &mut self,
+        account: Address,
+        value: U256,
+    ) -> Result<(), permit::Error> {
+        Ok(self.erc20._mint(account, value)?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -55,8 +61,8 @@ impl Erc20PermitExample {
         v: u8,
         r: B256,
         s: B256,
-    ) -> Result<(), Vec<u8>> {
-        Ok(self.erc20_permit.permit(
+    ) -> Result<(), permit::Error> {
+        self.erc20_permit.permit(
             owner,
             spender,
             value,
@@ -66,7 +72,7 @@ impl Erc20PermitExample {
             s,
             &mut self.erc20,
             &mut self.nonces,
-        )?)
+        )
     }
 }
 ----

--- a/docs/modules/ROOT/pages/erc20.adoc
+++ b/docs/modules/ROOT/pages/erc20.adoc
@@ -19,9 +19,9 @@ Here's what our GLD token might look like.
 #[storage]
 struct GLDToken {
     #[borrow]
-    pub erc20: Erc20,
+    erc20: Erc20,
     #[borrow]
-    pub metadata: Erc20Metadata,
+    metadata: Erc20Metadata,
 }
 
 #[public]
@@ -57,7 +57,7 @@ To use a different value, you will need to override the `decimals()` function in
 
 [source,rust]
 ----
-pub fn decimals(&self) -> u8 {
+fn decimals(&self) -> u8 {
     16
 }
 ----

--- a/docs/modules/ROOT/pages/erc4626.adoc
+++ b/docs/modules/ROOT/pages/erc4626.adoc
@@ -17,9 +17,16 @@ In order to make https://docs.rs/openzeppelin-stylus/0.2.0-alpha.4/openzeppelin_
 [source,rust]
 ----
 use openzeppelin_stylus::token::erc20::{
-    extensions::{Erc20Metadata, Erc4626, IErc4626},
+    self,
+    extensions::{erc4626, Erc20Metadata, Erc4626, IErc4626},
     Erc20,
 };
+
+#[derive(SolidityError, Debug)]
+enum Error {
+    Erc4626(erc4626::Error),
+    Erc20(erc20::Error),
+}
 
 #[entrypoint]
 #[storage]
@@ -43,15 +50,15 @@ impl Erc4626Example {
         self.erc4626.asset()
     }
 
-    fn total_assets(&mut self) -> Result<U256, Vec<u8>> {
+    fn total_assets(&mut self) -> Result<U256, Error> {
         Ok(self.erc4626.total_assets()?)
     }
 
-    fn convert_to_shares(&mut self, assets: U256) -> Result<U256, Vec<u8>> {
+    fn convert_to_shares(&mut self, assets: U256) -> Result<U256, Error> {
         Ok(self.erc4626.convert_to_shares(assets, &self.erc20)?)
     }
 
-    fn convert_to_assets(&mut self, shares: U256) -> Result<U256, Vec<u8>> {
+    fn convert_to_assets(&mut self, shares: U256) -> Result<U256, Error> {
         Ok(self.erc4626.convert_to_assets(shares, &self.erc20)?)
     }
 
@@ -59,7 +66,7 @@ impl Erc4626Example {
         self.erc4626.max_deposit(receiver)
     }
 
-    fn preview_deposit(&mut self, assets: U256) -> Result<U256, Vec<u8>> {
+    fn preview_deposit(&mut self, assets: U256) -> Result<U256, Error> {
         Ok(self.erc4626.preview_deposit(assets, &self.erc20)?)
     }
 
@@ -67,7 +74,7 @@ impl Erc4626Example {
         &mut self,
         assets: U256,
         receiver: Address,
-    ) -> Result<U256, Vec<u8>> {
+    ) -> Result<U256, Error> {
         Ok(self.erc4626.deposit(assets, receiver, &mut self.erc20)?)
     }
 
@@ -75,23 +82,19 @@ impl Erc4626Example {
         self.erc4626.max_mint(receiver)
     }
 
-    fn preview_mint(&mut self, shares: U256) -> Result<U256, Vec<u8>> {
+    fn preview_mint(&mut self, shares: U256) -> Result<U256, Error> {
         Ok(self.erc4626.preview_mint(shares, &self.erc20)?)
     }
 
-    fn mint(
-        &mut self,
-        shares: U256,
-        receiver: Address,
-    ) -> Result<U256, Vec<u8>> {
+    fn mint(&mut self, shares: U256, receiver: Address) -> Result<U256, Error> {
         Ok(self.erc4626.mint(shares, receiver, &mut self.erc20)?)
     }
 
-    fn max_withdraw(&mut self, owner: Address) -> Result<U256, Vec<u8>> {
+    fn max_withdraw(&mut self, owner: Address) -> Result<U256, Error> {
         Ok(self.erc4626.max_withdraw(owner, &self.erc20)?)
     }
 
-    fn preview_withdraw(&mut self, assets: U256) -> Result<U256, Vec<u8>> {
+    fn preview_withdraw(&mut self, assets: U256) -> Result<U256, Error> {
         Ok(self.erc4626.preview_withdraw(assets, &self.erc20)?)
     }
 
@@ -100,7 +103,7 @@ impl Erc4626Example {
         assets: U256,
         receiver: Address,
         owner: Address,
-    ) -> Result<U256, Vec<u8>> {
+    ) -> Result<U256, Error> {
         Ok(self.erc4626.withdraw(assets, receiver, owner, &mut self.erc20)?)
     }
 
@@ -108,7 +111,7 @@ impl Erc4626Example {
         self.erc4626.max_redeem(owner, &self.erc20)
     }
 
-    fn preview_redeem(&mut self, shares: U256) -> Result<U256, Vec<u8>> {
+    fn preview_redeem(&mut self, shares: U256) -> Result<U256, Error> {
         Ok(self.erc4626.preview_redeem(shares, &self.erc20)?)
     }
 
@@ -117,7 +120,7 @@ impl Erc4626Example {
         shares: U256,
         receiver: Address,
         owner: Address,
-    ) -> Result<U256, Vec<u8>> {
+    ) -> Result<U256, Error> {
         Ok(self.erc4626.redeem(shares, receiver, owner, &mut self.erc20)?)
     }
 }

--- a/docs/modules/ROOT/pages/erc721-burnable.adoc
+++ b/docs/modules/ROOT/pages/erc721-burnable.adoc
@@ -9,26 +9,23 @@ In order to make https://docs.rs/openzeppelin-stylus/0.2.0-alpha.4/openzeppelin_
 
 [source,rust]
 ----
-use openzeppelin_stylus::{
-    token::erc721::{
-        extensions::IErc721Burnable,
-        Erc721, IErc721,
-    },
+use openzeppelin_stylus::token::erc721::{
+    extensions::IErc721Burnable, Erc721, Error, IErc721,
 };
 
 #[entrypoint]
 #[storage]
 struct Erc721Example {
     #[borrow]
-    pub erc721: Erc721,
+    erc721: Erc721,
 }
 
 #[public]
 #[inherit(Erc721)]
 impl Erc721Example {
-    pub fn burn(&mut self, token_id: U256) -> Result<(), Vec<u8>> {
+    fn burn(&mut self, token_id: U256) -> Result<(), Error> {
         // ...
-        self.erc721.burn(token_id).map_err(|e| e.into())
+        self.erc721.burn(token_id)
     }
 }
 ----

--- a/docs/modules/ROOT/pages/erc721-burnable.adoc
+++ b/docs/modules/ROOT/pages/erc721-burnable.adoc
@@ -10,7 +10,7 @@ In order to make https://docs.rs/openzeppelin-stylus/0.2.0-alpha.4/openzeppelin_
 [source,rust]
 ----
 use openzeppelin_stylus::token::erc721::{
-    extensions::IErc721Burnable, Erc721, Error, IErc721,
+    self, extensions::IErc721Burnable, Erc721, IErc721,
 };
 
 #[entrypoint]
@@ -23,7 +23,7 @@ struct Erc721Example {
 #[public]
 #[inherit(Erc721)]
 impl Erc721Example {
-    fn burn(&mut self, token_id: U256) -> Result<(), Error> {
+    fn burn(&mut self, token_id: U256) -> Result<(), erc721::Error> {
         // ...
         self.erc721.burn(token_id)
     }

--- a/docs/modules/ROOT/pages/erc721-consecutive.adoc
+++ b/docs/modules/ROOT/pages/erc721-consecutive.adoc
@@ -11,7 +11,7 @@ In order to make https://docs.rs/openzeppelin-stylus/0.2.0-alpha.4/openzeppelin_
 ----
 use openzeppelin_stylus::{
     token::erc721::{
-        extensions::consecutive::{Erc721Consecutive, Error},
+        extensions::consecutive::{self, Erc721Consecutive},
         Erc721,
     },
     utils::introspection::erc165::IErc165,
@@ -27,11 +27,15 @@ struct Erc721ConsecutiveExample {
 #[public]
 #[inherit(Erc721Consecutive)]
 impl Erc721ConsecutiveExample {
-    fn burn(&mut self, token_id: U256) -> Result<(), Error> {
+    fn burn(&mut self, token_id: U256) -> Result<(), consecutive::Error> {
         self.erc721_consecutive._burn(token_id)
     }
 
-    fn mint(&mut self, to: Address, token_id: U256) -> Result<(), Error> {
+    fn mint(
+        &mut self,
+        to: Address,
+        token_id: U256,
+    ) -> Result<(), consecutive::Error> {
         self.erc721_consecutive._mint(to, token_id)
     }
 

--- a/docs/modules/ROOT/pages/erc721-consecutive.adoc
+++ b/docs/modules/ROOT/pages/erc721-consecutive.adoc
@@ -11,7 +11,7 @@ In order to make https://docs.rs/openzeppelin-stylus/0.2.0-alpha.4/openzeppelin_
 ----
 use openzeppelin_stylus::{
     token::erc721::{
-        extensions::consecutive::{self, Erc721Consecutive},
+        extensions::{consecutive, Erc721Consecutive},
         Erc721,
     },
     utils::introspection::erc165::IErc165,

--- a/docs/modules/ROOT/pages/erc721-enumerable.adoc
+++ b/docs/modules/ROOT/pages/erc721-enumerable.adoc
@@ -12,25 +12,32 @@ you need to create a specified contract as follows:
 ----
 use openzeppelin_stylus::{
     token::erc721::{
-        extensions::{Erc721Enumerable, IErc721Burnable},
+        self,
+        extensions::{enumerable, Erc721Enumerable, IErc721Burnable},
         Erc721, IErc721,
     },
     utils::introspection::erc165::IErc165,
 };
 
+#[derive(SolidityError, Debug)]
+enum Error {
+    Enumerable(enumerable::Error),
+    Erc721(erc721::Error),
+}
+
 #[entrypoint]
 #[storage]
 struct Erc721Example {
     #[borrow]
-    pub erc721: Erc721,
+    erc721: Erc721,
     #[borrow]
-    pub enumerable: Erc721Enumerable,
+    enumerable: Erc721Enumerable,
 }
 
 #[public]
 #[inherit(Erc721, Erc721Enumerable)]
 impl Erc721Example {
-    pub fn burn(&mut self, token_id: U256) -> Result<(), Vec<u8>> {
+    fn burn(&mut self, token_id: U256) -> Result<(), Error> {
         // Retrieve the owner.
         let owner = self.erc721.owner_of(token_id)?;
 
@@ -47,7 +54,7 @@ impl Erc721Example {
         Ok(())
     }
 
-    pub fn mint(&mut self, to: Address, token_id: U256) -> Result<(), Vec<u8>> {
+    fn mint(&mut self, to: Address, token_id: U256) -> Result<(), Error> {
         self.erc721._mint(to, token_id)?;
 
         // Update the extension's state.
@@ -61,12 +68,12 @@ impl Erc721Example {
         Ok(())
     }
 
-    pub fn safe_transfer_from(
+    fn safe_transfer_from(
         &mut self,
         from: Address,
         to: Address,
         token_id: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // Retrieve the previous owner.
         let previous_owner = self.erc721.owner_of(token_id)?;
 
@@ -88,13 +95,13 @@ impl Erc721Example {
     }
 
     #[selector(name = "safeTransferFrom")]
-    pub fn safe_transfer_from_with_data(
+    fn safe_transfer_from_with_data(
         &mut self,
         from: Address,
         to: Address,
         token_id: U256,
         data: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // Retrieve the previous owner.
         let previous_owner = self.erc721.owner_of(token_id)?;
 
@@ -115,12 +122,12 @@ impl Erc721Example {
         Ok(())
     }
 
-    pub fn transfer_from(
+    fn transfer_from(
         &mut self,
         from: Address,
         to: Address,
         token_id: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // Retrieve the previous owner.
         let previous_owner = self.erc721.owner_of(token_id)?;
 
@@ -141,7 +148,7 @@ impl Erc721Example {
         Ok(())
     }
 
-    pub fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+    fn supports_interface(interface_id: FixedBytes<4>) -> bool {
         Erc721::supports_interface(interface_id)
             || Erc721Enumerable::supports_interface(interface_id)
     }

--- a/docs/modules/ROOT/pages/erc721-metadata.adoc
+++ b/docs/modules/ROOT/pages/erc721-metadata.adoc
@@ -9,20 +9,17 @@ In order to make https://docs.rs/openzeppelin-stylus/0.2.0-alpha.4/openzeppelin_
 
 [source,rust]
 ----
-use openzeppelin_stylus::{
-    token::erc721::{
-        extensions::Erc721Metadata,
-        Erc721,
-    },
+use openzeppelin_stylus::token::erc721::{
+    extensions::Erc721Metadata, Erc721, Error,
 };
 
 #[entrypoint]
 #[storage]
 struct Erc721Example {
     #[borrow]
-    pub erc721: Erc721,
+    erc721: Erc721,
     #[borrow]
-    pub metadata: Metadata,
+    metadata: Erc721Metadata,
 }
 
 #[public]
@@ -31,8 +28,8 @@ impl Erc721Example {
     // ...
 
     #[selector(name = "tokenURI")]
-    pub fn token_uri(&self, token_id: U256) -> Result<String, Vec<u8>> {
-        Ok(self.metadata.token_uri(token_id, &self.erc721)?)
+    fn token_uri(&self, token_id: U256) -> Result<String, Error> {
+        self.metadata.token_uri(token_id, &self.erc721)
     }
 }
 ----

--- a/docs/modules/ROOT/pages/erc721-metadata.adoc
+++ b/docs/modules/ROOT/pages/erc721-metadata.adoc
@@ -10,7 +10,7 @@ In order to make https://docs.rs/openzeppelin-stylus/0.2.0-alpha.4/openzeppelin_
 [source,rust]
 ----
 use openzeppelin_stylus::token::erc721::{
-    extensions::Erc721Metadata, Erc721, Error,
+    self, extensions::Erc721Metadata, Erc721,
 };
 
 #[entrypoint]
@@ -28,7 +28,7 @@ impl Erc721Example {
     // ...
 
     #[selector(name = "tokenURI")]
-    fn token_uri(&self, token_id: U256) -> Result<String, Error> {
+    fn token_uri(&self, token_id: U256) -> Result<String, erc721::Error> {
         self.metadata.token_uri(token_id, &self.erc721)
     }
 }

--- a/docs/modules/ROOT/pages/erc721-pausable.adoc
+++ b/docs/modules/ROOT/pages/erc721-pausable.adoc
@@ -12,23 +12,29 @@ In order to make your ERC721 token `pausable`, you need to use the https://docs.
 [source,rust]
 ----
 use openzeppelin_stylus::{
-    token::erc721::Erc721,
-    utils::Pausable,
+    token::erc721::{self, extensions::IErc721Burnable, Erc721, IErc721},
+    utils::{pausable, Pausable},
 };
+
+#[derive(SolidityError, Debug)]
+enum Error {
+    Erc721(erc721::Error),
+    Pausable(pausable::Error),
+}
 
 #[entrypoint]
 #[storage]
 struct Erc721Example {
     #[borrow]
-    pub erc721: Erc721,
+    erc721: Erc721,
     #[borrow]
-    pub pausable: Pausable,
+    pausable: Pausable,
 }
 
 #[public]
 #[inherit(Erc721, Pausable)]
 impl Erc721Example {
-    pub fn burn(&mut self, token_id: U256) -> Result<(), Vec<u8>> {
+    fn burn(&mut self, token_id: U256) -> Result<(), Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
@@ -36,7 +42,7 @@ impl Erc721Example {
         Ok(())
     }
 
-    pub fn mint(&mut self, to: Address, token_id: U256) -> Result<(), Vec<u8>> {
+    fn mint(&mut self, to: Address, token_id: U256) -> Result<(), Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
@@ -44,12 +50,12 @@ impl Erc721Example {
         Ok(())
     }
 
-    pub fn safe_transfer_from(
+    fn safe_transfer_from(
         &mut self,
         from: Address,
         to: Address,
         token_id: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
@@ -58,13 +64,13 @@ impl Erc721Example {
     }
 
     #[selector(name = "safeTransferFrom")]
-    pub fn safe_transfer_from_with_data(
+    fn safe_transfer_from_with_data(
         &mut self,
         from: Address,
         to: Address,
         token_id: U256,
         data: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
@@ -72,30 +78,17 @@ impl Erc721Example {
         Ok(())
     }
 
-    pub fn transfer_from(
+    fn transfer_from(
         &mut self,
         from: Address,
         to: Address,
         token_id: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         // ...
         self.pausable.when_not_paused()?;
         // ...
         self.erc721.transfer_from(from, to, token_id)?;
         Ok(())
-    }
-}
-----
-
-Additionally, you need to ensure proper initialization during xref:deploy.adoc[contract deployment]. Make sure to include the following code in your Solidity Constructor:
-
-[source,solidity]
-----
-contract Erc721Example {
-    bool private _paused;
-
-    constructor() {
-        _paused = false;
     }
 }
 ----

--- a/docs/modules/ROOT/pages/erc721-uri-storage.adoc
+++ b/docs/modules/ROOT/pages/erc721-uri-storage.adoc
@@ -14,8 +14,9 @@ You need to create a specified contract as follows:
 [source,rust]
 ----
 use openzeppelin_stylus::token::erc721::{
+    self,
     extensions::{Erc721Metadata, Erc721UriStorage, IErc721Burnable},
-    Erc721, Error,
+    Erc721,
 };
 
 #[entrypoint]
@@ -31,16 +32,20 @@ struct Erc721MetadataExample {
 #[public]
 #[inherit(Erc721, Erc721Metadata)]
 impl Erc721MetadataExample {
-    fn mint(&mut self, to: Address, token_id: U256) -> Result<(), Error> {
+    fn mint(
+        &mut self,
+        to: Address,
+        token_id: U256,
+    ) -> Result<(), erc721::Error> {
         self.erc721._mint(to, token_id)
     }
 
-    fn burn(&mut self, token_id: U256) -> Result<(), Error> {
+    fn burn(&mut self, token_id: U256) -> Result<(), erc721::Error> {
         self.erc721.burn(token_id)
     }
 
     #[selector(name = "tokenURI")]
-    fn token_uri(&self, token_id: U256) -> Result<String, Error> {
+    fn token_uri(&self, token_id: U256) -> Result<String, erc721::Error> {
         self.uri_storage.token_uri(token_id, &self.erc721, &self.metadata)
     }
 

--- a/docs/modules/ROOT/pages/erc721-uri-storage.adoc
+++ b/docs/modules/ROOT/pages/erc721-uri-storage.adoc
@@ -14,45 +14,38 @@ You need to create a specified contract as follows:
 [source,rust]
 ----
 use openzeppelin_stylus::token::erc721::{
-    extensions::{
-        Erc721Metadata, Erc721UriStorage,
-        IErc721Burnable, IErc721Metadata,
-    },
-    Erc721, IErc721,
+    extensions::{Erc721Metadata, Erc721UriStorage, IErc721Burnable},
+    Erc721, Error,
 };
 
 #[entrypoint]
 #[storage]
 struct Erc721MetadataExample {
     #[borrow]
-    pub erc721: Erc721,
+    erc721: Erc721,
     #[borrow]
-    pub metadata: Metadata,
-    pub uri_storage: UriStorage,
+    metadata: Erc721Metadata,
+    uri_storage: Erc721UriStorage,
 }
 
 #[public]
-#[inherit(Erc721, Erc721Metadata, Erc721UriStorage)]
+#[inherit(Erc721, Erc721Metadata)]
 impl Erc721MetadataExample {
-    pub fn mint(&mut self, to: Address, token_id: U256) -> Result<(), Vec<u8>> {
-        Ok(self.erc721._mint(to, token_id)?)
+    fn mint(&mut self, to: Address, token_id: U256) -> Result<(), Error> {
+        self.erc721._mint(to, token_id)
     }
 
-    pub fn burn(&mut self, token_id: U256) -> Result<(), Vec<u8>> {
-        Ok(self.erc721.burn(token_id)?)
+    fn burn(&mut self, token_id: U256) -> Result<(), Error> {
+        self.erc721.burn(token_id)
     }
 
     #[selector(name = "tokenURI")]
-    pub fn token_uri(&self, token_id: U256) -> Result<String, Vec<u8>> {
-        Ok(self.uri_storage.token_uri(
-            token_id,
-            &self.erc721,
-            &self.metadata,
-        )?)
+    fn token_uri(&self, token_id: U256) -> Result<String, Error> {
+        self.uri_storage.token_uri(token_id, &self.erc721, &self.metadata)
     }
 
     #[selector(name = "setTokenURI")]
-    pub fn set_token_uri(&mut self, token_id: U256, token_uri: String) {
+    fn set_token_uri(&mut self, token_id: U256, token_uri: String) {
         self.uri_storage._set_token_uri(token_id, token_uri)
     }
 }

--- a/docs/modules/ROOT/pages/erc721.adoc
+++ b/docs/modules/ROOT/pages/erc721.adoc
@@ -22,7 +22,7 @@ Here's what a contract for tokenized items might look like:
 [source,rust]
 ----
 use openzeppelin_stylus::token::erc721::{
-    extensions::Erc721Metadata, Erc721, Error,
+    self, extensions::Erc721Metadata, Erc721,
 };
 
 #[entrypoint]
@@ -38,7 +38,7 @@ struct GameItem {
 #[public]
 #[inherit(Erc721, Erc721Metadata)]
 impl GameItem {
-    fn award_item(&mut self, player: Address) -> Result<U256, Error> {
+    fn award_item(&mut self, player: Address) -> Result<U256, erc721::Error> {
         let token_id = self.next_token_id.get() + uint!(1_U256);
         self.next_token_id.set(token_id);
 

--- a/docs/modules/ROOT/pages/erc721.adoc
+++ b/docs/modules/ROOT/pages/erc721.adoc
@@ -21,24 +21,25 @@ Here's what a contract for tokenized items might look like:
 
 [source,rust]
 ----
+use openzeppelin_stylus::token::erc721::{
+    extensions::Erc721Metadata, Erc721, Error,
+};
+
 #[entrypoint]
 #[storage]
 struct GameItem {
     #[borrow]
-    pub erc721: Erc721,
+    erc721: Erc721,
     #[borrow]
-    pub metadata: Metadata,
-    pub next_token_id: StorageU256,
+    metadata: Erc721Metadata,
+    next_token_id: StorageU256,
 }
 
 #[public]
-#[inherit(Erc721, Metadata)]
+#[inherit(Erc721, Erc721Metadata)]
 impl GameItem {
-    pub fn award_item(
-        &mut self,
-        player: Address,
-    ) -> Result<U256, Vec<u8>> {
-        let token_id = self._next_token_id.get() + uint!(1_U256);
+    fn award_item(&mut self, player: Address) -> Result<U256, Error> {
+        let token_id = self.next_token_id.get() + uint!(1_U256);
         self.next_token_id.set(token_id);
 
         self.erc721._mint(player, token_id)?;

--- a/docs/modules/ROOT/pages/utilities.adoc
+++ b/docs/modules/ROOT/pages/utilities.adoc
@@ -19,13 +19,13 @@ Contracts for Stylus provides helpers for implementing ERC-165 in your contracts
 #[storage]
 struct Erc721Example {
     #[borrow]
-    pub erc721: Erc721,
+    erc721: Erc721,
 }
 
 #[public]
 #[inherit(Erc721)]
 impl Erc721Example {
-    pub fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+    fn supports_interface(interface_id: FixedBytes<4>) -> bool {
         Erc721::supports_interface(interface_id)
     }
 }

--- a/examples/access-control/src/lib.rs
+++ b/examples/access-control/src/lib.rs
@@ -25,7 +25,7 @@ struct AccessControlExample {
     access: AccessControl,
 }
 
-const TRANSFER_ROLE: [u8; 32] =
+pub const TRANSFER_ROLE: [u8; 32] =
     keccak_const::Keccak256::new().update(b"TRANSFER_ROLE").finalize();
 
 #[public]

--- a/examples/access-control/src/lib.rs
+++ b/examples/access-control/src/lib.rs
@@ -20,24 +20,24 @@ enum Error {
 #[storage]
 struct AccessControlExample {
     #[borrow]
-    pub erc20: Erc20,
+    erc20: Erc20,
     #[borrow]
-    pub access: AccessControl,
+    access: AccessControl,
 }
 
-pub const TRANSFER_ROLE: [u8; 32] =
+const TRANSFER_ROLE: [u8; 32] =
     keccak_const::Keccak256::new().update(b"TRANSFER_ROLE").finalize();
 
 #[public]
 #[inherit(Erc20, AccessControl)]
 impl AccessControlExample {
-    pub fn make_admin(&mut self, account: Address) -> Result<(), Error> {
+    fn make_admin(&mut self, account: Address) -> Result<(), Error> {
         self.access.only_role(AccessControl::DEFAULT_ADMIN_ROLE.into())?;
         self.access.grant_role(TRANSFER_ROLE.into(), account)?;
         Ok(())
     }
 
-    pub fn transfer_from(
+    fn transfer_from(
         &mut self,
         from: Address,
         to: Address,
@@ -50,7 +50,7 @@ impl AccessControlExample {
 
     // WARNING: This should not be part of the public API, it's here for testing
     // purposes only.
-    pub fn set_role_admin(&mut self, role: B256, new_admin_role: B256) {
+    fn set_role_admin(&mut self, role: B256, new_admin_role: B256) {
         self.access._set_role_admin(role, new_admin_role)
     }
 }

--- a/examples/basic/token/src/lib.rs
+++ b/examples/basic/token/src/lib.rs
@@ -26,7 +26,6 @@ impl Erc20Example {
         account: Address,
         value: U256,
     ) -> Result<(), erc20::Error> {
-        self.erc20._mint(account, value)?;
-        Ok(())
+        self.erc20._mint(account, value)
     }
 }

--- a/examples/basic/token/src/lib.rs
+++ b/examples/basic/token/src/lib.rs
@@ -4,8 +4,10 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 use alloy_primitives::{Address, U256};
-use openzeppelin_stylus::token::erc20::{extensions::Erc20Metadata, Erc20};
-use stylus_sdk::prelude::*;
+use openzeppelin_stylus::token::erc20::{
+    self, extensions::Erc20Metadata, Erc20,
+};
+use stylus_sdk::prelude::{entrypoint, public, storage, *};
 
 #[entrypoint]
 #[storage]
@@ -23,7 +25,7 @@ impl Erc20Example {
         &mut self,
         account: Address,
         value: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), erc20::Error> {
         self.erc20._mint(account, value)?;
         Ok(())
     }

--- a/examples/basic/token/src/lib.rs
+++ b/examples/basic/token/src/lib.rs
@@ -13,15 +13,15 @@ use stylus_sdk::prelude::{entrypoint, public, storage, *};
 #[storage]
 struct Erc20Example {
     #[borrow]
-    pub erc20: Erc20,
+    erc20: Erc20,
     #[borrow]
-    pub metadata: Erc20Metadata,
+    metadata: Erc20Metadata,
 }
 
 #[public]
 #[inherit(Erc20, Erc20Metadata)]
 impl Erc20Example {
-    pub fn mint(
+    fn mint(
         &mut self,
         account: Address,
         value: U256,

--- a/examples/ecdsa/src/lib.rs
+++ b/examples/ecdsa/src/lib.rs
@@ -20,7 +20,6 @@ impl ECDSAExample {
         r: B256,
         s: B256,
     ) -> Result<Address, ecdsa::Error> {
-        let signer = ecdsa::recover(self, hash, v, r, s)?;
-        Ok(signer)
+        ecdsa::recover(self, hash, v, r, s)
     }
 }

--- a/examples/ecdsa/src/lib.rs
+++ b/examples/ecdsa/src/lib.rs
@@ -13,7 +13,7 @@ struct ECDSAExample;
 
 #[public]
 impl ECDSAExample {
-    pub fn recover(
+    fn recover(
         &mut self,
         hash: B256,
         v: u8,

--- a/examples/ecdsa/src/lib.rs
+++ b/examples/ecdsa/src/lib.rs
@@ -9,7 +9,7 @@ use stylus_sdk::prelude::*;
 
 #[entrypoint]
 #[storage]
-struct ECDSAExample {}
+struct ECDSAExample;
 
 #[public]
 impl ECDSAExample {
@@ -19,7 +19,7 @@ impl ECDSAExample {
         v: u8,
         r: B256,
         s: B256,
-    ) -> Result<Address, Vec<u8>> {
+    ) -> Result<Address, ecdsa::Error> {
         let signer = ecdsa::recover(self, hash, v, r, s)?;
         Ok(signer)
     }

--- a/examples/erc1155-metadata-uri/src/lib.rs
+++ b/examples/erc1155-metadata-uri/src/lib.rs
@@ -15,9 +15,9 @@ use stylus_sdk::prelude::*;
 #[storage]
 struct Erc1155MetadataUriExample {
     #[borrow]
-    pub erc1155: Erc1155,
-    pub metadata_uri: Erc1155MetadataUri,
-    pub uri_storage: Erc1155UriStorage,
+    erc1155: Erc1155,
+    metadata_uri: Erc1155MetadataUri,
+    uri_storage: Erc1155UriStorage,
 }
 
 #[public]

--- a/examples/erc1155-supply/src/lib.rs
+++ b/examples/erc1155-supply/src/lib.rs
@@ -45,8 +45,7 @@ impl Erc1155Example {
         value: U256,
         data: Bytes,
     ) -> Result<(), erc1155::Error> {
-        self.erc1155_supply._mint(to, id, value, &data)?;
-        Ok(())
+        self.erc1155_supply._mint(to, id, value, &data)
     }
 
     fn mint_batch(
@@ -56,8 +55,7 @@ impl Erc1155Example {
         values: Vec<U256>,
         data: Bytes,
     ) -> Result<(), erc1155::Error> {
-        self.erc1155_supply._mint_batch(to, ids, values, &data)?;
-        Ok(())
+        self.erc1155_supply._mint_batch(to, ids, values, &data)
     }
 
     // Add token burning feature.
@@ -67,8 +65,7 @@ impl Erc1155Example {
         id: U256,
         value: U256,
     ) -> Result<(), erc1155::Error> {
-        self.erc1155_supply._burn(from, id, value)?;
-        Ok(())
+        self.erc1155_supply._burn(from, id, value)
     }
 
     fn burn_batch(
@@ -77,8 +74,7 @@ impl Erc1155Example {
         ids: Vec<U256>,
         values: Vec<U256>,
     ) -> Result<(), erc1155::Error> {
-        self.erc1155_supply._burn_batch(from, ids, values)?;
-        Ok(())
+        self.erc1155_supply._burn_batch(from, ids, values)
     }
 
     fn supports_interface(interface_id: FixedBytes<4>) -> bool {

--- a/examples/erc1155-supply/src/lib.rs
+++ b/examples/erc1155-supply/src/lib.rs
@@ -18,7 +18,7 @@ use stylus_sdk::{abi::Bytes, prelude::*};
 #[storage]
 struct Erc1155Example {
     #[borrow]
-    pub erc1155_supply: Erc1155Supply,
+    erc1155_supply: Erc1155Supply,
 }
 
 #[public]
@@ -38,7 +38,7 @@ impl Erc1155Example {
     }
 
     // Add token minting feature.
-    pub fn mint(
+    fn mint(
         &mut self,
         to: Address,
         id: U256,
@@ -49,7 +49,7 @@ impl Erc1155Example {
         Ok(())
     }
 
-    pub fn mint_batch(
+    fn mint_batch(
         &mut self,
         to: Address,
         ids: Vec<U256>,
@@ -61,7 +61,7 @@ impl Erc1155Example {
     }
 
     // Add token burning feature.
-    pub fn burn(
+    fn burn(
         &mut self,
         from: Address,
         id: U256,
@@ -71,7 +71,7 @@ impl Erc1155Example {
         Ok(())
     }
 
-    pub fn burn_batch(
+    fn burn_batch(
         &mut self,
         from: Address,
         ids: Vec<U256>,

--- a/examples/erc1155-supply/src/lib.rs
+++ b/examples/erc1155-supply/src/lib.rs
@@ -6,6 +6,7 @@ use alloc::vec::Vec;
 use alloy_primitives::{Address, FixedBytes, U256};
 use openzeppelin_stylus::{
     token::erc1155::{
+        self,
         extensions::{Erc1155Supply, IErc1155Supply},
         Erc1155,
     },
@@ -43,7 +44,7 @@ impl Erc1155Example {
         id: U256,
         value: U256,
         data: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), erc1155::Error> {
         self.erc1155_supply._mint(to, id, value, &data)?;
         Ok(())
     }
@@ -54,7 +55,7 @@ impl Erc1155Example {
         ids: Vec<U256>,
         values: Vec<U256>,
         data: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), erc1155::Error> {
         self.erc1155_supply._mint_batch(to, ids, values, &data)?;
         Ok(())
     }
@@ -65,7 +66,7 @@ impl Erc1155Example {
         from: Address,
         id: U256,
         value: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), erc1155::Error> {
         self.erc1155_supply._burn(from, id, value)?;
         Ok(())
     }
@@ -75,7 +76,7 @@ impl Erc1155Example {
         from: Address,
         ids: Vec<U256>,
         values: Vec<U256>,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), erc1155::Error> {
         self.erc1155_supply._burn_batch(from, ids, values)?;
         Ok(())
     }

--- a/examples/erc1155/src/lib.rs
+++ b/examples/erc1155/src/lib.rs
@@ -20,9 +20,9 @@ enum Error {
 #[storage]
 struct Erc1155Example {
     #[borrow]
-    pub erc1155: Erc1155,
+    erc1155: Erc1155,
     #[borrow]
-    pub pausable: Pausable,
+    pausable: Pausable,
 }
 
 #[public]

--- a/examples/erc1155/src/lib.rs
+++ b/examples/erc1155/src/lib.rs
@@ -5,10 +5,16 @@ use alloc::vec::Vec;
 
 use alloy_primitives::{Address, FixedBytes, U256};
 use openzeppelin_stylus::{
-    token::erc1155::{extensions::IErc1155Burnable, Erc1155, IErc1155},
-    utils::{introspection::erc165::IErc165, Pausable},
+    token::erc1155::{self, extensions::IErc1155Burnable, Erc1155, IErc1155},
+    utils::{introspection::erc165::IErc165, pausable, Pausable},
 };
 use stylus_sdk::{abi::Bytes, prelude::*};
+
+#[derive(SolidityError, Debug)]
+enum Error {
+    Erc1155(erc1155::Error),
+    Pausable(pausable::Error),
+}
 
 #[entrypoint]
 #[storage]
@@ -28,7 +34,7 @@ impl Erc1155Example {
         token_id: U256,
         amount: U256,
         data: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         self.pausable.when_not_paused()?;
         self.erc1155._mint(to, token_id, amount, &data)?;
         Ok(())
@@ -40,7 +46,7 @@ impl Erc1155Example {
         token_ids: Vec<U256>,
         amounts: Vec<U256>,
         data: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         self.pausable.when_not_paused()?;
         self.erc1155._mint_batch(to, token_ids, amounts, &data)?;
         Ok(())
@@ -51,7 +57,7 @@ impl Erc1155Example {
         account: Address,
         token_id: U256,
         value: U256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         self.pausable.when_not_paused()?;
         self.erc1155.burn(account, token_id, value)?;
         Ok(())
@@ -62,7 +68,7 @@ impl Erc1155Example {
         account: Address,
         token_ids: Vec<U256>,
         values: Vec<U256>,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         self.pausable.when_not_paused()?;
         self.erc1155.burn_batch(account, token_ids, values)?;
         Ok(())
@@ -75,7 +81,7 @@ impl Erc1155Example {
         id: U256,
         value: U256,
         data: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         self.pausable.when_not_paused()?;
         self.erc1155.safe_transfer_from(from, to, id, value, data)?;
         Ok(())
@@ -88,7 +94,7 @@ impl Erc1155Example {
         ids: Vec<U256>,
         values: Vec<U256>,
         data: Bytes,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), Error> {
         self.pausable.when_not_paused()?;
         self.erc1155.safe_batch_transfer_from(from, to, ids, values, data)?;
         Ok(())
@@ -102,11 +108,11 @@ impl Erc1155Example {
     /// **production**, ensure strict access control to prevent unauthorized
     /// pausing or unpausing, which can disrupt contract functionality. Remove
     /// or secure these functions before deployment.
-    fn pause(&mut self) -> Result<(), Vec<u8>> {
+    fn pause(&mut self) -> Result<(), Error> {
         self.pausable.pause().map_err(|e| e.into())
     }
 
-    fn unpause(&mut self) -> Result<(), Vec<u8>> {
+    fn unpause(&mut self) -> Result<(), Error> {
         self.pausable.unpause().map_err(|e| e.into())
     }
 }

--- a/examples/erc20-flash-mint/src/lib.rs
+++ b/examples/erc20-flash-mint/src/lib.rs
@@ -9,10 +9,7 @@ use openzeppelin_stylus::token::erc20::{
     extensions::{flash_mint, Erc20FlashMint, IErc3156FlashLender},
     Erc20,
 };
-use stylus_sdk::{
-    abi::Bytes,
-    prelude::{entrypoint, public, storage, SolidityError, *},
-};
+use stylus_sdk::{abi::Bytes, prelude::*};
 
 #[derive(SolidityError, Debug)]
 enum Error {

--- a/examples/erc20-permit/src/lib.rs
+++ b/examples/erc20-permit/src/lib.rs
@@ -5,7 +5,10 @@ use alloc::vec::Vec;
 
 use alloy_primitives::{Address, B256, U256};
 use openzeppelin_stylus::{
-    token::erc20::{extensions::Erc20Permit, Erc20},
+    token::erc20::{
+        extensions::{permit, Erc20Permit},
+        Erc20,
+    },
     utils::{cryptography::eip712::IEip712, nonces::Nonces},
 };
 use stylus_sdk::prelude::*;
@@ -33,9 +36,12 @@ impl IEip712 for Eip712 {
 #[inherit(Erc20, Nonces, Erc20Permit<Eip712>)]
 impl Erc20PermitExample {
     // Add token minting feature.
-    fn mint(&mut self, account: Address, value: U256) -> Result<(), Vec<u8>> {
-        self.erc20._mint(account, value)?;
-        Ok(())
+    fn mint(
+        &mut self,
+        account: Address,
+        value: U256,
+    ) -> Result<(), permit::Error> {
+        Ok(self.erc20._mint(account, value)?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -48,7 +54,7 @@ impl Erc20PermitExample {
         v: u8,
         r: B256,
         s: B256,
-    ) -> Result<(), Vec<u8>> {
+    ) -> Result<(), permit::Error> {
         Ok(self.erc20_permit.permit(
             owner,
             spender,

--- a/examples/erc20-permit/src/lib.rs
+++ b/examples/erc20-permit/src/lib.rs
@@ -25,7 +25,7 @@ struct Erc20PermitExample {
 }
 
 #[storage]
-struct Eip712 {}
+struct Eip712;
 
 impl IEip712 for Eip712 {
     const NAME: &'static str = "ERC-20 Permit Example";

--- a/examples/erc20-permit/src/lib.rs
+++ b/examples/erc20-permit/src/lib.rs
@@ -17,11 +17,11 @@ use stylus_sdk::prelude::*;
 #[storage]
 struct Erc20PermitExample {
     #[borrow]
-    pub erc20: Erc20,
+    erc20: Erc20,
     #[borrow]
-    pub nonces: Nonces,
+    nonces: Nonces,
     #[borrow]
-    pub erc20_permit: Erc20Permit<Eip712>,
+    erc20_permit: Erc20Permit<Eip712>,
 }
 
 #[storage]
@@ -55,7 +55,7 @@ impl Erc20PermitExample {
         r: B256,
         s: B256,
     ) -> Result<(), permit::Error> {
-        Ok(self.erc20_permit.permit(
+        self.erc20_permit.permit(
             owner,
             spender,
             value,
@@ -65,6 +65,6 @@ impl Erc20PermitExample {
             s,
             &mut self.erc20,
             &mut self.nonces,
-        )?)
+        )
     }
 }

--- a/examples/erc20-permit/tests/erc20permit.rs
+++ b/examples/erc20-permit/tests/erc20permit.rs
@@ -1,4 +1,4 @@
-// #![cfg(feature = "e2e")]
+#![cfg(feature = "e2e")]
 
 use abi::Erc20Permit;
 use alloy::{

--- a/examples/erc20/src/lib.rs
+++ b/examples/erc20/src/lib.rs
@@ -1,124 +1,17 @@
-#![cfg_attr(not(test), no_main)]
-extern crate alloc;
-
-use alloc::vec::Vec;
-
-use alloy_primitives::{Address, FixedBytes, U256};
-use openzeppelin_stylus::{
-    token::erc20::{
-        self,
-        extensions::{capped, Capped, Erc20Metadata, IErc20Burnable},
-        Erc20, IErc20,
-    },
-    utils::{introspection::erc165::IErc165, pausable, Pausable},
-};
-use stylus_sdk::prelude::*;
-
-const DECIMALS: u8 = 10;
-
-#[derive(SolidityError, Debug)]
-enum Error {
-    Capped(capped::Error),
-    Erc20(erc20::Error),
-    Pausable(pausable::Error),
-}
-
-#[entrypoint]
-#[storage]
-struct Erc20Example {
-    #[borrow]
-    erc20: Erc20,
-    #[borrow]
-    metadata: Erc20Metadata,
-    #[borrow]
-    capped: Capped,
-    #[borrow]
-    pausable: Pausable,
-}
-
 #[public]
-#[inherit(Erc20, Erc20Metadata, Capped, Pausable)]
+#[inherit(Erc20)]
 impl Erc20Example {
-    // Overrides the default [`Metadata::decimals`], and sets it to `10`.
-    //
-    // If you don't provide this method in the `entrypoint` contract, it will
-    // default to `18`.
-    fn decimals(&self) -> u8 {
-        DECIMALS
-    }
-
-    fn burn(&mut self, value: U256) -> Result<(), Error> {
-        self.pausable.when_not_paused()?;
-        self.erc20.burn(value).map_err(|e| e.into())
+    fn burn(&mut self, value: U256) -> Result<(), erc20::Error> {
+        // ...
+        self.erc20.burn(value)
     }
 
     fn burn_from(
         &mut self,
         account: Address,
         value: U256,
-    ) -> Result<(), Error> {
-        self.pausable.when_not_paused()?;
-        self.erc20.burn_from(account, value).map_err(|e| e.into())
-    }
-
-    // Add token minting feature.
-    //
-    // Make sure to handle `Capped` properly. You should not call
-    // [`Erc20::_update`] to mint tokens -- it will the break `Capped`
-    // mechanism.
-    fn mint(&mut self, account: Address, value: U256) -> Result<(), Error> {
-        self.pausable.when_not_paused()?;
-        let max_supply = self.capped.cap();
-
-        // Overflow check required.
-        let supply = self
-            .erc20
-            .total_supply()
-            .checked_add(value)
-            .expect("new supply should not exceed `U256::MAX`");
-
-        if supply > max_supply {
-            return Err(capped::Error::ExceededCap(
-                capped::ERC20ExceededCap {
-                    increased_supply: supply,
-                    cap: max_supply,
-                },
-            ))?;
-        }
-
-        self.erc20._mint(account, value)?;
-        Ok(())
-    }
-
-    fn transfer(&mut self, to: Address, value: U256) -> Result<bool, Error> {
-        self.pausable.when_not_paused()?;
-        self.erc20.transfer(to, value).map_err(|e| e.into())
-    }
-
-    fn transfer_from(
-        &mut self,
-        from: Address,
-        to: Address,
-        value: U256,
-    ) -> Result<bool, Error> {
-        self.pausable.when_not_paused()?;
-        self.erc20.transfer_from(from, to, value).map_err(|e| e.into())
-    }
-
-    fn supports_interface(interface_id: FixedBytes<4>) -> bool {
-        Erc20::supports_interface(interface_id)
-            || Erc20Metadata::supports_interface(interface_id)
-    }
-
-    /// WARNING: These functions are intended for **testing purposes** only. In
-    /// **production**, ensure strict access control to prevent unauthorized
-    /// pausing or unpausing, which can disrupt contract functionality. Remove
-    /// or secure these functions before deployment.
-    fn pause(&mut self) -> Result<(), Error> {
-        self.pausable.pause().map_err(|e| e.into())
-    }
-
-    fn unpause(&mut self) -> Result<(), Error> {
-        self.pausable.unpause().map_err(|e| e.into())
+    ) -> Result<(), erc20::Error> {
+        // ...
+        self.erc20.burn_from(account, value)
     }
 }

--- a/examples/erc20/src/lib.rs
+++ b/examples/erc20/src/lib.rs
@@ -1,17 +1,124 @@
+#![cfg_attr(not(test), no_main)]
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use alloy_primitives::{Address, FixedBytes, U256};
+use openzeppelin_stylus::{
+    token::erc20::{
+        self,
+        extensions::{capped, Capped, Erc20Metadata, IErc20Burnable},
+        Erc20, IErc20,
+    },
+    utils::{introspection::erc165::IErc165, pausable, Pausable},
+};
+use stylus_sdk::prelude::*;
+
+const DECIMALS: u8 = 10;
+
+#[derive(SolidityError, Debug)]
+enum Error {
+    Capped(capped::Error),
+    Erc20(erc20::Error),
+    Pausable(pausable::Error),
+}
+
+#[entrypoint]
+#[storage]
+struct Erc20Example {
+    #[borrow]
+    erc20: Erc20,
+    #[borrow]
+    metadata: Erc20Metadata,
+    #[borrow]
+    capped: Capped,
+    #[borrow]
+    pausable: Pausable,
+}
+
 #[public]
-#[inherit(Erc20)]
+#[inherit(Erc20, Erc20Metadata, Capped, Pausable)]
 impl Erc20Example {
-    fn burn(&mut self, value: U256) -> Result<(), erc20::Error> {
-        // ...
-        self.erc20.burn(value)
+    // Overrides the default [`Metadata::decimals`], and sets it to `10`.
+    //
+    // If you don't provide this method in the `entrypoint` contract, it will
+    // default to `18`.
+    fn decimals(&self) -> u8 {
+        DECIMALS
+    }
+
+    fn burn(&mut self, value: U256) -> Result<(), Error> {
+        self.pausable.when_not_paused()?;
+        self.erc20.burn(value).map_err(|e| e.into())
     }
 
     fn burn_from(
         &mut self,
         account: Address,
         value: U256,
-    ) -> Result<(), erc20::Error> {
-        // ...
-        self.erc20.burn_from(account, value)
+    ) -> Result<(), Error> {
+        self.pausable.when_not_paused()?;
+        self.erc20.burn_from(account, value).map_err(|e| e.into())
+    }
+
+    // Add token minting feature.
+    //
+    // Make sure to handle `Capped` properly. You should not call
+    // [`Erc20::_update`] to mint tokens -- it will the break `Capped`
+    // mechanism.
+    fn mint(&mut self, account: Address, value: U256) -> Result<(), Error> {
+        self.pausable.when_not_paused()?;
+        let max_supply = self.capped.cap();
+
+        // Overflow check required.
+        let supply = self
+            .erc20
+            .total_supply()
+            .checked_add(value)
+            .expect("new supply should not exceed `U256::MAX`");
+
+        if supply > max_supply {
+            return Err(capped::Error::ExceededCap(
+                capped::ERC20ExceededCap {
+                    increased_supply: supply,
+                    cap: max_supply,
+                },
+            ))?;
+        }
+
+        self.erc20._mint(account, value)?;
+        Ok(())
+    }
+
+    fn transfer(&mut self, to: Address, value: U256) -> Result<bool, Error> {
+        self.pausable.when_not_paused()?;
+        self.erc20.transfer(to, value).map_err(|e| e.into())
+    }
+
+    fn transfer_from(
+        &mut self,
+        from: Address,
+        to: Address,
+        value: U256,
+    ) -> Result<bool, Error> {
+        self.pausable.when_not_paused()?;
+        self.erc20.transfer_from(from, to, value).map_err(|e| e.into())
+    }
+
+    fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+        Erc20::supports_interface(interface_id)
+            || Erc20Metadata::supports_interface(interface_id)
+    }
+
+    /// WARNING: These functions are intended for **testing purposes** only. In
+    /// **production**, ensure strict access control to prevent unauthorized
+    /// pausing or unpausing, which can disrupt contract functionality. Remove
+    /// or secure these functions before deployment.
+    fn pause(&mut self) -> Result<(), Error> {
+        self.pausable.pause().map_err(|e| e.into())
+    }
+
+    fn unpause(&mut self) -> Result<(), Error> {
+        self.pausable.unpause().map_err(|e| e.into())
     }
 }

--- a/examples/erc20/src/lib.rs
+++ b/examples/erc20/src/lib.rs
@@ -27,13 +27,13 @@ enum Error {
 #[storage]
 struct Erc20Example {
     #[borrow]
-    pub erc20: Erc20,
+    erc20: Erc20,
     #[borrow]
-    pub metadata: Erc20Metadata,
+    metadata: Erc20Metadata,
     #[borrow]
-    pub capped: Capped,
+    capped: Capped,
     #[borrow]
-    pub pausable: Pausable,
+    pausable: Pausable,
 }
 
 #[public]
@@ -43,16 +43,16 @@ impl Erc20Example {
     //
     // If you don't provide this method in the `entrypoint` contract, it will
     // default to `18`.
-    pub fn decimals(&self) -> u8 {
+    fn decimals(&self) -> u8 {
         DECIMALS
     }
 
-    pub fn burn(&mut self, value: U256) -> Result<(), Error> {
+    fn burn(&mut self, value: U256) -> Result<(), Error> {
         self.pausable.when_not_paused()?;
         self.erc20.burn(value).map_err(|e| e.into())
     }
 
-    pub fn burn_from(
+    fn burn_from(
         &mut self,
         account: Address,
         value: U256,
@@ -66,7 +66,7 @@ impl Erc20Example {
     // Make sure to handle `Capped` properly. You should not call
     // [`Erc20::_update`] to mint tokens -- it will the break `Capped`
     // mechanism.
-    pub fn mint(&mut self, account: Address, value: U256) -> Result<(), Error> {
+    fn mint(&mut self, account: Address, value: U256) -> Result<(), Error> {
         self.pausable.when_not_paused()?;
         let max_supply = self.capped.cap();
 
@@ -90,16 +90,12 @@ impl Erc20Example {
         Ok(())
     }
 
-    pub fn transfer(
-        &mut self,
-        to: Address,
-        value: U256,
-    ) -> Result<bool, Error> {
+    fn transfer(&mut self, to: Address, value: U256) -> Result<bool, Error> {
         self.pausable.when_not_paused()?;
         self.erc20.transfer(to, value).map_err(|e| e.into())
     }
 
-    pub fn transfer_from(
+    fn transfer_from(
         &mut self,
         from: Address,
         to: Address,
@@ -109,7 +105,7 @@ impl Erc20Example {
         self.erc20.transfer_from(from, to, value).map_err(|e| e.into())
     }
 
-    pub fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+    fn supports_interface(interface_id: FixedBytes<4>) -> bool {
         Erc20::supports_interface(interface_id)
             || Erc20Metadata::supports_interface(interface_id)
     }
@@ -118,11 +114,11 @@ impl Erc20Example {
     /// **production**, ensure strict access control to prevent unauthorized
     /// pausing or unpausing, which can disrupt contract functionality. Remove
     /// or secure these functions before deployment.
-    pub fn pause(&mut self) -> Result<(), Error> {
+    fn pause(&mut self) -> Result<(), Error> {
         self.pausable.pause().map_err(|e| e.into())
     }
 
-    pub fn unpause(&mut self) -> Result<(), Error> {
+    fn unpause(&mut self) -> Result<(), Error> {
         self.pausable.unpause().map_err(|e| e.into())
     }
 }

--- a/examples/erc4626/src/lib.rs
+++ b/examples/erc4626/src/lib.rs
@@ -5,10 +5,17 @@ use alloc::vec::Vec;
 
 use alloy_primitives::{Address, U256, U8};
 use openzeppelin_stylus::token::erc20::{
-    extensions::{Erc20Metadata, Erc4626, IErc4626},
+    self,
+    extensions::{erc4626, Erc20Metadata, Erc4626, IErc4626},
     Erc20,
 };
 use stylus_sdk::prelude::*;
+
+#[derive(SolidityError, Debug)]
+enum Error {
+    Erc20(erc20::Error),
+    Erc4626(erc4626::Error),
+}
 
 #[entrypoint]
 #[storage]
@@ -32,15 +39,15 @@ impl Erc4626Example {
         self.erc4626.asset()
     }
 
-    fn total_assets(&mut self) -> Result<U256, Vec<u8>> {
+    fn total_assets(&mut self) -> Result<U256, Error> {
         Ok(self.erc4626.total_assets()?)
     }
 
-    fn convert_to_shares(&mut self, assets: U256) -> Result<U256, Vec<u8>> {
+    fn convert_to_shares(&mut self, assets: U256) -> Result<U256, Error> {
         Ok(self.erc4626.convert_to_shares(assets, &self.erc20)?)
     }
 
-    fn convert_to_assets(&mut self, shares: U256) -> Result<U256, Vec<u8>> {
+    fn convert_to_assets(&mut self, shares: U256) -> Result<U256, Error> {
         Ok(self.erc4626.convert_to_assets(shares, &self.erc20)?)
     }
 
@@ -48,7 +55,7 @@ impl Erc4626Example {
         self.erc4626.max_deposit(receiver)
     }
 
-    fn preview_deposit(&mut self, assets: U256) -> Result<U256, Vec<u8>> {
+    fn preview_deposit(&mut self, assets: U256) -> Result<U256, Error> {
         Ok(self.erc4626.preview_deposit(assets, &self.erc20)?)
     }
 
@@ -56,7 +63,7 @@ impl Erc4626Example {
         &mut self,
         assets: U256,
         receiver: Address,
-    ) -> Result<U256, Vec<u8>> {
+    ) -> Result<U256, Error> {
         Ok(self.erc4626.deposit(assets, receiver, &mut self.erc20)?)
     }
 
@@ -64,23 +71,19 @@ impl Erc4626Example {
         self.erc4626.max_mint(receiver)
     }
 
-    fn preview_mint(&mut self, shares: U256) -> Result<U256, Vec<u8>> {
+    fn preview_mint(&mut self, shares: U256) -> Result<U256, Error> {
         Ok(self.erc4626.preview_mint(shares, &self.erc20)?)
     }
 
-    fn mint(
-        &mut self,
-        shares: U256,
-        receiver: Address,
-    ) -> Result<U256, Vec<u8>> {
+    fn mint(&mut self, shares: U256, receiver: Address) -> Result<U256, Error> {
         Ok(self.erc4626.mint(shares, receiver, &mut self.erc20)?)
     }
 
-    fn max_withdraw(&mut self, owner: Address) -> Result<U256, Vec<u8>> {
+    fn max_withdraw(&mut self, owner: Address) -> Result<U256, Error> {
         Ok(self.erc4626.max_withdraw(owner, &self.erc20)?)
     }
 
-    fn preview_withdraw(&mut self, assets: U256) -> Result<U256, Vec<u8>> {
+    fn preview_withdraw(&mut self, assets: U256) -> Result<U256, Error> {
         Ok(self.erc4626.preview_withdraw(assets, &self.erc20)?)
     }
 
@@ -89,7 +92,7 @@ impl Erc4626Example {
         assets: U256,
         receiver: Address,
         owner: Address,
-    ) -> Result<U256, Vec<u8>> {
+    ) -> Result<U256, Error> {
         Ok(self.erc4626.withdraw(assets, receiver, owner, &mut self.erc20)?)
     }
 
@@ -97,7 +100,7 @@ impl Erc4626Example {
         self.erc4626.max_redeem(owner, &self.erc20)
     }
 
-    fn preview_redeem(&mut self, shares: U256) -> Result<U256, Vec<u8>> {
+    fn preview_redeem(&mut self, shares: U256) -> Result<U256, Error> {
         Ok(self.erc4626.preview_redeem(shares, &self.erc20)?)
     }
 
@@ -106,7 +109,7 @@ impl Erc4626Example {
         shares: U256,
         receiver: Address,
         owner: Address,
-    ) -> Result<U256, Vec<u8>> {
+    ) -> Result<U256, Error> {
         Ok(self.erc4626.redeem(shares, receiver, owner, &mut self.erc20)?)
     }
 }

--- a/examples/erc721-consecutive/src/lib.rs
+++ b/examples/erc721-consecutive/src/lib.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 use alloy_primitives::{Address, FixedBytes, U256};
 use openzeppelin_stylus::{
     token::erc721::{
-        extensions::consecutive::{Erc721Consecutive, Error},
+        extensions::{consecutive, Erc721Consecutive},
         Erc721,
     },
     utils::introspection::erc165::IErc165,
@@ -21,11 +21,15 @@ struct Erc721ConsecutiveExample {
 #[public]
 #[inherit(Erc721Consecutive)]
 impl Erc721ConsecutiveExample {
-    fn burn(&mut self, token_id: U256) -> Result<(), Error> {
+    fn burn(&mut self, token_id: U256) -> Result<(), consecutive::Error> {
         self.erc721_consecutive._burn(token_id)
     }
 
-    fn mint(&mut self, to: Address, token_id: U256) -> Result<(), Error> {
+    fn mint(
+        &mut self,
+        to: Address,
+        token_id: U256,
+    ) -> Result<(), consecutive::Error> {
         self.erc721_consecutive._mint(to, token_id)
     }
 

--- a/examples/erc721-metadata/src/lib.rs
+++ b/examples/erc721-metadata/src/lib.rs
@@ -6,6 +6,7 @@ use alloc::{string::String, vec::Vec};
 use alloy_primitives::{Address, FixedBytes, U256};
 use openzeppelin_stylus::{
     token::erc721::{
+        self,
         extensions::{
             Erc721Metadata as Metadata, Erc721UriStorage as UriStorage,
             IErc721Burnable,
@@ -29,16 +30,20 @@ struct Erc721MetadataExample {
 #[public]
 #[inherit(Erc721, Metadata)]
 impl Erc721MetadataExample {
-    pub fn mint(&mut self, to: Address, token_id: U256) -> Result<(), Vec<u8>> {
+    pub fn mint(
+        &mut self,
+        to: Address,
+        token_id: U256,
+    ) -> Result<(), erc721::Error> {
         Ok(self.erc721._mint(to, token_id)?)
     }
 
-    pub fn burn(&mut self, token_id: U256) -> Result<(), Vec<u8>> {
+    pub fn burn(&mut self, token_id: U256) -> Result<(), erc721::Error> {
         Ok(self.erc721.burn(token_id)?)
     }
 
     #[selector(name = "tokenURI")]
-    pub fn token_uri(&self, token_id: U256) -> Result<String, Vec<u8>> {
+    pub fn token_uri(&self, token_id: U256) -> Result<String, erc721::Error> {
         Ok(self.uri_storage.token_uri(
             token_id,
             &self.erc721,

--- a/examples/erc721-metadata/src/lib.rs
+++ b/examples/erc721-metadata/src/lib.rs
@@ -21,16 +21,16 @@ use stylus_sdk::prelude::*;
 #[storage]
 struct Erc721MetadataExample {
     #[borrow]
-    pub erc721: Erc721,
+    erc721: Erc721,
     #[borrow]
-    pub metadata: Metadata,
-    pub uri_storage: UriStorage,
+    metadata: Metadata,
+    uri_storage: UriStorage,
 }
 
 #[public]
 #[inherit(Erc721, Metadata)]
 impl Erc721MetadataExample {
-    pub fn mint(
+    fn mint(
         &mut self,
         to: Address,
         token_id: U256,
@@ -38,21 +38,21 @@ impl Erc721MetadataExample {
         self.erc721._mint(to, token_id)
     }
 
-    pub fn burn(&mut self, token_id: U256) -> Result<(), erc721::Error> {
+    fn burn(&mut self, token_id: U256) -> Result<(), erc721::Error> {
         self.erc721.burn(token_id)
     }
 
     #[selector(name = "tokenURI")]
-    pub fn token_uri(&self, token_id: U256) -> Result<String, erc721::Error> {
+    fn token_uri(&self, token_id: U256) -> Result<String, erc721::Error> {
         self.uri_storage.token_uri(token_id, &self.erc721, &self.metadata)
     }
 
     #[selector(name = "setTokenURI")]
-    pub fn set_token_uri(&mut self, token_id: U256, token_uri: String) {
+    fn set_token_uri(&mut self, token_id: U256, token_uri: String) {
         self.uri_storage._set_token_uri(token_id, token_uri)
     }
 
-    pub fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+    fn supports_interface(interface_id: FixedBytes<4>) -> bool {
         Erc721::supports_interface(interface_id)
             || Metadata::supports_interface(interface_id)
     }

--- a/examples/erc721-metadata/src/lib.rs
+++ b/examples/erc721-metadata/src/lib.rs
@@ -35,20 +35,16 @@ impl Erc721MetadataExample {
         to: Address,
         token_id: U256,
     ) -> Result<(), erc721::Error> {
-        Ok(self.erc721._mint(to, token_id)?)
+        self.erc721._mint(to, token_id)
     }
 
     pub fn burn(&mut self, token_id: U256) -> Result<(), erc721::Error> {
-        Ok(self.erc721.burn(token_id)?)
+        self.erc721.burn(token_id)
     }
 
     #[selector(name = "tokenURI")]
     pub fn token_uri(&self, token_id: U256) -> Result<String, erc721::Error> {
-        Ok(self.uri_storage.token_uri(
-            token_id,
-            &self.erc721,
-            &self.metadata,
-        )?)
+        self.uri_storage.token_uri(token_id, &self.erc721, &self.metadata)
     }
 
     #[selector(name = "setTokenURI")]

--- a/examples/erc721/src/lib.rs
+++ b/examples/erc721/src/lib.rs
@@ -27,17 +27,17 @@ enum Error {
 #[storage]
 struct Erc721Example {
     #[borrow]
-    pub erc721: Erc721,
+    erc721: Erc721,
     #[borrow]
-    pub enumerable: Enumerable,
+    enumerable: Enumerable,
     #[borrow]
-    pub pausable: Pausable,
+    pausable: Pausable,
 }
 
 #[public]
 #[inherit(Erc721, Enumerable, Pausable)]
 impl Erc721Example {
-    pub fn burn(&mut self, token_id: U256) -> Result<(), Error> {
+    fn burn(&mut self, token_id: U256) -> Result<(), Error> {
         self.pausable.when_not_paused()?;
 
         // Retrieve the owner.
@@ -56,7 +56,7 @@ impl Erc721Example {
         Ok(())
     }
 
-    pub fn mint(&mut self, to: Address, token_id: U256) -> Result<(), Error> {
+    fn mint(&mut self, to: Address, token_id: U256) -> Result<(), Error> {
         self.pausable.when_not_paused()?;
 
         self.erc721._mint(to, token_id)?;
@@ -72,7 +72,7 @@ impl Erc721Example {
         Ok(())
     }
 
-    pub fn safe_mint(
+    fn safe_mint(
         &mut self,
         to: Address,
         token_id: U256,
@@ -93,7 +93,7 @@ impl Erc721Example {
         Ok(())
     }
 
-    pub fn safe_transfer_from(
+    fn safe_transfer_from(
         &mut self,
         from: Address,
         to: Address,
@@ -122,7 +122,7 @@ impl Erc721Example {
     }
 
     #[selector(name = "safeTransferFrom")]
-    pub fn safe_transfer_from_with_data(
+    fn safe_transfer_from_with_data(
         &mut self,
         from: Address,
         to: Address,
@@ -151,7 +151,7 @@ impl Erc721Example {
         Ok(())
     }
 
-    pub fn transfer_from(
+    fn transfer_from(
         &mut self,
         from: Address,
         to: Address,
@@ -179,7 +179,7 @@ impl Erc721Example {
         Ok(())
     }
 
-    pub fn supports_interface(interface_id: FixedBytes<4>) -> bool {
+    fn supports_interface(interface_id: FixedBytes<4>) -> bool {
         Erc721::supports_interface(interface_id)
             || Enumerable::supports_interface(interface_id)
     }
@@ -188,11 +188,11 @@ impl Erc721Example {
     /// **production**, ensure strict access control to prevent unauthorized
     /// pausing or unpausing, which can disrupt contract functionality. Remove
     /// or secure these functions before deployment.
-    pub fn pause(&mut self) -> Result<(), Error> {
+    fn pause(&mut self) -> Result<(), Error> {
         self.pausable.pause().map_err(|e| e.into())
     }
 
-    pub fn unpause(&mut self) -> Result<(), Error> {
+    fn unpause(&mut self) -> Result<(), Error> {
         self.pausable.unpause().map_err(|e| e.into())
     }
 }

--- a/examples/merkle-proofs/src/lib.rs
+++ b/examples/merkle-proofs/src/lib.rs
@@ -20,7 +20,7 @@ sol! {
 }
 
 #[derive(SolidityError)]
-pub enum VerifierError {
+enum VerifierError {
     InvalidProofLength(MerkleProofInvalidMultiProofLength),
     InvalidRootChild(MerkleProofInvalidRootChild),
     InvalidTotalHashes(MerkleProofInvalidTotalHashes),
@@ -56,12 +56,12 @@ struct VerifierContract;
 
 #[public]
 impl VerifierContract {
-    pub fn verify(&self, proof: Vec<B256>, root: B256, leaf: B256) -> bool {
+    fn verify(&self, proof: Vec<B256>, root: B256, leaf: B256) -> bool {
         let proof: Vec<[u8; 32]> = proof.into_iter().map(|m| *m).collect();
         Verifier::<KeccakBuilder>::verify(&proof, *root, *leaf)
     }
 
-    pub fn verify_multi_proof(
+    fn verify_multi_proof(
         &self,
         proof: Vec<B256>,
         proof_flags: Vec<bool>,

--- a/examples/ownable-two-step/src/lib.rs
+++ b/examples/ownable-two-step/src/lib.rs
@@ -5,10 +5,16 @@ use alloc::vec::Vec;
 
 use alloy_primitives::{Address, U256};
 use openzeppelin_stylus::{
-    access::ownable_two_step::Ownable2Step,
-    token::erc20::{Erc20, IErc20},
+    access::{ownable, ownable_two_step::Ownable2Step},
+    token::erc20::{self, Erc20, IErc20},
 };
 use stylus_sdk::prelude::*;
+
+#[derive(SolidityError, Debug)]
+enum Error {
+    Erc20(erc20::Error),
+    Ownable(ownable::Error),
+}
 
 #[entrypoint]
 #[storage]
@@ -22,11 +28,7 @@ struct Ownable2StepExample {
 #[public]
 #[inherit(Erc20, Ownable2Step)]
 impl Ownable2StepExample {
-    pub fn transfer(
-        &mut self,
-        to: Address,
-        value: U256,
-    ) -> Result<(), Vec<u8>> {
+    pub fn transfer(&mut self, to: Address, value: U256) -> Result<(), Error> {
         self.ownable.only_owner()?;
         self.erc20.transfer(to, value)?;
         Ok(())

--- a/examples/ownable-two-step/src/lib.rs
+++ b/examples/ownable-two-step/src/lib.rs
@@ -20,15 +20,15 @@ enum Error {
 #[storage]
 struct Ownable2StepExample {
     #[borrow]
-    pub erc20: Erc20,
+    erc20: Erc20,
     #[borrow]
-    pub ownable: Ownable2Step,
+    ownable: Ownable2Step,
 }
 
 #[public]
 #[inherit(Erc20, Ownable2Step)]
 impl Ownable2StepExample {
-    pub fn transfer(&mut self, to: Address, value: U256) -> Result<(), Error> {
+    fn transfer(&mut self, to: Address, value: U256) -> Result<(), Error> {
         self.ownable.only_owner()?;
         self.erc20.transfer(to, value)?;
         Ok(())

--- a/examples/ownable/src/lib.rs
+++ b/examples/ownable/src/lib.rs
@@ -20,15 +20,15 @@ enum Error {
 #[storage]
 struct OwnableExample {
     #[borrow]
-    pub erc20: Erc20,
+    erc20: Erc20,
     #[borrow]
-    pub ownable: Ownable,
+    ownable: Ownable,
 }
 
 #[public]
 #[inherit(Erc20, Ownable)]
 impl OwnableExample {
-    pub fn transfer(&mut self, to: Address, value: U256) -> Result<(), Error> {
+    fn transfer(&mut self, to: Address, value: U256) -> Result<(), Error> {
         self.ownable.only_owner()?;
         self.erc20.transfer(to, value)?;
         Ok(())

--- a/examples/ownable/src/lib.rs
+++ b/examples/ownable/src/lib.rs
@@ -5,10 +5,16 @@ use alloc::vec::Vec;
 
 use alloy_primitives::{Address, U256};
 use openzeppelin_stylus::{
-    access::ownable::Ownable,
-    token::erc20::{Erc20, IErc20},
+    access::ownable::{self, Ownable},
+    token::erc20::{self, Erc20, IErc20},
 };
 use stylus_sdk::prelude::*;
+
+#[derive(SolidityError, Debug)]
+enum Error {
+    Erc20(erc20::Error),
+    Ownable(ownable::Error),
+}
 
 #[entrypoint]
 #[storage]
@@ -22,11 +28,7 @@ struct OwnableExample {
 #[public]
 #[inherit(Erc20, Ownable)]
 impl OwnableExample {
-    pub fn transfer(
-        &mut self,
-        to: Address,
-        value: U256,
-    ) -> Result<(), Vec<u8>> {
+    pub fn transfer(&mut self, to: Address, value: U256) -> Result<(), Error> {
         self.ownable.only_owner()?;
         self.erc20.transfer(to, value)?;
         Ok(())

--- a/examples/poseidon/src/lib.rs
+++ b/examples/poseidon/src/lib.rs
@@ -13,7 +13,7 @@ use stylus_sdk::prelude::*;
 
 #[entrypoint]
 #[storage]
-struct PoseidonExample {}
+struct PoseidonExample;
 
 #[public]
 impl PoseidonExample {

--- a/examples/poseidon/src/lib.rs
+++ b/examples/poseidon/src/lib.rs
@@ -17,7 +17,7 @@ struct PoseidonExample;
 
 #[public]
 impl PoseidonExample {
-    pub fn hash(&mut self, inputs: [U256; 2]) -> U256 {
+    fn hash(&mut self, inputs: [U256; 2]) -> U256 {
         let mut hasher = Poseidon2::<BN256Params, FpBN256>::new();
 
         for input in inputs.iter() {

--- a/examples/poseidon/src/lib.rs
+++ b/examples/poseidon/src/lib.rs
@@ -17,7 +17,7 @@ struct PoseidonExample;
 
 #[public]
 impl PoseidonExample {
-    pub fn hash(&mut self, inputs: [U256; 2]) -> Result<U256, Vec<u8>> {
+    pub fn hash(&mut self, inputs: [U256; 2]) -> U256 {
         let mut hasher = Poseidon2::<BN256Params, FpBN256>::new();
 
         for input in inputs.iter() {
@@ -30,6 +30,6 @@ impl PoseidonExample {
         let hash = hasher.squeeze();
         let hash = hash.into_bigint().into_bytes_le();
 
-        Ok(U256::from_le_slice(&hash))
+        U256::from_le_slice(&hash)
     }
 }

--- a/examples/safe-erc20/src/lib.rs
+++ b/examples/safe-erc20/src/lib.rs
@@ -8,7 +8,7 @@ use stylus_sdk::prelude::*;
 #[storage]
 struct SafeErc20Example {
     #[borrow]
-    pub safe_erc20: SafeErc20,
+    safe_erc20: SafeErc20,
 }
 
 #[public]

--- a/examples/vesting-wallet/src/lib.rs
+++ b/examples/vesting-wallet/src/lib.rs
@@ -8,7 +8,7 @@ use stylus_sdk::prelude::*;
 #[storage]
 struct VestingWalletExample {
     #[borrow]
-    pub vesting_wallet: VestingWallet,
+    vesting_wallet: VestingWallet,
 }
 
 #[public]


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OpenZeppelin!

Consider opening an issue for discussion prior to submitting a PR. New features will be merged faster if they were first discussed and designed with the team.

Describe the changes introduced in this pull request. Include any context necessary for understanding the PR's purpose.
-->

<!-- Fill in with issue number -->
Resolves #327 

#### PR Checklist

<!--
Before merging the pull request all of the following must be completed.
Feel free to submit a PR or Draft PR even if some items are pending.
Some of the items may not apply.
-->

- [x] Tests
- [x] Documentation
- [x] Changelog
