### PR TITLE
EnumerableSet Trait and Implementations

### DIFF
--- a/contracts/src/access/control/extensions/enumerable.rs
+++ b/contracts/src/access/control/extensions/enumerable.rs
@@ -12,7 +12,7 @@ use crate::{
     access::control::AccessControl,
     utils::{
         introspection::erc165::IErc165,
-        structs::enumerable_set::EnumerableAddressSet,
+        structs::enumerable_set::{EnumerableAddressSet, EnumerableSet},
     },
 };
 

--- a/contracts/src/utils/structs/enumerable_set.rs
+++ b/contracts/src/utils/structs/enumerable_set.rs
@@ -9,12 +9,15 @@
 /// * Set can be cleared (all elements removed) in O(n).
 use alloc::{vec, vec::Vec};
 
-use alloy_primitives::{uint, Address, FixedBytes, U256};
+use alloy_primitives::{
+    uint, Address, FixedBytes, U128, U16, U256, U32, U64, U8,
+};
 use stylus_sdk::{
     prelude::*,
     storage::{
         StorageAddress, StorageFixedBytes, StorageKey, StorageMap, StorageType,
-        StorageU256, StorageVec,
+        StorageU128, StorageU16, StorageU256, StorageU32, StorageU64,
+        StorageU8, StorageVec,
     },
 };
 
