### PR TITLE
build: Fix failing cargo-stylus@0.6.0 install -> bump nightly channel to 2025-06-03 

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # We should use stable here once nitro-testnode is updated and the contracts fit
 # the size limit (issue <https://github.com/OpenZeppelin/rust-contracts-stylus/issues/129>).
-channel = "nightly-2024-10-11"
+channel = "nightly-2025-06-03"
 components = ["rust-src"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
This nightly channel is post-Rust-1.87.0, which is [default](https://github.com/OffchainLabs/stylus-hello-world/blob/5b3fa18f70ff58b8964b089be688f9616de54499/rust-toolchain.toml) for new Stylus projects.