### PR TITLE
build(ci): update nitro-testnode

### DIFF
--- a/lib/e2e/src/deploy.rs
+++ b/lib/e2e/src/deploy.rs
@@ -16,7 +16,7 @@ use stylus_sdk::{abi::Bytes, alloy_primitives, function_selector};
 use crate::{project::Crate, system::DEPLOYER_ADDRESS, Constructor, Receipt};
 
 const CONTRACT_INITIALIZATION_ERROR_SELECTOR: [u8; 4] =
-    function_selector!("ContractInitializationError", Address);
+    function_selector!("ContractInitializationError", Address, Bytes);
 
 const PROGRAM_UP_TO_DATE_ERROR_SELECTOR: [u8; 4] =
     function_selector!("ProgramUpToDate");

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -34,7 +34,7 @@ for CRATE_NAME in $(get_example_crate_names); do
 done
 
 export RPC_URL=http://localhost:8547
-export DEPLOYER_ADDRESS=0x6ac4839Bfe169CadBBFbDE3f29bd8459037Bf64e
+export DEPLOYER_ADDRESS=0xcEcba2F1DC234f70Dd89F2041029807F8D03A990
 
 # No need to compile benchmarks with `--release`
 # since this only runs the benchmarking code and the contracts have already been compiled with `--release`.

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -9,7 +9,7 @@ cargo build --release --target wasm32-unknown-unknown \
   -Z build-std-features=panic_immediate_abort
 
 export RPC_URL=http://localhost:8547
-export DEPLOYER_ADDRESS=0x6ac4839Bfe169CadBBFbDE3f29bd8459037Bf64e
+export DEPLOYER_ADDRESS=0xcEcba2F1DC234f70Dd89F2041029807F8D03A990
 
 # If any arguments are set, just pass them as-is to the cargo test command
 if [[ $# -eq 0 ]]; then

--- a/scripts/nitro-testnode.sh
+++ b/scripts/nitro-testnode.sh
@@ -46,9 +46,8 @@ if $HAS_INIT; then
   cd "$MYDIR" || exit
   cd ..
 
-  git clone --recurse-submodules https://github.com/OffchainLabs/nitro-testnode.git
+  git clone -b release --recurse-submodules https://github.com/OffchainLabs/nitro-testnode.git
   cd ./nitro-testnode || exit
-  git pull origin release --recurse-submodules
   git checkout 06ced35af92319b361fa44c832a4a400d09423d2 || exit
 
   ./test-node.bash --no-run --init || exit

--- a/scripts/nitro-testnode.sh
+++ b/scripts/nitro-testnode.sh
@@ -46,10 +46,10 @@ if $HAS_INIT; then
   cd "$MYDIR" || exit
   cd ..
 
-  git clone --recurse-submodules https://github.com/OffchainLabs/nitro-testnode.git --branch v3-support
+  git clone --recurse-submodules https://github.com/OffchainLabs/nitro-testnode.git
   cd ./nitro-testnode || exit
   git pull origin release --recurse-submodules
-  git checkout 1fe1b72bd33cb5bd862c04447435f1c159ff7a3f || exit
+  git checkout 06ced35af92319b361fa44c832a4a400d09423d2 || exit
 
   ./test-node.bash --no-run --init || exit
 fi


### PR DESCRIPTION
We need to update the nitro-testnode as the CI jobs started failing, like in #716.