### PR TITLE
fix(audit): Encoding Ambiguity in ct_num_bits Function (update docs)

### DIFF
--- a/lib/crypto/src/arithmetic/mod.rs
+++ b/lib/crypto/src/arithmetic/mod.rs
@@ -110,6 +110,8 @@ pub trait BigInteger:
 
     /// Return the minimum number of bits needed to encode this number.
     ///
+    /// Returns zero bits to encode `self` if zero.
+    ///
     /// # Examples
     /// ```
     /// use openzeppelin_crypto::arithmetic::{BigInteger, uint::U64};

--- a/lib/crypto/src/arithmetic/uint.rs
+++ b/lib/crypto/src/arithmetic/uint.rs
@@ -188,6 +188,8 @@ impl<const N: usize> Uint<N> {
     }
 
     /// Return the minimum number of bits needed to encode this number.
+    ///
+    /// Returns zero bits to encode `self` if zero.
     #[doc(hidden)]
     #[must_use]
     pub const fn ct_num_bits(&self) -> usize {
@@ -956,6 +958,8 @@ impl<const N: usize> WideUint<N> {
     }
 
     /// Find the number of bits in the binary decomposition of `self`.
+    ///
+    /// Returns zero bits to encode `self` if zero.
     #[must_use]
     pub const fn ct_num_bits(&self) -> usize {
         let high_num_bits = self.high.ct_num_bits();


### PR DESCRIPTION
Fixes L-03: Encoding Ambiguity in ct_num_bits Function

Part of the code relies on existing logic of num_bits. Instead of changing the behavior of num_bits function, update documentation to make no surprise for consumers.