### PR TITLE
ref: remove ct_ prefix in crypto library

### DIFF
--- a/lib/crypto/src/arithmetic/uint.rs
+++ b/lib/crypto/src/arithmetic/uint.rs
@@ -88,7 +88,7 @@ impl<const N: usize> Uint<N> {
     #[doc(hidden)]
     #[inline]
     #[must_use]
-    pub const fn ct_is_odd(&self) -> bool {
+    pub const fn is_odd(&self) -> bool {
         self.limbs[0] & 1 == 1
     }
 
@@ -96,14 +96,14 @@ impl<const N: usize> Uint<N> {
     #[doc(hidden)]
     #[inline]
     #[must_use]
-    pub const fn ct_is_even(&self) -> bool {
+    pub const fn is_even(&self) -> bool {
         self.limbs[0] & 1 == 0
     }
 
     /// Checks `self` is greater or equal then `rhs` (constant).
     #[must_use]
     #[inline(always)]
-    pub const fn ct_ge(&self, rhs: &Self) -> bool {
+    pub const fn ge(&self, rhs: &Self) -> bool {
         let mut result = true;
         ct_for_unroll6!((i in 0..N) {
             let a = self.limbs[i];
@@ -120,7 +120,7 @@ impl<const N: usize> Uint<N> {
     /// Checks `self` is greater then `rhs` (constant).
     #[must_use]
     #[inline(always)]
-    pub const fn ct_gt(&self, rhs: &Self) -> bool {
+    pub const fn gt(&self, rhs: &Self) -> bool {
         let mut result = false;
         ct_for_unroll6!((i in 0..N) {
             let a = self.limbs[i];
@@ -137,7 +137,7 @@ impl<const N: usize> Uint<N> {
     /// Checks `self` is less or equal then `rhs` (constant).
     #[must_use]
     #[inline(always)]
-    pub const fn ct_le(&self, rhs: &Self) -> bool {
+    pub const fn le(&self, rhs: &Self) -> bool {
         let mut result = true;
         ct_for_unroll6!((i in 0..N) {
             let a = self.limbs[i];
@@ -154,7 +154,7 @@ impl<const N: usize> Uint<N> {
     /// Checks `self` is less then `rhs` (constant).
     #[must_use]
     #[inline(always)]
-    pub const fn ct_lt(&self, rhs: &Self) -> bool {
+    pub const fn lt(&self, rhs: &Self) -> bool {
         let mut result = false;
         ct_for_unroll6!((i in 0..N) {
             let a = self.limbs[i];
@@ -171,14 +171,14 @@ impl<const N: usize> Uint<N> {
     /// Checks `self` is zero (constant).
     #[must_use]
     #[inline(always)]
-    pub const fn ct_is_zero(&self) -> bool {
-        self.ct_eq(&Self::ZERO)
+    pub const fn is_zero(&self) -> bool {
+        self.eq(&Self::ZERO)
     }
 
     /// Checks if `self` is equal to `rhs` (constant).
     #[must_use]
     #[inline(always)]
-    pub const fn ct_eq(&self, rhs: &Self) -> bool {
+    pub const fn eq(&self, rhs: &Self) -> bool {
         ct_for!((i in 0..N) {
             if self.limbs[i] != rhs.limbs[i] {
                 return false;
@@ -190,8 +190,8 @@ impl<const N: usize> Uint<N> {
     /// Checks if `self` is not equal to `rhs` (constant).
     #[must_use]
     #[inline(always)]
-    pub const fn ct_ne(&self, rhs: &Self) -> bool {
-        !self.ct_eq(rhs)
+    pub const fn ne(&self, rhs: &Self) -> bool {
+        !self.eq(rhs)
     }
 
     /// Return the minimum number of bits needed to encode this number.
@@ -199,9 +199,9 @@ impl<const N: usize> Uint<N> {
     /// One bit is necessary to encode zero.
     #[doc(hidden)]
     #[must_use]
-    pub const fn ct_num_bits(&self) -> usize {
+    pub const fn num_bits(&self) -> usize {
         // One bit is necessary to encode zero.
-        if self.ct_is_zero() {
+        if self.is_zero() {
             return 1;
         }
 
@@ -226,7 +226,7 @@ impl<const N: usize> Uint<N> {
 
     /// Find the `i`-th bit of `self`.
     #[must_use]
-    pub const fn ct_get_bit(&self, i: usize) -> bool {
+    pub const fn get_bit(&self, i: usize) -> bool {
         // If `i` is more than total bits, return `false`.
         if i >= Self::BITS {
             return false;
@@ -257,7 +257,7 @@ impl<const N: usize> Uint<N> {
 
     /// Multiplies `self` by `2`, returning the result and whether overflow
     /// occurred (constant).
-    const fn ct_checked_mul2(mut self) -> (Self, bool) {
+    const fn checked_mul2(mut self) -> (Self, bool) {
         let mut last = 0;
         ct_for!((i in 0..N) {
             let a = self.limbs[i];
@@ -284,7 +284,7 @@ impl<const N: usize> Uint<N> {
     /// occurred (constant).
     #[inline(always)]
     #[must_use]
-    pub const fn ct_checked_sub(mut self, rhs: &Self) -> (Self, bool) {
+    pub const fn checked_sub(mut self, rhs: &Self) -> (Self, bool) {
         let mut borrow = false;
 
         ct_for_unroll6!((i in 0..N) {
@@ -298,15 +298,15 @@ impl<const N: usize> Uint<N> {
     /// lower boundary (constant).
     #[inline(always)]
     #[must_use]
-    pub const fn ct_wrapping_sub(&self, rhs: &Self) -> Self {
-        self.ct_checked_sub(rhs).0
+    pub const fn wrapping_sub(&self, rhs: &Self) -> Self {
+        self.checked_sub(rhs).0
     }
 
     /// Add `rhs` to `self`, returning the result and whether overflow occurred
     /// (constant).
     #[inline]
     #[must_use]
-    pub const fn ct_checked_add(mut self, rhs: &Self) -> (Self, bool) {
+    pub const fn checked_add(mut self, rhs: &Self) -> (Self, bool) {
         let mut carry = false;
 
         ct_for!((i in 0..N) {
@@ -354,7 +354,7 @@ impl<const N: usize> Uint<N> {
     /// [wiki]: https://en.wikipedia.org/wiki/Multiplication_algorithm
     #[inline(always)]
     #[must_use]
-    pub const fn ct_widening_mul(&self, rhs: &Self) -> (Self, Self) {
+    pub const fn widening_mul(&self, rhs: &Self) -> (Self, Self) {
         let (mut lo, mut hi) = ([0u64; N], [0u64; N]);
         // For each digit of the first number,
         ct_for_unroll6!((i in 0..N) {
@@ -389,31 +389,31 @@ impl<const N: usize> Uint<N> {
 
     /// Multiply two numbers and panic on overflow.
     #[must_use]
-    pub const fn ct_mul(&self, rhs: &Self) -> Self {
-        let (low, high) = self.ct_widening_mul(rhs);
-        assert!(high.ct_eq(&Uint::<N>::ZERO), "overflow on multiplication");
+    pub const fn mul(&self, rhs: &Self) -> Self {
+        let (low, high) = self.widening_mul(rhs);
+        assert!(high.eq(&Uint::<N>::ZERO), "overflow on multiplication");
         low
     }
 
     /// Add two numbers and panic on overflow.
     #[must_use]
-    pub const fn ct_add(&self, rhs: &Self) -> Self {
-        let (low, carry) = self.ct_adc(rhs, false);
+    pub const fn add(&self, rhs: &Self) -> Self {
+        let (low, carry) = self.adc(rhs, false);
         assert!(!carry, "overflow on addition");
         low
     }
 
     /// Add two numbers wrapping around the upper boundary.
     #[must_use]
-    pub const fn ct_wrapping_add(&self, rhs: &Self) -> Self {
-        let (low, _) = self.ct_adc(rhs, false);
+    pub const fn wrapping_add(&self, rhs: &Self) -> Self {
+        let (low, _) = self.adc(rhs, false);
         low
     }
 
     /// Computes `a + b + carry`, returning the result along with the new carry.
     #[inline(always)]
     #[must_use]
-    pub const fn ct_adc(&self, rhs: &Uint<N>, mut carry: bool) -> (Self, bool) {
+    pub const fn adc(&self, rhs: &Uint<N>, mut carry: bool) -> (Self, bool) {
         let mut limbs = [Limb::ZERO; N];
 
         ct_for!((i in 0..N) {
@@ -425,7 +425,7 @@ impl<const N: usize> Uint<N> {
 
     /// Create a new [`Uint`] from the provided little endian bytes.
     #[must_use]
-    pub const fn ct_from_le_slice(bytes: &[u8]) -> Self {
+    pub const fn from_le_slice(bytes: &[u8]) -> Self {
         const LIMB_BYTES: usize = Limb::BITS as usize / 8;
         assert!(
             bytes.len() == LIMB_BYTES * N,
@@ -467,7 +467,7 @@ impl<const N: usize> Uint<N> {
 // ----------- From Impls -----------
 
 /// Constant conversions from primitive types.
-macro_rules! impl_ct_from_primitive {
+macro_rules! impl_from_primitive {
     ($int:ty, $func_name:ident) => {
         impl<const N: usize> Uint<N> {
             #[doc = "Create a [`Uint`] from"]
@@ -484,11 +484,11 @@ macro_rules! impl_ct_from_primitive {
         }
     };
 }
-impl_ct_from_primitive!(u8, from_u8);
-impl_ct_from_primitive!(u16, from_u16);
-impl_ct_from_primitive!(u32, from_u32);
-impl_ct_from_primitive!(u64, from_u64);
-impl_ct_from_primitive!(usize, from_usize);
+impl_from_primitive!(u8, from_u8);
+impl_from_primitive!(u16, from_u16);
+impl_from_primitive!(u32, from_u32);
+impl_from_primitive!(u64, from_u64);
+impl_from_primitive!(usize, from_usize);
 
 // Logic for `u128` conversion is different from `u8`..`u64`, due to the size of
 // the `Limb`.
@@ -545,7 +545,7 @@ impl_from_primitive!(u128, from_u128);
 ///
 /// Implements conversion [`Uint`] -> `$int` for `$int` not bigger than `Limb`'s
 /// max size.
-macro_rules! impl_ct_into_primitive {
+macro_rules! impl_into_primitive {
     ($int:ty, $func_name:ident) => {
         impl<const N: usize> Uint<N> {
             #[doc = "Create a"]
@@ -574,11 +574,11 @@ macro_rules! impl_ct_into_primitive {
     };
 }
 
-impl_ct_into_primitive!(u8, into_u8);
-impl_ct_into_primitive!(u16, into_u16);
-impl_ct_into_primitive!(u32, into_u32);
-impl_ct_into_primitive!(u64, into_u64);
-impl_ct_into_primitive!(usize, into_usize);
+impl_into_primitive!(u8, into_u8);
+impl_into_primitive!(u16, into_u16);
+impl_into_primitive!(u32, into_u32);
+impl_into_primitive!(u64, into_u64);
+impl_into_primitive!(usize, into_usize);
 
 impl<const N: usize> Uint<N> {
     /// Create a `u128` integer from [`Uint`] (constant).
@@ -900,27 +900,27 @@ impl<const N: usize> BigInteger for Uint<N> {
     const ZERO: Self = Self { limbs: [0u64; N] };
 
     fn is_odd(&self) -> bool {
-        self.ct_is_odd()
+        self.is_odd()
     }
 
     fn is_even(&self) -> bool {
-        self.ct_is_even()
+        self.is_even()
     }
 
     fn is_zero(&self) -> bool {
-        self.ct_is_zero()
+        self.is_zero()
     }
 
     fn num_bits(&self) -> usize {
-        self.ct_num_bits()
+        self.num_bits()
     }
 
     fn get_bit(&self, i: usize) -> bool {
-        self.ct_get_bit(i)
+        self.get_bit(i)
     }
 
     fn from_bytes_le(bytes: &[u8]) -> Self {
-        Self::ct_from_le_slice(bytes)
+        Self::from_le_slice(bytes)
     }
 
     fn into_bytes_le(self) -> Vec<u8> {
@@ -966,7 +966,7 @@ pub const fn from_str_radix<const LIMBS: usize>(
         let digit = Uint::from_u32(parse_digit(bytes[index], radix));
 
         // Add a digit multiplied by order.
-        uint = uint.ct_add(&digit.ct_mul(&order));
+        uint = uint.add(&digit.mul(&order));
 
         // If we reached the beginning of the string, return the number.
         if index == 0 {
@@ -974,7 +974,7 @@ pub const fn from_str_radix<const LIMBS: usize>(
         }
 
         // Increase the order of magnitude.
-        order = uint_radix.ct_mul(&order);
+        order = uint_radix.mul(&order);
 
         // Move to the next digit.
         index -= 1;
@@ -1098,24 +1098,24 @@ impl<const N: usize> WideUint<N> {
     ///
     /// [wiki]: https://en.wikipedia.org/wiki/Division_algorithm
     #[must_use]
-    pub const fn ct_rem(&self, rhs: &Uint<N>) -> Uint<N> {
-        assert!(!rhs.ct_is_zero(), "should not divide by zero");
+    pub const fn rem(&self, rhs: &Uint<N>) -> Uint<N> {
+        assert!(!rhs.is_zero(), "should not divide by zero");
 
         let mut remainder = Uint::<N>::ZERO;
-        let num_bits = self.ct_num_bits();
+        let num_bits = self.num_bits();
 
         // Start from the last bit.
         ct_rev_for!((index in 0..num_bits) {
             // Shift the remainder to the left by 1,
-            let (result, carry) = remainder.ct_checked_mul2();
+            let (result, carry) = remainder.checked_mul2();
             remainder = result;
 
             // and set the first bit to remainder from the dividend.
-            remainder.limbs[0] |= self.ct_get_bit(index) as Limb;
+            remainder.limbs[0] |= self.get_bit(index) as Limb;
 
             // If the remainder overflows, subtract the divisor.
-            if remainder.ct_ge(rhs) || carry {
-                (remainder, _) = remainder.ct_checked_sub(rhs);
+            if remainder.ge(rhs) || carry {
+                (remainder, _) = remainder.checked_sub(rhs);
             }
         });
 
@@ -1126,21 +1126,21 @@ impl<const N: usize> WideUint<N> {
     ///
     /// One bit is necessary to encode zero.
     #[must_use]
-    pub const fn ct_num_bits(&self) -> usize {
-        if self.high.ct_is_zero() {
-            self.low.ct_num_bits()
+    pub const fn num_bits(&self) -> usize {
+        if self.high.is_zero() {
+            self.low.num_bits()
         } else {
-            self.high.ct_num_bits() + Uint::<N>::BITS
+            self.high.num_bits() + Uint::<N>::BITS
         }
     }
 
     /// Compute the `i`-th bit of `self`.
     #[must_use]
-    pub const fn ct_get_bit(&self, i: usize) -> bool {
+    pub const fn get_bit(&self, i: usize) -> bool {
         if i >= Uint::<N>::BITS {
-            self.high.ct_get_bit(i - Uint::<N>::BITS)
+            self.high.get_bit(i - Uint::<N>::BITS)
         } else {
-            self.low.ct_get_bit(i)
+            self.low.get_bit(i)
         }
     }
 }
@@ -1237,55 +1237,55 @@ mod test {
     }
 
     #[test]
-    fn ct_rem() {
+    fn rem() {
         let dividend = from_num!("43129923721897334698312931");
         let divisor = from_num!("375923422");
         let result =
-            WideUint::<4>::new(dividend, Uint::<4>::ZERO).ct_rem(&divisor);
+            WideUint::<4>::new(dividend, Uint::<4>::ZERO).rem(&divisor);
         assert_eq!(result, from_num!("216456157"));
     }
 
     #[test]
     #[should_panic = "should not divide by zero"]
-    fn ct_rem_zero() {
+    fn rem_zero() {
         let zero = Uint::<4>::ZERO;
         let divisor = from_num!("375923422");
-        let result = WideUint::<4>::new(zero, zero).ct_rem(&divisor);
+        let result = WideUint::<4>::new(zero, zero).rem(&divisor);
         assert_eq!(result, zero);
 
         let dividend = from_num!("43129923721897334698312931");
         let divisor = zero;
-        let _ = WideUint::<4>::new(dividend, zero).ct_rem(&divisor);
+        let _ = WideUint::<4>::new(dividend, zero).rem(&divisor);
     }
 
     #[test]
-    fn ct_ge_le_gt_lt_eq_ne() {
+    fn ge_le_gt_lt_eq_ne() {
         let a: Uint<4> = Uint::new([0, 0, 0, 5]);
         let b: Uint<4> = Uint::new([4, 0, 0, 0]);
-        assert!(a.ct_ge(&b));
-        assert!(a.ct_gt(&b));
-        assert!(!a.ct_le(&b));
-        assert!(!a.ct_lt(&b));
-        assert!(!a.ct_eq(&b));
-        assert!(a.ct_ne(&b));
+        assert!(a.ge(&b));
+        assert!(a.gt(&b));
+        assert!(!a.le(&b));
+        assert!(!a.lt(&b));
+        assert!(!a.eq(&b));
+        assert!(a.ne(&b));
 
         let a: Uint<4> = Uint::new([0, 0, 0, 5]);
         let b: Uint<4> = Uint::new([0, 0, 0, 6]);
-        assert!(!a.ct_ge(&b));
-        assert!(!a.ct_gt(&b));
-        assert!(a.ct_le(&b));
-        assert!(a.ct_lt(&b));
-        assert!(!a.ct_eq(&b));
-        assert!(a.ct_ne(&b));
+        assert!(!a.ge(&b));
+        assert!(!a.gt(&b));
+        assert!(a.le(&b));
+        assert!(a.lt(&b));
+        assert!(!a.eq(&b));
+        assert!(a.ne(&b));
 
         let a: Uint<4> = Uint::new([0, 0, 1, 2]);
         let b: Uint<4> = Uint::new([0, 0, 1, 2]);
-        assert!(a.ct_ge(&b));
-        assert!(!a.ct_gt(&b));
-        assert!(a.ct_le(&b));
-        assert!(!a.ct_lt(&b));
-        assert!(a.ct_eq(&b));
-        assert!(!a.ct_ne(&b));
+        assert!(a.ge(&b));
+        assert!(!a.gt(&b));
+        assert!(a.le(&b));
+        assert!(!a.lt(&b));
+        assert!(a.eq(&b));
+        assert!(!a.ne(&b));
     }
 
     #[test]

--- a/lib/crypto/src/const_helpers.rs
+++ b/lib/crypto/src/const_helpers.rs
@@ -1,7 +1,7 @@
 //! This module contains helpers for functions with constant context, like
-//! [`ct_for`] - constant time `for` cycle, as well as its optimized versions
-//! like [`ct_for_unroll6`], that performs [loop unroll] optimization and can be
-//! used both from compile time and runtime.
+//! [`crate::const_for`] - constant time `for` cycle, as well as its optimized
+//! versions like [`crate::const_for_unroll6`], that performs [loop unroll]
+//! optimization and can be used both from compile time and runtime.
 //!
 //! Beware of using an optimized version everywhere, since it can bloat
 //! binary (WASM) size easily.
@@ -13,12 +13,12 @@
 ///
 /// ```rust,ignore
 /// // This loop runs from 0 to 10 (not including 10).
-/// ct_for!((i in 0..10) {
+/// const_for!((i in 0..10) {
 ///     // loop body here
 /// });
 /// ```
 #[macro_export]
-macro_rules! ct_for {
+macro_rules! const_for {
     (($i:ident in $start:tt.. $end:tt) $code:expr) => {{
         let mut $i = $start;
         loop {
@@ -33,7 +33,7 @@ macro_rules! ct_for {
 ///
 /// ```rust,ignore
 /// // This loop:
-/// ct_rev_for!((i in 0..10) {
+/// const_rev_for!((i in 0..10) {
 ///     // loop body here
 /// });
 /// // is similar to the following loop:
@@ -43,7 +43,7 @@ macro_rules! ct_for {
 /// // Will runs from 9 till 0 (not including 0).
 /// ```
 #[macro_export]
-macro_rules! ct_rev_for {
+macro_rules! const_rev_for {
     (($i:ident in $end:tt.. $start:tt) $code:expr) => {{
         let mut $i = $start;
         loop {
@@ -55,7 +55,7 @@ macro_rules! ct_rev_for {
 /// Allows `for` loop in constant context, with 2 stages loop unroll
 /// optimization.
 #[macro_export]
-macro_rules! ct_for_unroll2 {
+macro_rules! const_for_unroll2 {
     (($i:ident in $start:tt.. $end:tt) $code:expr) => {{
         let mut $i = $start;
         loop {
@@ -68,7 +68,7 @@ macro_rules! ct_for_unroll2 {
 /// Allows `for` loop in constant context, with 4 stages loop unroll
 /// optimization.
 #[macro_export]
-macro_rules! ct_for_unroll4 {
+macro_rules! const_for_unroll4 {
     (($i:ident in $start:tt.. $end:tt) $code:expr) => {{
         let mut $i = $start;
         loop {
@@ -83,7 +83,7 @@ macro_rules! ct_for_unroll4 {
 /// Allows `for` loop in constant context, with 6 stages loop unroll
 /// optimization.
 #[macro_export]
-macro_rules! ct_for_unroll6 {
+macro_rules! const_for_unroll6 {
     (($i:ident in $start:tt.. $end:tt) $code:expr) => {{
         let mut $i = $start;
         loop {
@@ -102,7 +102,7 @@ macro_rules! ct_for_unroll6 {
 ///
 /// Start (`$start`) index is not inclusive.
 #[macro_export]
-macro_rules! ct_rev_for_unroll6 {
+macro_rules! const_rev_for_unroll6 {
     (($i:ident in $end:tt.. $start:tt) $code:expr) => {{
         let mut $i = $start;
         loop {
@@ -119,7 +119,7 @@ macro_rules! ct_rev_for_unroll6 {
 /// Allows `for` loop in constant context, with 8 stages loop unroll
 /// optimization.
 #[macro_export]
-macro_rules! ct_for_unroll8 {
+macro_rules! const_for_unroll8 {
     (($i:ident in $start:tt.. $end:tt) $code:expr) => {{
         let mut $i = $start;
         loop {

--- a/lib/crypto/src/curve/te/instance/bandersnatch.rs
+++ b/lib/crypto/src/curve/te/instance/bandersnatch.rs
@@ -54,7 +54,7 @@ impl CurveConfig for BandersnatchConfig {
 impl TECurveConfig for BandersnatchConfig {
     type MontCurveConfig = Self;
 
-    const COEFF_A: Self::BaseField = fp_from_num!("5").ct_neg();
+    const COEFF_A: Self::BaseField = fp_from_num!("5").neg();
     const COEFF_D: Self::BaseField =
         fp_from_num!("45022363124591815672509500913686876175488063829319466900776701791074614335719");
     const GENERATOR: Affine<Self> =

--- a/lib/crypto/src/curve/te/instance/curve25519.rs
+++ b/lib/crypto/src/curve/te/instance/curve25519.rs
@@ -52,7 +52,7 @@ impl CurveConfig for Curve25519Config {
 impl TECurveConfig for Curve25519Config {
     type MontCurveConfig = Self;
 
-    const COEFF_A: Self::BaseField = fp_from_num!("1").ct_neg();
+    const COEFF_A: Self::BaseField = fp_from_num!("1").neg();
     const COEFF_D: Self::BaseField = fp_from_num!("37095705934669439343138083508754565189542113879843219016388785533085940283555");
     const GENERATOR: Affine<Self> =
         Affine::new_unchecked(G_GENERATOR_X, G_GENERATOR_Y);

--- a/lib/crypto/src/curve/te/instance/jubjub.rs
+++ b/lib/crypto/src/curve/te/instance/jubjub.rs
@@ -50,7 +50,7 @@ impl CurveConfig for JubjubConfig {
 impl TECurveConfig for JubjubConfig {
     type MontCurveConfig = Self;
 
-    const COEFF_A: Self::BaseField = fp_from_num!("1").ct_neg();
+    const COEFF_A: Self::BaseField = fp_from_num!("1").neg();
     const COEFF_D: Self::BaseField = fp_from_num!("19257038036680949359750312669786877991949435402254120286184196891950884077233");
     const GENERATOR: Affine<Self> =
         Affine::new_unchecked(G_GENERATOR_X, G_GENERATOR_Y);

--- a/lib/crypto/src/field/fp.rs
+++ b/lib/crypto/src/field/fp.rs
@@ -33,7 +33,7 @@ use crate::{
         uint::{Uint, WideUint},
         BigInteger,
     },
-    ct_for, ct_for_unroll6,
+    const_for, const_for_unroll6,
     field::{group::AdditiveGroup, prime::PrimeField, Field},
 };
 
@@ -228,7 +228,7 @@ pub const fn inv<T: FpParams<N>, const N: usize>() -> u64 {
     // euler_totient(2^64) - 1 = (1 << 63) - 1 = 1111111... (63 digits).
     // We compute this powering via standard square and multiply.
     let mut inv = 1u64;
-    ct_for!((_i in 0..63) {
+    const_for!((_i in 0..63) {
         // Square
         inv = inv.wrapping_mul(inv);
         // Multiply
@@ -412,12 +412,12 @@ impl<P: FpParams<N>, const N: usize> Fp<P, N> {
         mut hi: Uint<N>,
     ) -> (bool, Uint<N>) {
         let mut carry2 = false;
-        ct_for_unroll6!((i in 0..N) {
+        const_for_unroll6!((i in 0..N) {
             let tmp = lo.limbs[i].wrapping_mul(P::INV);
 
             let (_, mut carry) = limb::mac(lo.limbs[i], tmp, P::MODULUS.limbs[0]);
 
-            ct_for_unroll6!((j in 1..N) {
+            const_for_unroll6!((j in 1..N) {
                 let k = i + j;
                 if k >= N {
                     (hi.limbs[k - N], carry) = limb::carrying_mac(
@@ -453,11 +453,11 @@ impl<P: FpParams<N>, const N: usize> Fp<P, N> {
     #[inline(always)]
     const fn montgomery_reduction(self) -> Uint<N> {
         let mut limbs = self.montgomery_form.limbs;
-        ct_for!((i in 0..N) {
+        const_for!((i in 0..N) {
             let k = limbs[i].wrapping_mul(P::INV);
 
             let (_, mut carry) = limb::mac(limbs[i], k, Self::MODULUS.limbs[0]);
-            ct_for!((j in 1..N) {
+            const_for!((j in 1..N) {
                 (limbs[(j + i) % N], carry) = limb::carrying_mac(
                     limbs[(j + i) % N],
                     k,

--- a/lib/crypto/src/field/fp.rs
+++ b/lib/crypto/src/field/fp.rs
@@ -120,13 +120,13 @@ pub trait FpParams<const N: usize>: Send + Sync + 'static + Sized {
     /// reduction for efficient implementation.
     #[inline(always)]
     fn mul_assign(a: &mut Fp<Self, N>, b: &Fp<Self, N>) {
-        *a = a.ct_mul(b);
+        *a = a.mul(b);
     }
 
     /// Set `a *= a`.
     #[inline(always)]
     fn square_in_place(a: &mut Fp<Self, N>) {
-        *a = a.ct_mul(a);
+        *a = a.mul(a);
     }
 
     /// Compute `a^{-1}` if `a` is not zero.
@@ -341,7 +341,7 @@ impl<P: FpParams<N>, const N: usize> Fp<P, N> {
         if r.ct_is_zero() {
             r
         } else {
-            r.ct_mul(&Fp { montgomery_form: P::R2, phantom: PhantomData })
+            r.mul(&Fp { montgomery_form: P::R2, phantom: PhantomData })
         }
     }
 
@@ -352,7 +352,7 @@ impl<P: FpParams<N>, const N: usize> Fp<P, N> {
     /// [reference]: https://en.wikipedia.org/wiki/Montgomery_modular_multiplication
     #[inline(always)]
     #[must_use]
-    pub const fn ct_mul(&self, rhs: &Self) -> Self {
+    pub const fn mul(self, rhs: &Self) -> Self {
         let (carry, result) = self.ct_mul_without_cond_subtract(rhs);
         if P::HAS_MODULUS_SPARE_BIT {
             result.ct_subtract_modulus()
@@ -495,7 +495,7 @@ impl<P: FpParams<N>, const N: usize> Fp<P, N> {
         if elem.ct_is_zero() {
             elem
         } else {
-            elem.ct_mul(&Fp::new_unchecked(P::R2))
+            elem.mul(&Fp::new_unchecked(P::R2))
         }
     }
 

--- a/lib/crypto/src/field/fp.rs
+++ b/lib/crypto/src/field/fp.rs
@@ -364,9 +364,9 @@ impl<P: FpParams<N>, const N: usize> Fp<P, N> {
     /// Negate `self` and return the result (constant).
     #[inline(always)]
     #[must_use]
-    pub const fn ct_neg(&self) -> Self {
+    pub const fn neg(self) -> Self {
         if self.ct_is_zero() {
-            return *self;
+            return self;
         }
 
         // Should not overflow. Montgomery should always be less than modulus.


### PR DESCRIPTION
Remove confusing "ct_" prefix for constant functions