@@ -86,6 +89,13 @@ where
 macro_rules! impl_set {
     ($($name:ident $key:ident $value:ident)+) => {
         $(
+            ///
+            #[storage]
+            pub struct $name {
+                values: StorageVec<$value>,
+                positions: StorageMap<$key, StorageU256>,
+            }
+
             impl EnumerableSet<$key, $value> for $name {
                 fn add(&mut self, value: $key) -> bool {
                     if self.contains(value) {
@@ -173,55 +183,20 @@ macro_rules! impl_set {
     };
 }
 
-/// State of an [`EnumerableAddressSet`] contract.
-#[storage]
-pub struct EnumerableAddressSet {
-    /// Values in the set.
-    values: StorageVec<StorageAddress>,
-    /// Value -> Index of the value in the `values` array.
-    positions: StorageMap<Address, StorageU256>,
-}
-impl_set!(EnumerableAddressSet Address StorageAddress);
-
-/// Sets to add: Uint
-
-#[storage]
-pub struct EmumerableBytes32Set {
-    /// Values in the set.
-    values: StorageVec<StorageFixedBytes<32>>,
-    /// Value -> Index of the value in the `values` array.
-    positions: StorageMap<FixedBytes<32>, StorageU256>,
-}
 // use alias to avoid macro issues with brackets
 type Bytes32 = FixedBytes<32>;
 type StorageBytes32 = StorageFixedBytes<32>;
-impl_set!(EmumerableBytes32Set Bytes32 StorageBytes32);
 
-/*
-#[storage]
-pub struct EmumerableStringSet {
-    /// Values in the set.
-    values: StorageVec<StorageString>,
-    /// Value -> Index of the value in the `values` array.
-    positions: StorageMap<String, StorageU256>,
-}
-impl_set!(EmumerableStringSet String StorageString);
-*/
-
-macro_rules! impl_uint_sets {
-    ($($uint:ident $int:ident)+) => {
-        $(
-            #[storage]
-            pub struct EmumerableBytes32Set {
-                /// Values in the set.
-                values: StorageVec<StorageFixedBytes<32>>,
-                /// Value -> Index of the value in the `values` array.
-                positions: StorageMap<FixedBytes<32>, StorageU256>,
-            }
-
-        )+
-    };
-}
+impl_set!(
+    EnumerableAddressSet Address StorageAddress
+    EmumerableBytes32Set Bytes32 StorageBytes32
+    EnumerableU8Set U8 StorageU8
+    EnumerableU16Set U16 StorageU16
+    EnumerableU32Set U32 StorageU32
+    EnumerableU64Set U64 StorageU64
+    EnumerableU128Set U128 StorageU128
+    EnumerableU256Set U256 StorageU256
+);
 
 #[cfg(test)]
 mod tests {

--- a/contracts/src/utils/structs/enumerable_set.rs
+++ b/contracts/src/utils/structs/enumerable_set.rs
@@ -9,13 +9,169 @@
 /// * Set can be cleared (all elements removed) in O(n).
 use alloc::{vec, vec::Vec};
 
-use alloy_primitives::{uint, Address, U256};
+use alloy_primitives::{uint, Address, FixedBytes, U256};
 use stylus_sdk::{
     prelude::*,
     storage::{
-        StorageAddress, StorageMap, StorageType, StorageU256, StorageVec,
+        StorageAddress, StorageFixedBytes, StorageKey, StorageMap, StorageType,
+        StorageU256, StorageVec,
     },
 };
+
+/// EnumarableSet trait for defining new sets.
+///
+/// This trait is automatically implemented if using the `impl_set` macro.
+pub trait EnumerableSet<K, V>
+where
+    K: StorageKey,
+    V: StorageType,
+{
+    /// Adds a value to a set.
+    ///
+    /// Returns true if the `value` was added to the set, that is if it was not
+    /// already present.
+    ///
+    /// # Arguments
+    ///
+    /// * `&mut self` - Write access to the set's state.
+    /// * `value` - The value to add to the set.
+    fn add(&mut self, value: K) -> bool;
+
+    /// Removes a `value` from a set.
+    ///
+    /// Returns true if the `value` was removed from the set, that is if it was
+    /// present.
+    ///
+    /// # Arguments
+    ///
+    /// * `&mut self` - Write access to the set's state.
+    /// * `value` - The value to remove from the set.
+    fn remove(&mut self, value: K) -> bool;
+
+    /// Returns true if the `value` is in the set.
+    ///
+    /// # Arguments
+    ///
+    /// * `&self` - Read access to the set's state.
+    /// * `value` - The value to check for in the set.
+    fn contains(&self, value: K) -> bool;
+
+    /// Returns the number of values in the set.
+    ///
+    /// # Arguments
+    ///
+    /// * `&self` - Read access to the set's state.
+    fn length(&self) -> U256;
+
+    /// Returns the value stored at position `index` in the set.
+    ///
+    /// Note that there are no guarantees on the ordering of values inside the
+    /// array, and it may change when more values are added or removed.
+    ///
+    /// # Arguments
+    ///
+    /// * `&self` - Read access to the set's state.
+    /// * `index` - The index of the value to return.
+    fn at(&self, index: U256) -> Option<K>;
+
+    /// Returns the entire set in an array.
+    ///
+    /// # Arguments
+    ///
+    /// * `&self` - Read access to the set's state.
+    fn values(&self) -> Vec<K>;
+}
+
+///
+macro_rules! impl_set {
+    ($($name:ident $key:ident $value:ident)+) => {
+        $(
+            impl EnumerableSet<$key, $value> for $name {
+                fn add(&mut self, value: $key) -> bool {
+                    if self.contains(value) {
+                        false
+                    } else {
+                        self.values.push(value);
+                        // The value is stored at length-1, but we add 1 to all indexes
+                        // and use [`U256::ZERO`] as a sentinel value.
+                        self.positions.setter(value).set(U256::from(self.values.len()));
+                        true
+                    }
+                }
+
+                fn remove(&mut self, value: $key) -> bool {
+                    // We cache the value's position to prevent multiple reads from the same
+                    // storage slot.
+                    let position = self.positions.get(value);
+
+                    if position.is_zero() {
+                        false
+                    } else {
+                        // To delete an element from the `self.values` array in O(1),
+                        // we swap the element to delete with the last one in the array,
+                        // and then remove the last element (sometimes called as 'swap and
+                        // pop'). This modifies the order of the array, as noted
+                        // in [`Self::at`].
+                        let one = uint!(1_U256);
+                        let value_index = position - one;
+                        let last_index = self.length() - one;
+
+                        if value_index != last_index {
+                            let last_value = self
+                                .values
+                                .get(last_index)
+                                .expect("element at `last_index` must exist");
+
+                            // Move the `last_value` to the index where the value to delete
+                            // is.
+                            self.values
+                                .setter(value_index)
+                                .expect(
+                                    "element at `value_index` must exist - is being removed",
+                                )
+                                .set(last_value);
+                            // Update the tracked position of the lastValue (that was just
+                            // moved).
+                            self.positions.setter(last_value).set(position);
+                        }
+
+                        // Delete the slot where the moved value was stored.
+                        self.values.pop();
+
+                        // Delete the tracked position for the deleted slot.
+                        self.positions.delete(value);
+
+                        true
+                    }
+                }
+
+                fn contains(&self, value: $key) -> bool {
+                    !self.positions.get(value).is_zero()
+                }
+
+                fn length(&self) -> U256 {
+                    U256::from(self.values.len())
+                }
+
+                fn at(&self, index: U256) -> Option<$key> {
+                    self.values.get(index)
+                }
+
+                fn values(&self) -> Vec<$key> {
+                    let mut values = Vec::new();
+                    for idx in 0..self.values.len() {
+                        values.push(
+                            self.values
+                                .get(idx)
+                                .expect("element at index: {idx} must exist"),
+                        );
+                    }
+                    values
+                }
+            }
+        )+
+    };
+}
 
 /// State of an [`EnumerableAddressSet`] contract.
 #[storage]
@@ -25,132 +181,46 @@ pub struct EnumerableAddressSet {
     /// Value -> Index of the value in the `values` array.
     positions: StorageMap<Address, StorageU256>,
 }
+impl_set!(EnumerableAddressSet Address StorageAddress);
 
-impl EnumerableAddressSet {
-    /// Adds a value to a set. O(1).
-    ///
-    /// Returns true if the `value` was added to the set, that is if it was not
-    /// already present.
-    ///
-    /// # Arguments
-    ///
-    /// * `&mut self` - Write access to the set's state.
-    /// * `value` - The value to add to the set.
-    pub fn add(&mut self, value: Address) -> bool {
-        if self.contains(value) {
-            false
-        } else {
-            self.values.push(value);
-            // The value is stored at length-1, but we add 1 to all indexes
-            // and use [`U256::ZERO`] as a sentinel value.
-            self.positions.setter(value).set(U256::from(self.values.len()));
-            true
-        }
-    }
+/// Sets to add: Uint
 
-    /// Removes a `value` from a set. O(1).
-    ///
-    /// Returns true if the `value` was removed from the set, that is if it was
-    /// present.
-    ///
-    /// # Arguments
-    ///
-    /// * `&mut self` - Write access to the set's state.
-    /// * `value` - The value to remove from the set.
-    pub fn remove(&mut self, value: Address) -> bool {
-        // We cache the value's position to prevent multiple reads from the same
-        // storage slot.
-        let position = self.positions.get(value);
+#[storage]
+pub struct EmumerableBytes32Set {
+    /// Values in the set.
+    values: StorageVec<StorageFixedBytes<32>>,
+    /// Value -> Index of the value in the `values` array.
+    positions: StorageMap<FixedBytes<32>, StorageU256>,
+}
+// use alias to avoid macro issues with brackets
+type Bytes32 = FixedBytes<32>;
+type StorageBytes32 = StorageFixedBytes<32>;
+impl_set!(EmumerableBytes32Set Bytes32 StorageBytes32);
 
-        if position.is_zero() {
-            false
-        } else {
-            // To delete an element from the `self.values` array in O(1),
-            // we swap the element to delete with the last one in the array,
-            // and then remove the last element (sometimes called as 'swap and
-            // pop'). This modifies the order of the array, as noted
-            // in [`Self::at`].
-            let one = uint!(1_U256);
-            let value_index = position - one;
-            let last_index = self.length() - one;
+/*
+#[storage]
+pub struct EmumerableStringSet {
+    /// Values in the set.
+    values: StorageVec<StorageString>,
+    /// Value -> Index of the value in the `values` array.
+    positions: StorageMap<String, StorageU256>,
+}
+impl_set!(EmumerableStringSet String StorageString);
+*/
 
-            if value_index != last_index {
-                let last_value = self
-                    .values
-                    .get(last_index)
-                    .expect("element at `last_index` must exist");
-
-                // Move the `last_value` to the index where the value to delete
-                // is.
-                self.values
-                    .setter(value_index)
-                    .expect(
-                        "element at `value_index` must exist - is being removed",
-                    )
-                    .set(last_value);
-                // Update the tracked position of the lastValue (that was just
-                // moved).
-                self.positions.setter(last_value).set(position);
+macro_rules! impl_uint_sets {
+    ($($uint:ident $int:ident)+) => {
+        $(
+            #[storage]
+            pub struct EmumerableBytes32Set {
+                /// Values in the set.
+                values: StorageVec<StorageFixedBytes<32>>,
+                /// Value -> Index of the value in the `values` array.
+                positions: StorageMap<FixedBytes<32>, StorageU256>,
             }
 
-            // Delete the slot where the moved value was stored.
-            self.values.pop();
-
-            // Delete the tracked position for the deleted slot.
-            self.positions.delete(value);
-
-            true
-        }
-    }
-
-    /// Returns true if the `value` is in the set. O(1).
-    ///
-    /// # Arguments
-    ///
-    /// * `&self` - Read access to the set's state.
-    /// * `value` - The value to check for in the set.
-    pub fn contains(&self, value: Address) -> bool {
-        !self.positions.get(value).is_zero()
-    }
-
-    /// Returns the number of values in the set. O(1).
-    ///
-    /// # Arguments
-    ///
-    /// * `&self` - Read access to the set's state.
-    pub fn length(&self) -> U256 {
-        U256::from(self.values.len())
-    }
-
-    /// Returns the value stored at position `index` in the set. O(1).
-    ///
-    /// Note that there are no guarantees on the ordering of values inside the
-    /// array, and it may change when more values are added or removed.
-    ///
-    /// # Arguments
-    ///
-    /// * `&self` - Read access to the set's state.
-    /// * `index` - The index of the value to return.
-    pub fn at(&self, index: U256) -> Option<Address> {
-        self.values.get(index)
-    }
-
-    /// Returns the entire set in an array.
-    ///
-    /// # Arguments
-    ///
-    /// * `&self` - Read access to the set's state.
-    pub fn values(&self) -> Vec<Address> {
-        let mut values = Vec::new();
-        for idx in 0..self.values.len() {
-            values.push(
-                self.values
-                    .get(idx)
-                    .expect("element at index: {idx} must exist"),
-            );
-        }
-        values
-    }
+        )+
+    };
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OpenZeppelin!

Consider opening an issue for discussion prior to submitting a PR. New features will be merged faster if they were first discussed and designed with the team.

Describe the changes introduced in this pull request. Include any context necessary for understanding the PR's purpose.
-->
This PR adds a trait definition for `EnumerableSet` along with a macro to generate common sets.  It includes implementations for: `Address, FixedBytes<32>, U8, U16, U32, U64, U128, U256` along with extensive testing.

<!-- Fill in with issue number -->
Resolves #687

#### PR Checklist

<!--
Before merging the pull request all of the following must be completed.
Feel free to submit a PR or Draft PR even if some items are pending.
Some of the items may not apply.
-->

- [x] Tests
- [x] Documentation
- [ ] Changelog
