### PR TITLE
fix: export-abi bug for reentrant feature

### DIFF
--- a/.github/workflows/check-abi.yml
+++ b/.github/workflows/check-abi.yml
@@ -15,7 +15,6 @@ jobs:
   check-abi:
     name: Check ABI
     runs-on: ubuntu-latest
-    if: false  # disables this job; set to true or remove to re-enable
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `IERC721Receiver` Solidity Interface to `IErc721ReceiverInterface`. #743
 - Change `RECEIVER_FN_SELECTOR` type to `FixedBytes<4>`. #743
 
+### Fixed
+
+- Fix `export-abi` bug for `reentrant` feature. #753
+
 ## [0.3.0-alpha.1] - 2025-07-21
 
 - Add `BeaconProxy` contract and `IBeacon` interface, supporting the beacon proxy pattern for upgradeable contracts. #729

--- a/contracts/src/utils/storage_slot.rs
+++ b/contracts/src/utils/storage_slot.rs
@@ -54,10 +54,22 @@ impl StorageSlot {
         // TODO: Remove this once we have a proper way to inject the host for
         // custom storage slot access.
         // This has been implemented on Stylus SDK 0.10.0.
-        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(all(
+            not(target_arch = "wasm32"),
+            any(
+                all(not(feature = "export-abi"), feature = "reentrant"),
+                all(feature = "export-abi", feature = "reentrant")
+            )
+        ))]
         let host =
             VM { host: alloc::boxed::Box::new(stylus_sdk::host::WasmVM {}) };
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(any(
+            target_arch = "wasm32",
+            all(
+                any(feature = "export-abi", not(feature = "reentrant")),
+                any(not(feature = "export-abi"), not(feature = "reentrant"))
+            )
+        ))]
         let host = VM(stylus_sdk::host::WasmVM {});
 
         // SAFETY: Truncation is safe here because ST::SLOT_BYTES is never


### PR DESCRIPTION
The problem was for [`reentrant` feature](https://github.com/OffchainLabs/stylus-sdk-rs/blob/v0.9.0/stylus-sdk/Cargo.toml#L53).
Resolves #742 

#### PR Checklist

<!--
Before merging the pull request all of the following must be completed.
Feel free to submit a PR or Draft PR even if some items are pending.
Some of the items may not apply.
-->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog
