### PR TITLE
fix(audit): L-02: Inconsistent Data Types for carry and borrow Parameters

### DIFF
--- a/lib/crypto/src/arithmetic/limb.rs
+++ b/lib/crypto/src/arithmetic/limb.rs
@@ -112,7 +112,7 @@ pub const fn sbb(a: Limb, b: Limb, borrow: bool) -> (Limb, bool) {
     // Protects from overflow, when `a < b + borrow`.
     let overflow_protection = WideLimb::ONE << Limb::BITS;
     let tmp = overflow_protection + a - b - borrow;
-    let borrow = if tmp >> Limb::BITS == 0 { true } else { false };
+    let borrow = tmp >> Limb::BITS == 0;
     // overflow_protection will be truncated on cast.
     (tmp as Limb, borrow)
 }

--- a/lib/crypto/src/arithmetic/limb.rs
+++ b/lib/crypto/src/arithmetic/limb.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_lossless)]
 
-use num_traits::{ConstOne, ConstZero};
+use num_traits::ConstOne;
 
 /// A single limb of a big integer represented by 64-bits.
 pub type Limb = u64;
@@ -84,12 +84,12 @@ pub const fn carrying_mac(
 #[inline(always)]
 #[must_use]
 #[allow(clippy::cast_possible_truncation)]
-pub const fn adc(a: Limb, b: Limb, carry: Limb) -> (Limb, Limb) {
+pub const fn adc(a: Limb, b: Limb, carry: bool) -> (Limb, bool) {
     let a = a as WideLimb;
     let b = b as WideLimb;
     let carry = carry as WideLimb;
     let tmp = a + b + carry;
-    let carry = (tmp >> Limb::BITS) as Limb;
+    let carry = (tmp >> Limb::BITS) != 0;
     (tmp as Limb, carry)
 }
 
@@ -105,14 +105,14 @@ pub fn adc_assign(a: &mut Limb, b: Limb, carry: bool) -> bool {
 /// Calculate `a = a - b - borrow` and return the result and borrow.
 #[inline(always)]
 #[must_use]
-pub const fn sbb(a: Limb, b: Limb, borrow: Limb) -> (Limb, Limb) {
+pub const fn sbb(a: Limb, b: Limb, borrow: bool) -> (Limb, bool) {
     let a = a as WideLimb;
     let b = b as WideLimb;
     let borrow = borrow as WideLimb;
     // Protects from overflow, when `a < b + borrow`.
     let overflow_protection = WideLimb::ONE << Limb::BITS;
     let tmp = overflow_protection + a - b - borrow;
-    let borrow = if tmp >> Limb::BITS == 0 { Limb::ONE } else { Limb::ZERO };
+    let borrow = if tmp >> Limb::BITS == 0 { true } else { false };
     // overflow_protection will be truncated on cast.
     (tmp as Limb, borrow)
 }

--- a/lib/crypto/src/field/fp.rs
+++ b/lib/crypto/src/field/fp.rs
@@ -401,7 +401,7 @@ impl<P: FpParams<N>, const N: usize> Fp<P, N> {
         mut lo: Uint<N>,
         mut hi: Uint<N>,
     ) -> (bool, Uint<N>) {
-        let mut carry2 = 0;
+        let mut carry2 = false;
         ct_for_unroll6!((i in 0..N) {
             let tmp = lo.limbs[i].wrapping_mul(P::INV);
 
@@ -428,7 +428,7 @@ impl<P: FpParams<N>, const N: usize> Fp<P, N> {
             (hi.limbs[i], carry2) = limb::adc(hi.limbs[i], carry, carry2);
         });
 
-        (carry2 != 0, hi)
+        (carry2, hi)
     }
 
     /// Apply the Montgomery reduction to `self`.


### PR DESCRIPTION
Fixes L-02: Inconsistent Data Types for carry and borrow Parameters