### PR TITLE
fix(N-04): Missing Checks for Equality of Scalar and WideScalar in EdDSA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AdminChanged` event parameters no longer indexed. #794
 - Fix edge case with U64 -> u128 conversion. #815
 - Conditional compilation in storage slot utilities causing build failures across different target architectures and feature combinations. #823
-- Added constant `Uint::from_uint(..)` function. `Fp::from_fp(..)` is now constant also. #834
 
 ## [v0.3.0-rc.1] - 2025-08-07
 
@@ -32,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add bidirectional conversions between `ruint::Uint` and crypto library `Uint` types behind `ruint` feature toggle. #758
 - Add bidirectional conversions between `Uint` and `u8`, `u16`, `u32`, `u64`, `u128` types. #764
 - Add EDDSA (Ed25519) signature scheme. #757
+- Add constant `Uint::from_uint(..)` function. `Fp::from_fp(..)` is now constant also. #834
 
 ### Changed (Breaking)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `AdminChanged` event parameters no longer indexed. #794
 - Conditional compilation in storage slot utilities causing build failures across different target architectures and feature combinations. #823
+- Added constant `Uint::from_uint(..)` function. `Fp::from_fp(..)` is now constant also. #834
 
 ## [v0.3.0-rc.1] - 2025-08-07
 

--- a/lib/crypto/src/arithmetic/uint.rs
+++ b/lib/crypto/src/arithmetic/uint.rs
@@ -451,7 +451,7 @@ impl<const N: usize> Uint<N> {
     ///
     /// * If `value` is bigger than `Self` maximum size.
     #[must_use]
-    pub const fn ct_from_uint<const N2: usize>(value: Uint<N2>) -> Self {
+    pub const fn from_uint<const N2: usize>(value: Uint<N2>) -> Self {
         let mut res = Uint::<N>::ZERO;
         ct_for!((i in 0..{value.limbs.len()}) {
             if i < res.limbs.len() {
@@ -1425,8 +1425,8 @@ mod test {
         // Check that conversion between integers with different bit size works.
         proptest!(|(limbs: [u64; 4])|{
             let expected_uint = U256::new(limbs);
-            let wide_uint = U512::ct_from_uint(expected_uint);
-            let uint = U256::ct_from_uint(wide_uint);
+            let wide_uint = U512::from_uint(expected_uint);
+            let uint = U256::from_uint(wide_uint);
 
             assert_eq!(uint, expected_uint);
         });

--- a/lib/crypto/src/arithmetic/uint.rs
+++ b/lib/crypto/src/arithmetic/uint.rs
@@ -444,6 +444,24 @@ impl<const N: usize> Uint<N> {
 
         Self::new(res)
     }
+
+    /// Construct `Self` from the other [`Uint`] of different size (constant).
+    ///
+    /// # Panics
+    ///
+    /// * If `value` is bigger than `Self` maximum size.
+    #[must_use]
+    pub const fn ct_from_uint<const N2: usize>(value: Uint<N2>) -> Self {
+        let mut res = Uint::<N>::ZERO;
+        ct_for!((i in 0..{value.limbs.len()}) {
+            if i < res.limbs.len() {
+                res.limbs[i] = value.limbs[i];
+            } else if value.limbs[i] != Limb::ZERO {
+                panic!("converted element is too large")
+            }
+        });
+        res
+    }
 }
 
 // ----------- From Impls -----------
@@ -1121,7 +1139,7 @@ mod test {
 
     use crate::{
         arithmetic::{
-            uint::{from_str_hex, from_str_radix, Uint, WideUint, U256},
+            uint::{from_str_hex, from_str_radix, Uint, WideUint, U256, U512},
             BigInteger, Limb,
         },
         bits::BitIteratorBE,
@@ -1400,5 +1418,17 @@ mod test {
         test_uint_conversion!(uint_u64, u64);
         test_uint_conversion!(uint_u128, u128);
         test_uint_conversion!(uint_usize, usize);
+    }
+
+    #[test]
+    fn from_uint() {
+        // Check that conversion between integers with different bit size works.
+        proptest!(|(limbs: [u64; 4])|{
+            let expected_uint = U256::new(limbs);
+            let wide_uint = U512::ct_from_uint(expected_uint);
+            let uint = U256::ct_from_uint(wide_uint);
+
+            assert_eq!(uint, expected_uint);
+        });
     }
 }

--- a/lib/crypto/src/eddsa.rs
+++ b/lib/crypto/src/eddsa.rs
@@ -27,7 +27,7 @@ use crate::{
         fp::{Fp256, Fp512, FpParams, LIMBS_512},
         prime::PrimeField,
     },
-    fp_from_num, from_num,
+    fp_from_num,
 };
 
 /// Ed25519 scalar.
@@ -40,7 +40,7 @@ pub(crate) type WideScalar = Fp512<Curve25519Fr512Param>;
 pub(crate) struct Curve25519Fr512Param;
 impl FpParams<LIMBS_512> for Curve25519Fr512Param {
     const GENERATOR: Fp512<Self> = fp_from_num!("2");
-    const MODULUS: U512 = from_num!("7237005577332262213973186563042994240857116359379907606001950938285454250989");
+    const MODULUS: U512 = U512::ct_from_uint(Curve25519FrParam::MODULUS);
 }
 
 /// Ed25519 projective point.

--- a/lib/crypto/src/eddsa.rs
+++ b/lib/crypto/src/eddsa.rs
@@ -27,7 +27,6 @@ use crate::{
         fp::{Fp256, Fp512, FpParams, LIMBS_512},
         prime::PrimeField,
     },
-    fp_from_num,
 };
 
 /// Ed25519 scalar.
@@ -39,8 +38,8 @@ pub(crate) type WideScalar = Fp512<Curve25519Fr512Param>;
 /// Scalar field parameters for curve ed25519 with `512-bit` inner integer size.
 pub(crate) struct Curve25519Fr512Param;
 impl FpParams<LIMBS_512> for Curve25519Fr512Param {
-    const GENERATOR: Fp512<Self> = fp_from_num!("2");
-    const MODULUS: U512 = U512::ct_from_uint(Curve25519FrParam::MODULUS);
+    const GENERATOR: Fp512<Self> = Fp512::from_fp(Curve25519FrParam::GENERATOR);
+    const MODULUS: U512 = U512::from_uint(Curve25519FrParam::MODULUS);
 }
 
 /// Ed25519 projective point.

--- a/lib/crypto/src/field/fp.rs
+++ b/lib/crypto/src/field/fp.rs
@@ -25,12 +25,11 @@ use core::{
 };
 
 use educe::Educe;
-use num_traits::{ConstZero, One, Zero};
+use num_traits::{One, Zero};
 
 use crate::{
     arithmetic::{
         limb,
-        limb::Limb,
         uint::{Uint, WideUint},
         BigInteger,
     },
@@ -481,18 +480,12 @@ impl<P: FpParams<N>, const N: usize> Fp<P, N> {
     /// # Panics
     ///
     /// * If `value` is bigger than `Self` maximum size.
-    pub(crate) fn from_fp<P2: FpParams<N2>, const N2: usize>(
+    #[must_use]
+    pub fn from_fp<P2: FpParams<N2>, const N2: usize>(
         value: Fp<P2, N2>,
     ) -> Self {
-        let value_uint = value.into_bigint();
-        let mut uint = Uint::<N>::ZERO;
-        for i in 0..value_uint.limbs.len() {
-            if i < uint.limbs.len() {
-                uint.limbs[i] = value_uint.limbs[i];
-            } else if value_uint.limbs[i] != Limb::ZERO {
-                panic!("converted element is too large")
-            }
-        }
+        let value = value.into_bigint();
+        let uint = Uint::<N>::ct_from_uint(value);
         Self::from_bigint(uint)
     }
 }

--- a/lib/crypto/src/field/fp.rs
+++ b/lib/crypto/src/field/fp.rs
@@ -204,19 +204,14 @@ pub trait FpParams<const N: usize>: Send + Sync + 'static + Sized {
     #[must_use]
     #[inline(always)]
     fn from_bigint(num: Uint<N>) -> Fp<Self, N> {
-        let elem = Fp::new_unchecked(num);
-        if elem.is_zero() {
-            elem
-        } else {
-            elem * Fp::new_unchecked(Self::R2)
-        }
+        Fp::<Self, N>::ct_from_bigint(num)
     }
 
     /// Convert a field element to an integer less than [`Self::MODULUS`].
     #[must_use]
     #[inline(always)]
     fn into_bigint(elem: Fp<Self, N>) -> Uint<N> {
-        elem.montgomery_reduction()
+        elem.ct_into_bigint()
     }
 }
 
@@ -456,37 +451,60 @@ impl<P: FpParams<N>, const N: usize> Fp<P, N> {
     ///
     /// [reference]: https://cacr.uwaterloo.ca/hac/about/chap14.pdf
     #[inline(always)]
-    fn montgomery_reduction(self) -> Uint<N> {
+    const fn montgomery_reduction(self) -> Uint<N> {
         let mut limbs = self.montgomery_form.limbs;
-        for i in 0..N {
+        ct_for!((i in 0..N) {
             let k = limbs[i].wrapping_mul(P::INV);
 
             let (_, mut carry) = limb::mac(limbs[i], k, Self::MODULUS.limbs[0]);
-            for j in 1..N {
+            ct_for!((j in 1..N) {
                 (limbs[(j + i) % N], carry) = limb::carrying_mac(
                     limbs[(j + i) % N],
                     k,
                     Self::MODULUS.limbs[j],
                     carry,
                 );
-            }
+            });
             limbs[i % N] = carry;
-        }
+        });
         Uint::new(limbs)
     }
 
-    /// Construct `Self` from the other [`Fp`] element of different size.
+    /// Construct `Self` from the other [`Fp`] element of different size
+    /// (constant).
     ///
     /// # Panics
     ///
     /// * If `value` is bigger than `Self` maximum size.
     #[must_use]
-    pub fn from_fp<P2: FpParams<N2>, const N2: usize>(
+    pub const fn from_fp<P2: FpParams<N2>, const N2: usize>(
         value: Fp<P2, N2>,
     ) -> Self {
-        let value = value.into_bigint();
-        let uint = Uint::<N>::ct_from_uint(value);
-        Self::from_bigint(uint)
+        let value = value.ct_into_bigint();
+        let uint = Uint::<N>::from_uint(value);
+        Self::ct_from_bigint(uint)
+    }
+
+    /// Construct a field element from an integer (constant).
+    ///
+    /// By the end element will be converted to a montgomery form and reduced.
+    #[must_use]
+    #[inline(always)]
+    pub const fn ct_from_bigint(num: Uint<N>) -> Self {
+        let elem = Fp::new_unchecked(num);
+        if elem.ct_is_zero() {
+            elem
+        } else {
+            elem.ct_mul(&Fp::new_unchecked(P::R2))
+        }
+    }
+
+    /// Convert a field element to an integer less than [`Self::MODULUS`]
+    /// (constant).
+    #[must_use]
+    #[inline(always)]
+    pub const fn ct_into_bigint(self) -> Uint<N> {
+        self.montgomery_reduction()
     }
 }
 


### PR DESCRIPTION
This pr doesn't add equality checks, but ensures that modulus will be the same for WideScalar