### PR TITLE
build: remove cdylib crate-type from examples

### DIFF
--- a/examples/access-control/Cargo.toml
+++ b/examples/access-control/Cargo.toml
@@ -19,7 +19,7 @@ tokio.workspace = true
 eyre.workspace = true
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [features]
 e2e = []

--- a/examples/basic/token/Cargo.toml
+++ b/examples/basic/token/Cargo.toml
@@ -15,7 +15,7 @@ stylus-sdk.workspace = true
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "basic-example"

--- a/examples/ecdsa/Cargo.toml
+++ b/examples/ecdsa/Cargo.toml
@@ -18,7 +18,7 @@ tokio.workspace = true
 eyre.workspace = true
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [features]
 e2e = []

--- a/examples/erc1155-metadata-uri/Cargo.toml
+++ b/examples/erc1155-metadata-uri/Cargo.toml
@@ -22,7 +22,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "erc1155-metadata-uri-example"

--- a/examples/erc1155-supply/Cargo.toml
+++ b/examples/erc1155-supply/Cargo.toml
@@ -22,7 +22,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "erc1155-supply-example"

--- a/examples/erc1155/Cargo.toml
+++ b/examples/erc1155/Cargo.toml
@@ -22,7 +22,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "erc1155-example"

--- a/examples/erc20-flash-mint/Cargo.toml
+++ b/examples/erc20-flash-mint/Cargo.toml
@@ -22,7 +22,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "erc20-flash-mint-example"

--- a/examples/erc20-permit/Cargo.toml
+++ b/examples/erc20-permit/Cargo.toml
@@ -23,7 +23,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "erc20-permit-example"

--- a/examples/erc20-wrapper/Cargo.toml
+++ b/examples/erc20-wrapper/Cargo.toml
@@ -22,7 +22,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "erc20-wrapper-example"

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -22,7 +22,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "erc20-example"

--- a/examples/erc4626/Cargo.toml
+++ b/examples/erc4626/Cargo.toml
@@ -22,7 +22,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "erc4626-example"

--- a/examples/erc721-consecutive/Cargo.toml
+++ b/examples/erc721-consecutive/Cargo.toml
@@ -24,7 +24,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "erc721-consecutive-example"

--- a/examples/erc721-metadata/Cargo.toml
+++ b/examples/erc721-metadata/Cargo.toml
@@ -23,7 +23,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "erc721-metadata-example"

--- a/examples/erc721-wrapper/Cargo.toml
+++ b/examples/erc721-wrapper/Cargo.toml
@@ -22,7 +22,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "erc721-wrapper-example"

--- a/examples/erc721/Cargo.toml
+++ b/examples/erc721/Cargo.toml
@@ -23,7 +23,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "erc721-example"

--- a/examples/merkle-proofs/Cargo.toml
+++ b/examples/merkle-proofs/Cargo.toml
@@ -17,7 +17,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "merkle-proofs-example"

--- a/examples/ownable-two-step/Cargo.toml
+++ b/examples/ownable-two-step/Cargo.toml
@@ -18,7 +18,7 @@ tokio.workspace = true
 eyre.workspace = true
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [features]
 e2e = []

--- a/examples/ownable/Cargo.toml
+++ b/examples/ownable/Cargo.toml
@@ -18,7 +18,7 @@ tokio.workspace = true
 eyre.workspace = true
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [features]
 e2e = []

--- a/examples/pedersen/Cargo.toml
+++ b/examples/pedersen/Cargo.toml
@@ -18,7 +18,7 @@ tokio.workspace = true
 eyre.workspace = true
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [features]
 e2e = []

--- a/examples/poseidon/Cargo.toml
+++ b/examples/poseidon/Cargo.toml
@@ -18,7 +18,7 @@ tokio.workspace = true
 eyre.workspace = true
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [features]
 e2e = []

--- a/examples/safe-erc20/Cargo.toml
+++ b/examples/safe-erc20/Cargo.toml
@@ -22,7 +22,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "safe-erc20-example"

--- a/examples/vesting-wallet/Cargo.toml
+++ b/examples/vesting-wallet/Cargo.toml
@@ -22,7 +22,7 @@ e2e = []
 export-abi = ["stylus-sdk/export-abi", "openzeppelin-stylus/export-abi"]
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["lib"]
 
 [[bin]]
 name = "vesting-wallet-example"


### PR DESCRIPTION
Solves warning for all examples:
```sh
warning: output filename collision.
The lib target vesting_wallet_example in package vesting-wallet-example v0.2.0-rc.0 (/Users/bidzyyys/work/rust-contracts-stylus/examples/vesting-wallet) has the same output filename as the lib target vesting_wallet_example in package vesting-wallet-example v0.2.0-rc.0 (/Users/bidzyyys/work/rust-contracts-stylus/examples/vesting-wallet).
Colliding filename is: /Users/bidzyyys/work/rust-contracts-stylus/target/debug/deps/libvesting_wallet_example.dylib.dSYM
The targets should have unique names.
Consider changing their names to be unique or compiling them separately.
This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
```